### PR TITLE
ci: bound the cross-toolchain installs at 5 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,14 @@ jobs:
           persist-credentials: false
       - name: Install i386 cross-build toolchain
         if: matrix.altname == 'i686-gcc'
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             crossbuild-essential-i386
       - name: Install armhf cross-build toolchain
         if: matrix.altname == 'armhf-gcc'
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Both cross-toolchain steps of the `GCC-CLANG` matrix fetch from whichever Azure mirror their runner is handed, and the rate is the runner's, not the archive's. On 2026-09-02 a run drew one serving at 98.4 kB/s and the armhf install took 12 minutes 15 seconds; the i386 job of the same run, on another runner, finished in 25 seconds. A job that slow cannot pass anyway, so this bounds the two steps and lets them say why.

## Changes

| File | What |
| --- | --- |
| `.github/workflows/build.yml` | `timeout-minutes: 5` on the i386 and armhf toolchain steps |

### What the slow run looked like

mruby/mruby run 33601636671, job `ubuntu-24.04-armhf-gcc`:

```console
Fetched 72.3 MB in 12min 15s (98.4 kB/s)
```

The rate was flat across the fetch, between 87 and 128 kB/s on every package, so it was bandwidth rather than a stall: `gcc-13-arm-linux-gnueabihf` alone is 19.6 MB and took 3 minutes 44 seconds. `dpkg` then unpacked and configured all 35 packages in 6 seconds. The i386 step of the same run was 25 seconds, and the archive was not the difference.

### Why five minutes

The two installs over the last 60 runs of this workflow, in seconds, from the runs that completed:

| Job | n | Median | p90 | Max |
| --- | --- | --- | --- | --- |
| `ubuntu-24.04-i686-gcc` | 58 | 15 | 32 | 75 |
| `ubuntu-24.04-armhf-gcc` | 58 | 19 | 37 | 307 |

Five minutes is sixteen times the i386 median and twenty times the armhf one, and only one of those 116 installs passed even 100 seconds. That one, at 307 seconds, is also the only one the bound would have failed; its job did finish, in 587 seconds of its 900.

An install past five minutes has nowhere to go: the job allows 15 minutes, and an armhf job spends up to 6 of them building and testing under emulation. The 12 minute run above would have failed at the job's limit with the build half done, which is what it reads as in the log. Bounding the step fails it ten minutes earlier, frees the runner for the rest of the matrix, and names the install as the step that ran out.

## Testing

takumin/mruby run [33605753815](https://github.com/takumin/mruby/actions/runs/33605753815), all 13 jobs green, the two bounded steps finishing in 12 seconds (i386) and 21 (armhf).

## Environment

<details>

The distributions above are step wall clock read from the GitHub Actions API, over the 60 most recent runs of `build.yml` on mruby/mruby as of 2026-09-02, counting the jobs that completed. No compiler flags enter them.

The workflow file was read by `ruby -ryaml` (Ruby 4.0.6) and by `yamllint` (1.38.0). yamllint reports on it exactly what it reports on the file before this change: the same 6 warnings and 2 errors, all of them on lines this change does not touch, shifted by the 2 lines it adds.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by applying safeguards to cross-platform build setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->