### PR TITLE
amalgam: emit the baked defines ahead of the system includes

### DIFF
--- a/doc/guides/amalgamation.md
+++ b/doc/guides/amalgamation.md
@@ -141,12 +141,34 @@ Typical sizes depend on included gems:
 
 ### Build Configuration Defines
 
-The defines the build compiles with are written at the top of `mruby.h`, so
-that including it is enough to get the same `mrb_value` layout, integer width
-and feature set as the build the amalgamation was generated from. Both the
-defines the build configuration names (`conf.cc.defines`) and the ones gems
-contribute (`spec.build.defines`) are emitted. Each is wrapped in `#ifndef`,
-so passing the same define on the command line is not a redefinition.
+The defines the build compiles with are written at the top of `mruby.h`,
+ahead of its first `#include`, so that including it is enough to get the same
+`mrb_value` layout, integer width and feature set as the build the
+amalgamation was generated from. Both the defines the build configuration
+names (`conf.cc.defines`) and the ones gems contribute (`spec.build.defines`,
+`spec.cc.defines`) are emitted. Each is wrapped in `#ifndef`, so passing the
+same define on the command line is not a redefinition.
+
+Not every name a gem lists in `spec.cc.defines` reaches the header. `MRB_*`
+and `MRBGEM_*` are dropped: a define that changes how `mruby.h` itself is
+read belongs to the whole build rather than to one gem, and the `MRBGEM_*`
+version strings are not C constants. `__STDC_*` is dropped as well, the
+preamble writing the ones the amalgamation needs itself. A gem whose `MRB_*`
+define belongs in the header declares it in `spec.build.defines`.
+
+Their position ahead of every `#include` mirrors a normal build, where each
+`-D` precedes every header. That is what makes libc feature test macros work:
+a gem that uses a GNU extension declares `spec.cc.defines << '_GNU_SOURCE'`
+in its `mrbgem.rake` and the declaration reaches the amalgamation consumer's
+plain compiler invocation. Writing `#define _GNU_SOURCE` at the top of a gem
+source file does not survive amalgamation: the file lands in the middle of
+the combined translation unit, after the first libc header has been read.
+
+Note that in the combined translation unit a gem's defines apply to every
+source file, not only to the gem's own objects as in a normal build. Macros
+that add declarations (`_GNU_SOURCE`, `_DEFAULT_SOURCE`) are safe there;
+macros that restrict the libc feature set (`_POSIX_C_SOURCE`,
+`_XOPEN_SOURCE`) can hide declarations the other sources rely on.
 
 Two kinds are not written, and are left to whoever compiles the amalgamation:
 

--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -238,6 +238,11 @@ module MRuby
 
         #ifndef MRUBY_AMALGAM_H
         #define MRUBY_AMALGAM_H
+      PREAMBLE
+
+      write_baked_defines(f)
+
+      f.puts <<~PREAMBLE
 
         #ifdef __cplusplus
         #define __STDC_LIMIT_MACROS
@@ -253,18 +258,23 @@ module MRuby
 
       PREAMBLE
 
+      write_revision_define(f)
+    end
+
+    # Ahead of every #include, the way each -D of the real build's command
+    # line precedes every header: a feature test macro such as _GNU_SOURCE
+    # is dead once the first libc header has been read.
+    def write_baked_defines(f)
       build_defines = collect_build_defines
       unless build_defines.empty?
-        f.puts "/* Build configuration defines */"
+        f.puts "\n/* Build configuration defines */"
         build_defines.each do |name, value|
           f.puts "#ifndef #{name}"
           f.puts(value ? "#define #{name} #{value}" : "#define #{name}")
           f.puts "#endif"
         end
-        f.puts
       end
-
-      write_revision_define(f)
+      write_gem_cc_defines(f, main_library_gems)
     end
 
     # The revision the amalgam was generated from, ahead of the version.h that
@@ -350,8 +360,6 @@ module MRuby
     end
 
     def write_gem_headers(f)
-      write_gem_cc_defines(f, main_library_gems)
-
       main_library_gems.each do |gem|
         gem_include = "#{gem.dir}/include"
         next unless File.directory?(gem_include)


### PR DESCRIPTION
## Summary

The generated `mruby.h` writes the build's defines after the system headers it emits itself, so a libc feature test macro a gem asks for is already too late to be read. Moving both define blocks ahead of the first `#include` restores the ordering of the build the amalgamation was generated from.

## Changes

| File | What |
| --- | --- |
| `lib/mruby/amalgam.rb` | Add `write_baked_defines`, called from `write_header_preamble` ahead of the `#include` block, and move the `write_gem_cc_defines` call into it out of `write_gem_headers` |
| `doc/guides/amalgamation.md` | State where the defines sit, the `spec.cc.defines` convention a gem follows to reach the amalgamation, and what a restricting feature test macro does to a single translation unit |

### A feature test macro is read once

`write_header_preamble` emitted `#include <string.h>` and four other system headers, then `/* Build configuration defines */`. The gem defines came later still, from `write_gem_headers`, some nine thousand lines further down and right before the gem headers that use them.

For most defines the position does not matter, because nothing reads them until the mruby headers that follow. A libc feature test macro is the exception: glibc's `<features.h>` decides the feature set from what is defined when the first libc header pulls it in, and its include guard keeps a later definition from being reconsidered. By the time either define block was written, `<stdarg.h>` had already settled the question.

A gem that declares `spec.cc.defines << '_GNU_SOURCE'` therefore compiled in a normal build, where every `-D` precedes every header, and silently lost the GNU declarations in the amalgamation. There is no diagnostic short of the call that needs one:

```console
mruby.c:114559:51: error: call to undeclared function 'rawmemchr'
```

Both blocks now go directly after the include guard, ahead of the first `#include`. That is the invariant the amalgamation is trying to reproduce: on a real command line, every `-D` comes before every header.

### The convention the documentation now states

The place for a macro like this is the gem's `mrbgem.rake`, so that the declaration reaches the plain compiler invocation of whoever compiles the amalgamation. Writing `#define _GNU_SOURCE` at the top of a gem source file does not survive amalgamation either way, since that file lands in the middle of the combined translation unit, long after the first libc header.

The guide also notes the limit of the single translation unit. A gem's defines apply to every source in it, not just the gem's own objects as in a normal build. Macros that add declarations (`_GNU_SOURCE`, `_DEFAULT_SOURCE`) are safe that way; macros that restrict the libc feature set (`_POSIX_C_SOURCE`, `_XOPEN_SOURCE`) can hide declarations the other sources rely on.

## Behaviour

Only the generated header moves. For each configuration measured, `mruby.c` and `mruby_compiler.c` come out byte identical to master, and `mruby.h` keeps its line count with the same lines in it, sorted, as before: the whole change is the relocation.

| config | `mruby.c` | `mruby_compiler.c` | `mruby.h` |
| --- | --- | --- | --- |
| `MRB_NO_STDIO` | identical | identical | 5 lines moved, sorted content identical |
| default gembox | identical | identical | 17 lines moved, sorted content identical |
| default gembox + `_GNU_SOURCE` gem | identical | identical | 20 lines moved, sorted content identical |

Nothing is emitted that was not emitted before, so a consumer whose defines were already in the right order sees the same header content in a different order.

## Size

`.text` of `bin/mruby` across the five `build_config/ci/gcc-clang.rb` builds, base `b51971799`:

| build | master | this PR | delta |
| --- | --- | --- | --- |
| bintest | 1,374,374 | 1,374,374 | 0 |
| ascii-ctype | 1,360,438 | 1,360,438 | 0 |
| byte-string | 1,337,494 | 1,337,494 | 0 |
| cxx_abi | 1,407,177 | 1,407,177 | 0 |
| full-debug (`-O0`) | 1,964,614 | 1,964,614 | 0 |

No C source changes, and `lib/mruby/amalgam.rb` is read by `rake amalgam` alone: the compilers run on the same sources with the same flags.

## Testing

The fixture is a gem whose `mrbgem.rake` says `spec.cc.defines << '_GNU_SOURCE'` and whose one source calls `rawmemchr`, which glibc declares under `__USE_GNU` only. `strcasestr` reads as a GNU extension but has moved to `__USE_MISC` in this glibc, which is on by default, so it cannot tell the two apart.

Each generated `mruby.c` syntax checked on its own, `clang -O0 -fsyntax-only -I. mruby.c`:

| config | master | this PR |
| --- | --- | --- |
| `MRB_NO_STDIO` | 0 errors | 0 errors |
| default gembox | 0 errors | 0 errors |
| default gembox + `_GNU_SOURCE` gem | 1 error, the `rawmemchr` call | 0 errors |

| what | result |
| --- | --- |
| `rake -m test MRUBY_CONFIG=default` | 2594 total, 0 KO / 0 Crash / 0 Warning |
| `rake -m MRUBY_CONFIG=ci/gcc-clang` | all five builds link |

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor, 32 threads |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C compiler (checks) | Homebrew clang version 23.1.0 |
| binutils | GNU ld (GNU Binutils) 2.47.20260726 |
| glibc | Ubuntu GLIBC 2.39-0ubuntu8.8 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |
| rake | 13.3.1 |

The compile of `src/string.c` in each of the five builds, as `rake --verbose` printed it, with `-MMD -c`, the `-I` paths, the `-o` and the two `-ffile-prefix-map` taken off:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that build and gem compiler defines are emitted before standard includes in generated headers.
  * Documented filtering rules for reserved define names and guidance on using build versus compiler defines.
  * Explained how define placement preserves libc feature-test macros.
  * Added guidance on how defines affect all source files in combined builds.

* **Bug Fixes**
  * Corrected generated header output so defines appear in the proper order.
  * Prevented duplicate emission of gem compiler defines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->