### PR TITLE
mruby-regexp: scan for both ends of a literal prefix

### DIFF
--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -10,28 +10,104 @@
 #include "re_internal.h"
 #include <string.h>
 
+/* Whether the rest of a prefix of two bytes or more stands at `p`, whose
+   first byte is already known to. The last byte is tested before the ones
+   between it and the first, so that a position the scan below is about to
+   leave is left on one comparison. */
+static inline mrb_bool
+prefix_rest_at(const uint8_t *prefix, mrb_int plen, const char *p)
+{
+  return (uint8_t)p[plen - 1] == prefix[plen - 1] &&
+         (plen == 2 || memcmp(p + 1, prefix + 1, (size_t)(plen - 2)) == 0);
+}
+
+/*
+ * The first position at or after `sp` where a prefix of two bytes or more
+ * stands, or NULL when the subject holds none before `str_end`.
+ *
+ * A scan on the first byte alone proposes a position per occurrence of it, and
+ * a subject made mostly of that byte -- /aaaaab/ over a run of `a` -- then
+ * costs a rejected comparison per position. The prefix's last byte is scanned
+ * for too, at the offset it stands at: where it is not there, the next place
+ * it is names the next position worth proposing, and getting there is one
+ * scan rather than the occurrences of the first byte one at a time.
+ *
+ * The second scan runs only where the first byte was found and the last was
+ * not, so a subject that holds the first byte nowhere costs what it costs with
+ * one scan. Every round leaves `sp` past where it entered, so the two get
+ * through the subject once between them whichever of the bytes is the one that
+ * keeps being found.
+ *
+ * It earns its place by skipping positions the first scan would have proposed
+ * one at a time, and a subject can be built where it skips none: both bytes
+ * all through it, never at the distance the prefix puts them. It is dropped
+ * where that shows, leaving the walk the one scan it had before, so no subject
+ * pays for it twice over.
+ */
+static const char*
+find_prefix_ends(const uint8_t *prefix, mrb_int plen, const char *sp, const char *str_end)
+{
+  if (str_end - sp < plen) return NULL;
+  /* The last position a match can start at, so the first scan never proposes
+     one the subject is too short to hold. */
+  const char *limit = str_end - plen;
+  mrb_int last = plen - 1;
+  mrb_bool scan_last = TRUE;
+
+  while (sp <= limit) {
+    const char *base = sp;
+    const char *p0 = (const char*)memchr(sp, prefix[0], (size_t)(limit - sp) + 1);
+    if (!p0) return NULL;
+    if (prefix_rest_at(prefix, plen, p0)) return p0;
+    if (!scan_last || (uint8_t)p0[last] == prefix[last]) {
+      /* Nothing to scan for: either the last byte is here too and only the
+         bytes between the ends disagree, which says nothing about where the
+         next position is, or the scan has been dropped. */
+      sp = p0 + 1;
+      continue;
+    }
+    /* Where the last byte stands next names the position a match holding it
+       would start at, which is past the one the first byte just named. */
+    const char *p1 = (const char*)memchr(p0 + last + 1, prefix[last],
+                                         (size_t)(str_end - (p0 + last + 1)));
+    if (!p1) return NULL;
+    const char *cand = p1 - last;
+    /* Reaching no further than the first scan had just reached is the second
+       one proposing the positions it is supposed to be skipping. */
+    if (cand - p0 <= p0 - base) scan_last = FALSE;
+    sp = cand;
+  }
+  return NULL;
+}
+
+/* The first position at or after `sp` where a prefix of `plen` bytes stands,
+   or NULL when the subject holds none. The first scan, and the comparison at
+   the position it names, are here rather than behind the walk above: they are
+   the whole of the question for a prefix of one byte, and the whole of it
+   again wherever the position the scan names is the answer, which is what a
+   pattern that matches often asks over and over. The walk is entered only
+   where that answer was no. */
+static inline const char*
+find_prefix(const uint8_t *prefix, mrb_int plen, const char *sp, const char *str_end)
+{
+  const char *p = (const char*)memchr(sp, prefix[0], (size_t)(str_end - sp));
+  if (!p || plen == 1) return p;
+  /* A first occurrence of the first byte too near the end settles the whole
+     subject, since every later one stands nearer still. */
+  if (str_end - p < plen) return NULL;
+  if (prefix_rest_at(prefix, plen, p)) return p;
+  return find_prefix_ends(prefix, plen, p, str_end);
+}
+
 /*
  * Skip to the next position where the pattern's literal prefix could match.
- * Uses memchr on the first byte for fast scanning, then verifies the rest.
  * Returns the found position, or NULL if no match is possible.
  */
 static const char*
 skip_to_prefix(const mrb_regexp_pattern *pat, const char *sp, const char *str_end)
 {
   if (pat->prefix_len == 0) return sp;
-
-  uint8_t first = pat->prefix[0];
-  int plen = pat->prefix_len;
-
-  while (sp + plen <= str_end) {
-    const char *found = (const char*)memchr(sp, first, str_end - sp);
-    if (!found || found + plen > str_end) return NULL;
-    if (plen == 1 || memcmp(found + 1, pat->prefix + 1, plen - 1) == 0) {
-      return found;
-    }
-    sp = found + 1;
-  }
-  return NULL;
+  return find_prefix(pat->prefix, pat->prefix_len, sp, str_end);
 }
 
 /* Check if a byte is in the first-byte bitmap */
@@ -1632,7 +1708,8 @@ backtrack_exec(mrb_state *mrb, const mrb_regexp_pattern *pat,
   return ret;
 }
 
-/* Fast path for pure literal patterns: use memchr+memcmp, no NFA needed */
+/* Fast path for pure literal patterns: the whole pattern is the prefix, so
+   the search is the prefix skip itself and there is no NFA to run. */
 static int
 literal_exec(const mrb_regexp_pattern *pat,
              const char *str, mrb_int len, mrb_int start, mrb_int start_limit,
@@ -1641,28 +1718,24 @@ literal_exec(const mrb_regexp_pattern *pat,
   const char *start_cap = str + start_limit;
   const char *sp = str + start;
   const char *str_end = str + len;
-  int plen = pat->prefix_len;
+  mrb_int plen = pat->prefix_len;
 
   while (sp + plen <= str_end && sp <= start_cap) {
-    const char *found = (const char*)memchr(sp, pat->prefix[0], str_end - sp);
-    if (!found || found + plen > str_end || found > start_cap) return 0;
+    const char *found = find_prefix(pat->prefix, plen, sp, str_end);
+    if (!found || found > start_cap) return 0;
     if (!binary && mrb_re_char_interior_p(str, found, str_end)) {
       sp = found + 1;  /* not a char boundary, same rule as the other engines */
       continue;
     }
-    if (plen == 1 || memcmp(found + 1, pat->prefix + 1, plen - 1) == 0) {
-      /* No test that the end is a character boundary: a byte that spells no
-         character is RE_BYTE, which this path never holds (the prefix is
-         RE_CHAR only), so the literal is whole characters and a lead byte
-         that matched fixed the length of the one it starts. */
-      /* match found */
-      if (captures && captures_size >= 2) {
-        captures[0] = (int)(found - str);
-        captures[1] = (int)(found - str) + plen;
-      }
-      return 2;  /* group 0 start/end */
+    /* No test that the end is a character boundary: a byte that spells no
+       character is RE_BYTE, which this path never holds (the prefix is
+       RE_CHAR only), so the literal is whole characters and a lead byte
+       that matched fixed the length of the one it starts. */
+    if (captures && captures_size >= 2) {
+      captures[0] = (int)(found - str);
+      captures[1] = (int)(found - str) + plen;
     }
-    sp = found + 1;
+    return 2;  /* group 0 start/end */
   }
   return 0;
 }

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -525,3 +525,49 @@ assert("Regexp literal /regex/") do
   assert_equal "123", /\d+/.match("abc123")[0]
   assert_true /hello/i.match?("HELLO")
 end
+
+assert('Regexp - a literal is found wherever the scan on its ends leaves it') do
+  # The search scans for the literal's first byte, and where the last byte is
+  # not at the offset it would then stand at, for that byte instead. These put
+  # a match where each of the two scans is the one that has to find it, and at
+  # the ends of the subject, where neither may propose a position the subject
+  # is too short to hold.
+  run = 'a' * 100
+
+  # the first byte is every byte of the subject and only the last one differs
+  assert_nil (run + 'aaaa').index(/aaaaab/)
+  assert_equal 100, (run + 'aaaaab').index(/aaaaab/)
+  assert_equal 0, 'aaaaab'.index(/aaaaab/)
+
+  # a literal of two bytes, which has nothing between its ends to compare
+  assert_equal 100, (run + 'ab').index(/ab/)
+  assert_nil run.index(/ab/)
+
+  # the ends both stand where they would and the bytes between them do not
+  assert_equal 3, 'axcabcabc'.index(/abc/)
+
+  # a match at the last position the subject can hold one, and a subject one
+  # byte too short to hold any
+  assert_equal 3, 'xxxab'.index(/ab/)
+  assert_nil 'xxxa'.index(/ab/)
+
+  # the second scan is the one that gets there
+  assert_equal 6, ('ab' * 3 + 'ac').index(/ac/)
+
+  # every match in turn, so the search resumes from each
+  assert_equal ['ab', 'ab', 'ab'], 'abXabXab'.scan(/ab/)
+
+  # the same scan feeds the NFA engines, which run at each position it names
+  assert_equal 100, (run + 'aaaaabbb').index(/aaaaab+/)
+  assert_nil (run + 'aaaa').index(/aaaaab+/)
+
+  # A subject holding both of the literal's ends all through it, never at the
+  # distance the literal puts them, is where the scan on the last byte skips
+  # nothing and is dropped. What is left has to answer for the whole subject
+  # just the same, so ask it for a subject with no match and for one whose
+  # match is past where the scan was dropped.
+  weave = ('a' + 'x' * 3 + 'b' + 'x' * 3) * 64
+  assert_nil weave.index(/ab/)
+  assert_equal 512, (weave + 'ab').index(/ab/)
+  assert_equal 513, (weave + 'zab').index(/ab/)
+end


### PR DESCRIPTION
## Summary

The skip to a pattern's literal prefix scanned for its first byte and compared the rest at every occurrence of it, so a subject made mostly of that byte cost a rejected comparison per position. `("a" * 65536).index(/aaaaab/)` read 80 instructions per byte of subject to answer that it holds no match.

Scanning for the prefix's last byte as well, at the offset it stands at, answers with the positions where both hold. Both engines take their prefix skip from the same walk, so `/aaaaab/` and `/aaaaab+/` both come down from about 5,000,000 instructions to about 10,000.

Base: `b51971799`. No overlap with #7456, which changes `re_exec.c` only inside `pike_vm()` and `bt_match()`.

## Changes

| commit | what |
| --- | --- |
| `c938f60d6` | scan for the prefix's last byte where the first byte names a position the rest does not stand at, and pin the walk with tests |

### `find_prefix_ends()`

Where the last byte of the prefix is not at the offset it would stand at, the next place it is names the next position worth proposing, and one scan gets there instead of the occurrences of the first byte one at a time. The second scan runs only where the first byte was found and the last was not, so a subject that holds the first byte nowhere reads exactly what it read before.

A subject can hold both bytes all through it and never at the distance the prefix puts them, and there the second scan skips nothing and proposes the positions itself. It is dropped once it reaches no further than the first scan just reached, which leaves the walk the one scan it had, so the worst case is the search as it stands today.

### `find_prefix()`

The first scan, and the comparison at the position it names, sit here rather than inside the walk. They are the whole of the question for a prefix of one byte, and the whole of it again wherever the position the scan names is a match, which is what a pattern that matches often asks over and over, so the walk is entered only where that answer was no.

## Behaviour

Nothing observable changes. The same position is answered, and it is still the leftmost one: the second scan only moves the walk forward to a position the first scan would have reached, and the comparison at each proposed position is the one made before.

## Speed

Callgrind Ir per call, taken as `Ir(2N) - Ir(N)` over `N` so that startup and parsing cancel:

| case | master | this PR | |
| --- | ---: | ---: | --- |
| `("a" * 65536).index(/aaaaab/)` | 5,254,913 | 9,443 | 557x |
| `("a" * 65536).index(/aaaaab+/)` | 4,445,554 | 10,012 | 444x |
| a 42 KiB log `.index(/sZZZ/)` | 216,262 | 6,675 | 32.4x |
| `a` and `b` woven, `.index(/ab/)` | 560,212 | 322,778 | 1.74x |
| the same log `.index(/https/)` | 8,537 | 8,542 | +0.06% |
| the same log `.index(/zzzzzz/)` | 6,537 | 6,539 | +0.03% |
| the same log `.scan(/GET/)`, 513 hits | 447,004 | 443,280 | -0.83% |

The second row is a pattern the literal path does not take: both engines skip to the prefix through the same walk. The fourth is the subject the second scan cannot help with, built so that `a` and `b` are everywhere and never one apart.

The eight cases from the #7267 review, all of them literals of one byte:

| case | master | this PR | |
| --- | ---: | ---: | --- |
| `s480.gsub(/o/) { }` | 129,185 | 129,338 | +0.12% |
| `"abc".gsub(/b/) { }` | 18,319 | 18,332 | +0.07% |
| `"abc".scan(/b/) { }` | 17,210 | 17,223 | +0.08% |
| `"abc".sub!(/b/) { }` | 18,543 | 18,548 | +0.03% |
| `s480.gsub(/o/, "0")` | 30,034 | 30,187 | +0.51% |
| `"abc".scan(/b/)` | 15,471 | 15,484 | +0.08% |
| `"abc".sub!(/b/, "x")` | 18,599 | 18,609 | +0.05% |
| `s480.gsub(/z/) { }` | 14,905 | 14,913 | +0.05% |

Two unrelated controls, a recursive `fib` and an `Array#sort`, are identical to the instruction.

Wall clock, minimum of 7 runs of `Benchmark.measure` on a pinned core:

| case | iterations | master | this PR | |
| --- | ---: | ---: | ---: | --- |
| `("a" * 65536).index(/aaaaab/)` | 1,000 | 0.3303s | 0.0006s | 550x |
| `("a" * 65536).index(/aaaaab+/)` | 1,000 | 0.3085s | 0.0007s | 441x |
| a 42 KiB log `.index(/sZZZ/)` | 2,000 | 0.0279s | 0.0010s | 28x |
| `a` and `b` woven, `.index(/ab/)` | 1,000 | 0.0388s | 0.0304s | 1.28x |
| the same log `.scan(/GET/)` | 2,000 | 0.0536s | 0.0527s | -1.7% |
| the #7267 eight | | | | within 3.4%, all on the faster side |

## Size

`.text` of `bin/mruby` for the five `build_config/ci/gcc-clang.rb` builds, gcc, same worktree path, empty build directory, same `rake` target on both sides:

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,374,374 | 1,374,502 | +128 |
| ascii-ctype | 1,360,438 | 1,360,630 | +192 |
| byte-string | 1,337,494 | 1,337,622 | +128 |
| cxx_abi | 1,407,177 | 1,407,625 | +448 |
| full-debug (-O0) | 1,964,614 | 1,965,062 | +448 |

All of it is `re_exec.o`, whose `.text` goes from 17,954 to 18,082.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test` is green on all five builds, KO 0 and Crash 0, with each build's total one above master.

The new assertions put a match on either side of where the two scans hand over, at the last position a subject can hold one, in a subject one byte too short to hold any, at a position only the second scan reaches, and past the point where the second scan is dropped. The last of those is what a walk that stopped early rather than carrying on would fail.

## Environment

<details>

```
Ubuntu, Linux 7.0.0-30-generic x86_64, glibc 2.39
gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
valgrind-3.27.1

gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration
    -Wwrite-strings -Wzero-length-array
    -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DMRB_UTF8_STRING -DMRB_USE_RATIONAL
    -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The speed tables are taken with the full-core gembox at `-O3`. glibc's `memchr` dispatches to an AVX2 implementation here, which is what each scan costs.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved literal-pattern matching across subject boundaries and edge cases.
  - Fixed search behavior for short subjects, end-position matches, and successive matches during scanning.
  - Improved compatibility with different regular-expression matching engines.

- **Tests**
  - Added coverage for two-byte literals, boundary positions, repeated scans, and subjects where matching bytes are separated by unexpected distances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->