### PR TITLE
ci: check out Prism with the source and log each build's defines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
         run: ruby -v
       - name: Compiler version
         run: ${{ env.CC }} --version
+      - name: Defines
+        run: rake defines
       - name: Build
         run: rake -m test:build
       - name: Test
@@ -98,6 +100,9 @@ jobs:
           mkdir -p ~/cosmo && cd ~/cosmo
           wget https://cosmo.zip/pub/cosmocc/cosmocc.zip
           unzip cosmocc.zip
+      - name: Defines
+        run: |
+          COSMO_ROOT=~/cosmo rake defines MRUBY_CONFIG=cosmopolitan
       - name: Build
         run: |
           COSMO_ROOT=~/cosmo rake -m test:build MRUBY_CONFIG=cosmopolitan
@@ -118,6 +123,11 @@ jobs:
           submodules: true
       - name: Ruby version
         run: ruby -v
+      - name: Defines
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          rake defines
       - name: Build
         shell: cmd
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Install i386 cross-build toolchain
         if: matrix.altname == 'i686-gcc'
         run: |
@@ -82,6 +83,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Ruby version
         run: ruby -v
       - name: Cache cosmocc
@@ -113,6 +115,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Ruby version
         run: ruby -v
       - name: Build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          submodules: true
       - name: Ruby version
         run: ruby -v
       - name: Compiler version


### PR DESCRIPTION
## Summary

A CI job's log names the compiler it ran and the configuration it was handed, but not what that configuration came to. `rake defines`, added in #7453, prints exactly that, and this runs it in each build job ahead of the build.

## Changes

| File | What |
| --- | --- |
| `.github/workflows/build.yml` | The checkout takes the Prism submodule; a `Defines` step added to the `GCC-CLANG`, `Cosmopolitan` and `Windows-VC` jobs |
| `.github/workflows/coverage.yml` | The checkout takes the Prism submodule |

### The checkout takes the submodule

`actions/checkout` leaves submodules alone, so the first rake of a job is what pays for `mrbgems/mruby-compiler/lib/prism`: `mruby-compiler`'s rakefile runs `git submodule update --init` as it loads, with no depth, and clones the submodule's whole history. Until now that first rake was the build, and the clone read as build time. Putting a step in front of the build only moves the bill to that step, which is no more where it belongs.

Asking the checkout for it puts the work in the step that reports it, and makes it smaller, as the action passes the job's `fetch-depth`, 1 by default, down to the submodule:

```console
[command]/usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1
```

Local builds keep the rakefile path, which returns early once the submodule is populated. AppVeyor already fetches the submodule outside the build, in `install`.

### The step goes ahead of the build

A failure that turns on the configuration is then readable from the run that produced it, rather than reconstructed by reading the config files at the commit under test, and the tables are there when the build itself is what fails.

The task has no prerequisites and builds nothing: what it costs is one rake load, plus the `check_header` probes the configuration runs as it loads.

### Two jobs repeat their setup

A step does not inherit the environment of the step before it, so the `Defines` step of `Cosmopolitan` names `COSMO_ROOT` and `MRUBY_CONFIG` again, and the one of `Windows-VC` calls `vcvars64.bat` again, as those jobs' build and test steps already do.

### What a job prints

From the `Windows-VC` job of the run below:

```console
Defines of 'msvc':
  HAVE_MRUBY_ENCODING_GEM    conf                                  mrbgems/mruby-encoding/mrbgem.rake:5
  HAVE_MRUBY_IO_GEM          conf                                  mrbgems/mruby-io/mrbgem.rake:6
  HAVE_MRUBY_REGEXP_GEM      conf                                  mrbgems/mruby-regexp/mrbgem.rake:11
  MRB_GC_FIXED_ARENA         compilers                             build_config/ci/msvc.rb:15
  MRB_REVISION_HEADER        compilers internal                    tasks/revision.rake:68
  MRB_STACK_EXTEND_DOUBLING  cc internal, cxx internal             tasks/toolchains/visualcpp.rake:12
  MRB_USE_BIGINT             conf                                  mrbgems/mruby-bigint/mrbgem.rake:5
  MRB_USE_COMPLEX            conf                                  mrbgems/mruby-complex/mrbgem.rake:5
  MRB_USE_RATIONAL           conf                                  mrbgems/mruby-rational/mrbgem.rake:5
  MRB_USE_SET                conf                                  mrbgems/mruby-set/mrbgem.rake:5
  MRB_USE_TASK_SCHEDULER     conf                                  mrbgems/mruby-task/mrbgem.rake:7
  MRB_UTF8_STRING            conf                                  mrbgems/mruby-encoding/mrbgem.rake:6
  MRC_TARGET_MRUBY           mruby-compiler cc, mruby-bin-mrbc cc  mrbgems/mruby-compiler/mrbgem.rake:31, mrbgems/mruby-bin-mrbc/mrbgem.rake:24
  PRISM_BUILD_MINIMAL        mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:34
  PRISM_DEPTH_MAXIMUM=256    mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:24
  PRISM_XALLOCATOR           mruby-compiler cc                     mrbgems/mruby-compiler/mrbgem.rake:14
```

`MRB_STACK_EXTEND_DOUBLING` is one the config files do not mention: the `visualcpp` toolchain adds it, and only this job compiles with it.

The `GCC-CLANG` jobs print one table per build of `ci/gcc-clang`, five of them, except the `armhf` job, which prints four: `MRUBY_CI_EMULATED` keeps `full-debug` from being declared there, and the log now says so.

## Speed

`Checkout`, which now takes the submodule, and `Defines`, in seconds, against the base commit's own run (mruby/mruby run 33601260999, the same 13 jobs at `6ec00d3ff`), whose checkout took the source alone and whose build cloned the submodule:

| Job | Checkout, base | Checkout | Defines |
| --- | --- | --- | --- |
| `ubuntu-24.04-gcc` | 5 | 6 | 3 |
| `ubuntu-24.04-clang` | 2 | 5 | 3 |
| `ubuntu-22.04-gcc` | 1 | 4 | 3 |
| `ubuntu-22.04-clang` | 1 | 5 | 5 |
| `ubuntu-24.04-arm-gcc` | 1 | 4 | 4 |
| `ubuntu-24.04-i686-gcc` | 1 | 4 | 3 |
| `ubuntu-24.04-armhf-gcc` | 1 | 6 | 1 |
| `macos-26-clang` | 2 | 7 | 3 |
| `macos-15-clang` | 2 | 8 | 2 |
| `windows-2025-mingw-gcc` | 9 | 21 | 8 |
| `windows-2022-mingw-gcc` | 8 | 15 | 8 |
| `Cosmopolitan` | 1 | 6 | 1 |
| `Windows-VC` | 6 | 13 | 11 |

The build gives up a clone in exchange for the one the checkout takes on, and the one it gives up is the larger. The branch measured that by accident: an earlier revision carried the `Defines` step without the checkout line, so the full-history clone ran inside `Defines`, which cost 7 to 17 seconds a job there (takumin/mruby run 33603250020) against the 1 to 11 here.

Build step wall clock lands anywhere from 130 seconds under its base to 35 seconds over it, so the runners' own spread is wider than anything this moves.

`Coverage` takes the checkout line and nothing else. Its checkout goes from 1 second to 4, and its `Build and test` step from 242 seconds to 240 (takumin/mruby runs 33603250065 and 33607943173).

## Testing

takumin/mruby run [33607943252](https://github.com/takumin/mruby/actions/runs/33607943252), 13 jobs green, every `Defines` step printing a table per build of its configuration.

## Environment

<details>

The numbers above are step wall clock on GitHub-hosted runners, so no compiler flags enter them. The images are the ones the workflow already names: `ubuntu-24.04`, `ubuntu-24.04-arm`, `ubuntu-22.04`, `macos-26`, `macos-15`, `windows-2025` and `windows-2022`.

The workflow files were also read by `ruby -ryaml` and by `yamllint` (1.38.0). On `coverage.yml` it reports what it reported before this change. On `build.yml` it reports one more `line-length` error, the `vcvars64.bat` line of the new `Defines` step, which is a copy of the line the `Build` and `Test` steps of that job already carry. Neither file is linted in CI: `super-linter` runs with `VALIDATE_DOCKERFILE_HADOLINT` alone.

Locally, with Ruby 4.0.6 on Linux 7.0.0 x86_64, `MRUBY_CONFIG=ci/gcc-clang rake defines` prints the five tables in 4.1 seconds, and with `MRUBY_CI_EMULATED=1` and `CC=i686-linux-gnu-gcc` it prints four.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated build checks across supported compilation environments.
  * Added validation of generated definitions before the existing build process, helping detect configuration or compatibility issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
