### PR TITLE
mruby-compiler: exclude arm64 from mingw64 builtin setjmp/longjmp

### DIFF
--- a/mrbgems/mruby-compiler/include/mrc_throw.h
+++ b/mrbgems/mruby-compiler/include/mrc_throw.h
@@ -33,7 +33,7 @@ typedef void *mrc_jmpbuf_impl;
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define MRC_SETJMP _setjmp
 #define MRC_LONGJMP _longjmp
-#elif defined(__MINGW64__) && defined(__GNUC__) && __GNUC__ >= 4
+#elif defined(__MINGW64__) && !defined(_M_ARM64) && defined(__GNUC__) && __GNUC__ >= 4
 #define MRC_SETJMP __builtin_setjmp
 #define MRC_LONGJMP __builtin_longjmp
 #else


### PR DESCRIPTION
This is the same change as f4d6e676561408893862c7b5c2f5098b2df0ca8b that is for `mruby/throw.h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for MinGW64 ARM64 builds by using the standard jump-handling implementation instead of compiler built-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->