### PR TITLE
mruby-regexp: implement the absent repeater `(?~...)`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -36,6 +36,7 @@ simulation) with backtracking fallback.
 - `(?<=...)` positive lookbehind (fixed-length, per branch)
 - `(?<!...)` negative lookbehind (fixed-length, per branch)
 - `(?>...)` atomic group
+- `(?~...)` absent repeater
 - `(?imx-imx)` options for the rest of the enclosing group
 - `(?imx-imx:...)` options for the group's own body
 
@@ -221,8 +222,8 @@ Regexp.new("(a)(?<b>b)\\1")
 Two engines, chosen automatically at compile time by pattern analysis.
 
 - **Pike VM (NFA simulation)** for patterns without backreferences, non-greedy
-  quantifiers, lookaround, atomic groups or subexpression calls. O(pattern x
-  text), so it is immune to ReDoS.
+  quantifiers, lookaround, atomic groups, absent repeaters or subexpression
+  calls. O(pattern x text), so it is immune to ReDoS.
 - **Backtracking engine** for the rest, whose state the Pike VM's threads have
   no stack to hold. It backtracks on a stack of its own on the heap, so a
   search spends a constant amount of C stack however long the subject is.
@@ -268,6 +269,13 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   every inline repeat here follows. Onigmo switches such repeats to a
   capture-tracking empty check that answers a few of them differently, among
   them `/((?<g1>|){2}b){2}\g<g1>{0}/` and `/(?<g1>)b\g<g1>{1,3}?/`.
+- **An absent repeater's body captures nothing**: the body of `(?~...)` is a
+  test the scan runs at one position after another and no part of the match,
+  so a group inside one is left as the match found it. CRuby keeps what the
+  runs of the body wrote where Onigmo has no restore for the group, so `(a)`
+  in `/(?~(a)(b))/` holds `"a"` there against a subject starting with one
+  though the body never matched, and drops it where it has one, which leaves
+  `/(?~(a|b)+)/` with an empty group in both engines.
 - **No character class intersection**: `[a&&b]` raises `RegexpError`. A lone
   `&` is a member of the class.
 - **No encodings**: a byte that starts no whole character is that byte, inside

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -119,12 +119,27 @@ enum re_opcode {
                         that pass runs, `offset` is not a code index but the
                         parser's own bookkeeping, which is why this opcode is
                         not in op_holds_code_index(). */
-  RE_RETURN          /* end of a called group's body: a = the group. Finds
+  RE_RETURN,         /* end of a called group's body: a = the group. Finds
                         the topmost frame no return has answered yet, writes
                         the group's capture pair from it -- the invocation
                         that completes last is the one the pair names, as in
                         CRuby -- leaves a marker in the frame's place and
                         goes on where the frame says. */
+  RE_ABSENT_START,   /* the absent repeater (?~e) is entered: the state its
+                        scan runs on goes on the choice point stack, holding
+                        where the absent began and how far it may reach. */
+  RE_ABSENT,         /* the head of one round of that scan: offset = the
+                        instruction after the group, where the absent goes on
+                        once the scan has found the end it takes. The body
+                        follows and ends at the RE_ABSENT_END; the round
+                        either takes an end and jumps to `offset`, or runs
+                        the body once at the position it stands at and goes
+                        on to the next position. */
+  RE_ABSENT_END      /* end of the absent's body, reached where the body
+                        matched: the match is not the absent's, it is what
+                        says the absent may not reach past it, so the round
+                        records how far the absent may still reach and the
+                        scan goes on at the next position. */
 };
 
 /* RE_LOOK_END::a. The polarity says what a matched sub-pattern means. The

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -192,6 +192,7 @@ op_holds_code_index(uint8_t op)
   case RE_JMP: case RE_SPLIT: case RE_SPLITNG:
   case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
   case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+  case RE_ABSENT:
     return TRUE;
   default:
     return FALSE;
@@ -2032,6 +2033,32 @@ compile_atom(re_compiler *c)
           c->flags = saved_flags;
           break;
         }
+        else if (c->p[1] == '~') {
+          /* The absent repeater (?~e): the longest run of text from here
+             that holds no match of e. The body is no part of the match, it
+             is run at one position after another to say where the run has
+             to stop, so the three instructions are a scan rather than a
+             sub-pattern the search passes through, and RE_ABSENT is its
+             head. `offset` on that head is the text after the group, which
+             is patched in once the body is compiled, as a lookaround's is.
+
+             CRuby's syntax has no absent expression (?~|absent|exp) or
+             absent stopper (?~|absent): a `|` here opens an alternative of
+             the body like any other, so (?~|a|b) is this repeater over
+             `|a|b`, which matches empty everywhere and leaves the absent
+             with nothing it can reach. That is CRuby's answer too. */
+          next_char(c); next_char(c);  /* skip ?~ */
+          emit(c, RE_ABSENT_START, 0, 0);
+          uint32_t head = emit(c, RE_ABSENT, 0, 0);
+          compile_alt(c);
+          emit(c, RE_ABSENT_END, 0, 0);
+          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+          next_char(c);
+          c->pat->code[head].offset = (uint16_t)c->code_len;
+          c->needs_backtrack = TRUE;  /* the Pike VM has no scan of its own */
+          c->flags = saved_flags;
+          break;
+        }
         else if (c->p[1] == '\'' ||
                  (c->p[1] == '<' && c->p + 2 < c->src_end &&
                   c->p[2] != '=' && c->p[2] != '!')) {
@@ -2130,12 +2157,12 @@ compile_atom(re_compiler *c)
         }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?'name' (?> (?imx forms. Comment groups (?#...)
-             never get here either, having been removed by
-             preprocess_pattern(). The absent operator (?~...) and
-             conditionals (?(...)) are not implemented. Raise here rather
-             than falling through to the capturing-group path, which would
-             leave the stray `?` for compile_seq to spin on forever (A1). */
+             (?<= (?<! (?<name> (?'name' (?> (?~ (?imx forms. Comment groups
+             (?#...) never get here either, having been removed by
+             preprocess_pattern(). Conditionals (?(...)) are not implemented.
+             Raise here rather than falling through to the capturing-group
+             path, which would leave the stray `?` for compile_seq to spin on
+             forever (A1). */
           if (c->p[1] == '<') {
             /* `(?<` and nothing more, the only way a '<' reaches here: the
                pattern ends before the character that tells a lookbehind
@@ -3548,11 +3575,18 @@ epsilon_path(const re_inst *code, uint32_t code_len, uint32_t pc, uint32_t goal,
     case RE_ATOMIC: case RE_ATOMIC_END:
     case RE_BACKREF:
     case RE_CALL:
+    case RE_ABSENT_START:
       pc++;
       break;
     case RE_JMP:
     case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
     case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+    /* An absent repeater takes no text where its body matches at the
+       position it began at, so a repetition around one has a body that can
+       match empty and needs the handling this pass turns on. The body of
+       the absent is not on the path: it is a test the scan runs, not text
+       the search passes through. */
+    case RE_ABSENT:
       pc = code[pc].offset;
       break;
     case RE_SPLIT:
@@ -3706,6 +3740,7 @@ call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
       case RE_ATOMIC: case RE_ATOMIC_END:
       case RE_BACKREF: case RE_LOOK_END:
       case RE_LB_WIDTH:  /* a rewind, which consumes nothing */
+      case RE_ABSENT_START: case RE_ABSENT_END:
         pc++;
         continue;
       case RE_JMP:
@@ -3716,6 +3751,10 @@ call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
         pc++;
         continue;
       case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+      /* The scan of an absent repeater runs its body wherever it stands,
+         and the text after is reached once the scan is done, which is the
+         same shape a lookaround has here. */
+      case RE_ABSENT:
         if (look_forks) stack[top++] = in.offset;
         pc++;
         continue;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -926,6 +926,30 @@ enum re_cp_kind {
                    back past the call pops the frame with everything above
                    it, and MRB_REGEXP_STACK_LIMIT bounds the call depth by
                    bounding the frames. */
+  RE_CP_ABSENT, /* not a branch: the state one absent repeater's scan runs
+                   on. `sp` is where the absent began. `pc` is how far it may
+                   still reach as an offset into the subject: the whole of
+                   what stands after it until a match of the body says
+                   otherwise, and below `sp` once the body has matched empty
+                   where the absent began, which is the absent matching
+                   nothing anywhere. `group` is the end of the subject the
+                   text around it runs against, put back when the scan ends.
+                   RE_ABSENT pops it at the head of each round and pushes it
+                   back for the next, so the scan's state is backtracking
+                   state like any other and a failure that goes back past the
+                   absent drops it. Reaching it while backtracking resumes
+                   nothing: there is no round left to try. */
+  RE_CP_ABSENT_ITER, /* the round after the one now running, pushed directly
+                        above the state it belongs to: the body failing at
+                        this position is the scan going on at the next.
+                        RE_ABSENT_END takes it by hand once the body has
+                        matched, which is what drops the alternatives the
+                        body left rather than trying them. */
+  RE_CP_ABSENT_BACK, /* the ends an absent repeater has not answered with
+                        yet: `sp` is the next one and `group` is where the
+                        absent began, which is the last. Taking one pushes
+                        the one below it, so a scan of any length leaves one
+                        choice point behind rather than one per position. */
   RE_CP_RET     /* not a branch either: the mark RE_RETURN leaves in place of
                    popping the frame it answered, which backtracking may
                    still need. The next RE_RETURN's downward scan counts
@@ -1176,6 +1200,15 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
 {
   const mrb_regexp_pattern *pat = m->pat;
   const char *str = m->str;
+  /* Where the subject ends, which is where it really ends except while the
+     body of an absent repeater runs: there it is the furthest the absent may
+     still reach, since a run of text the absent could never take is one the
+     body has no business reading. The whole of the search reads it, an
+     assertion as much as a literal, so `\z` inside such a body holds where
+     the scan stops rather than where the string does, which is CRuby's
+     answer: Onigmo keeps the reach in the same `end` the rest of its
+     executor measures against. RE_ABSENT puts it back at the head of every
+     round. */
   const char *str_end = m->str_end;
   int *captures = m->captures;
   int ncap = m->ncap;
@@ -1580,6 +1613,108 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
       }
       break;
 
+    case RE_ABSENT_START:
+      /* The absent repeater is entered. Its scan runs on the state pushed
+         here: it began at sp, it may reach as far as the subject reaches
+         around it, and that same end is what the scan puts back when it is
+         done. The subject an absent inside the body of another one runs
+         against is the one that one has narrowed. */
+      if ((r = bt_push(m, sp, (uint32_t)(str_end - str), RE_CP_ABSENT,
+                       (uint32_t)(str_end - str))) != BT_OK) {
+        return r;
+      }
+      pc++;
+      break;
+
+    case RE_ABSENT:
+      {
+        /* One round of the scan, at the position the round before left.
+           Every position from where the absent began to the end it may still
+           reach is an end the absent can take, so the round either takes the
+           furthest of them, leaving the shorter ones to backtracking under
+           one choice point for all of them, or runs the body once here and
+           goes on at the next position.
+
+           The state is popped and pushed back rather than read in place: the
+           round runs the body above it, and a body that fails has to land on
+           the choice point that begins the next round and not inside a state
+           the next round is about to read. */
+        if (m->cp_top == 0 || m->cp[m->cp_top - 1].kind != RE_CP_ABSENT) goto fail;
+        re_cpoint st = m->cp[--m->cp_top];
+        m->pass = st.pass;
+        str_end = str + st.group;
+        int begun = (int)(st.sp - str);
+        int reach = (int32_t)st.pc;
+        /* The body matched empty where the absent began, so every run of
+           text from here holds a match of it, the empty one included. */
+        if (reach < begun) goto fail;
+        if ((int)(sp - str) >= reach) {
+          if (reach > begun) {
+            const char *prev = lookbehind_start(str, str_end, str + reach,
+                                                RE_LB_PACK(1, 1), binary);
+            if (prev && (r = bt_push(m, prev, inst.offset, RE_CP_ABSENT_BACK,
+                                     (uint32_t)begun)) != BT_OK) {
+              return r;
+            }
+          }
+          sp = str + reach;
+          pc = inst.offset;
+          break;
+        }
+        {
+          const char *next = sp + mrb_re_charlen(sp, str_end, binary);
+          if ((r = bt_push(m, st.sp, st.pc, RE_CP_ABSENT, st.group)) != BT_OK) return r;
+          if ((r = bt_push(m, next, pc, RE_CP_ABSENT_ITER, 0)) != BT_OK) return r;
+        }
+        /* The body runs against a subject that ends where the absent may
+           still reach, and as a pass of its own, as a lookaround's
+           sub-pattern does, so that the records of the loops inside it are
+           read only by the round that wrote them. */
+        str_end = str + reach;
+        m->pass = ++m->pass_seq;
+        pc++;
+      }
+      break;
+
+    case RE_ABSENT_END:
+      {
+        /* The body has matched, which says how far the absent may still
+           reach: not past the text the body just read, so it stops at the
+           last character of that text, or, where the body matched empty, at
+           the position the body ran at, which the empty match stands after
+           rather than inside. An empty match where the absent began leaves
+           it nothing at all, recorded as a reach below that position and
+           answered at the head of the next round.
+
+           The alternatives the body left are dropped: the scan asks whether
+           the body matches here, and one match is the whole of the answer.
+           So is what it captured. The body is a test the scan runs and no
+           part of the match, so a group inside one is left as the match
+           found it, whether the run of the body matched or failed. */
+        uint32_t idx = m->cp_top;
+        while (idx > 0 && m->cp[idx - 1].kind != RE_CP_ABSENT_ITER) idx--;
+        if (idx == 0) goto fail;
+        idx--;
+        re_cpoint it = m->cp[idx];
+        if (idx == 0 || m->cp[idx - 1].kind != RE_CP_ABSENT) goto fail;
+        re_cpoint *st = &m->cp[idx - 1];
+        int reach;
+        if (sp < it.sp) {
+          reach = (sp == st->sp) ? -1 : (int)(sp - str);
+        }
+        else {
+          const char *prev = lookbehind_start(str, str_end, sp, RE_LB_PACK(1, 1), binary);
+          reach = prev ? (int)(prev - str) : -1;
+        }
+        if (reach < (int32_t)st->pc) st->pc = (uint32_t)reach;
+        m->cp_top = idx;
+        bt_undo_to(m, it.undo_top);
+        m->pass = it.pass;
+        sp = it.sp;
+        pc = it.pc;
+      }
+      break;
+
     default:
       goto fail;
     }
@@ -1605,6 +1740,18 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
          either: backtracking past a call is just the call unwinding, and
          what is left to try is below them. */
       if (c.kind == RE_CP_BARRIER || c.kind == RE_CP_CALL || c.kind == RE_CP_RET) continue;
+      /* An absent repeater's state is not a branch either: reaching it is
+         the scan having no round left, and the subject the text around it
+         runs against comes back with it. */
+      if (c.kind == RE_CP_ABSENT) { str_end = str + c.group; continue; }
+      /* The ends of an absent repeater are answered longest first, and the
+         one below the end being taken is what is left to try after it. */
+      if (c.kind == RE_CP_ABSENT_BACK && c.sp > str + c.group) {
+        const char *prev = lookbehind_start(str, str_end, c.sp, RE_LB_PACK(1, 1), binary);
+        if (prev && (r = bt_push(m, prev, c.pc, RE_CP_ABSENT_BACK, c.group)) != BT_OK) {
+          return r;
+        }
+      }
       sp = c.sp;
       pc = c.pc;
       if (c.kind == RE_CP_ITER && (r = bt_iter_begin(m, c.group, sp)) != BT_OK) return r;

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1010,9 +1010,8 @@ assert("Regexp - patterns that used to hang the compiler now raise (A1)") do
   # Regexp.new is used so the pattern reaches the regexp compiler directly,
   # bypassing the literal validation the parser performs on /.../ literals.
 
-  # (?X) with an unsupported X: the absent operator (?~...) and conditionals
-  # (?(...)) are not implemented (inline options (?i)/(?i:...) now are).
-  assert_raise(RegexpError) { Regexp.new("(?~foo)") }
+  # (?X) with an unsupported X: conditionals (?(...)) are not implemented
+  # (inline options (?i)/(?i:...) and the absent repeater (?~...) now are).
   assert_raise(RegexpError) { Regexp.new("(?(<x>)a|b)") }
   assert_raise(RegexpError) { Regexp.new("(?") }
   assert_raise(RegexpError) { Regexp.new("(?<") }
@@ -1703,6 +1702,72 @@ assert("Regexp - an atomic group the parser refuses") do
   assert_raise(RegexpError) { Regexp.new("(?>") }
   # not a fixed-length construct, so not allowed in a lookbehind
   assert_raise(RegexpError) { Regexp.new("(?<=(?>a))b") }
+end
+
+assert("Regexp - absent repeater (?~...)") do
+  need_backtracking_stack
+  # The longest run of text from where it stands that holds no match of the
+  # body. A match of the body that begins inside the run and ends past it is
+  # not one the run holds, which is why `bar` starting at index 3 still
+  # leaves `fooba`.
+  assert_equal "a", /(?~b)/.match("abc")[0]
+  assert_equal "fooba", /(?~bar)/.match("foobarbaz")[0]
+  assert_equal "xyz", /(?~b)/.match("xyz")[0]
+  assert_equal ["a", "", "b", "", "c", ""], "aXbXc".scan(/(?~X)/)
+  # It gives text back as a greedy repeat does, one character at a time.
+  assert_equal "abcd", /a(?~x)d/.match("abcd")[0]
+  assert_equal "a", /(?~a)a/.match("aa")[0]
+  assert_nil /\A(?~b)\z/ =~ "xbz"
+  assert_equal 0, /\A(?~b)\z/ =~ "xyz"
+
+  # The body is matched where the scan stands, with the branches tried in
+  # the order the pattern gives them: the run stops before the last
+  # character of the match that is found, not of the shortest one there is.
+  assert_equal "fooba", /(?~bar|ba)/.match("foobarbaz")[0]
+  assert_equal "foob", /(?~ba|bar)/.match("foobarbaz")[0]
+
+  # A body that matches empty where the absent began leaves it nothing
+  # anywhere, so the earliest position it can match at is the end of the
+  # subject, where the body is not run at all.
+  assert_equal 3, /(?~)/.match("abc").begin(0)
+  assert_equal 3, /(?~x?)/.match("abc").begin(0)
+  assert_equal "", /(?~)/.match("")[0]
+  # One that matches empty further along stops the run there.
+  assert_equal "bcdefg", /(?~\b)/.match("abcdefg")[0]
+  assert_equal "a", /(?~$)/.match("a\nb")[0]
+  assert_equal "bc", /(?~\A)/.match("abc")[0]
+
+  # The body runs against a subject ending where the absent may still reach,
+  # so a greedy body is cut down by the run it is testing.
+  assert_equal "a", /(?~a+)/.match("aaa")[0]
+  assert_equal "aa", /(?~a+)/.match("aaaa")[0]
+  assert_equal "ab", /(?~b+)/.match("abbbc")[0]
+  assert_equal "aba", /(?~(?:ab)+)/.match("ababab")[0]
+
+  # Quantified, it repeats as any atom does, and its own empty iteration
+  # ends the repeat.
+  assert_equal "bc", /(?~a)*/.match("bcad")[0]
+  assert_equal "bc", /(?~a)+/.match("bcad")[0]
+  assert_equal "bc", /(?~a){2}/.match("bcad")[0]
+  assert_equal "", /(?~a)??/.match("bcad")[0]
+
+  # The body is a test and no part of the match, so a group inside it is
+  # left as the match found it.
+  assert_nil /(?~(b))/.match("abc")[1]
+  assert_equal "a", /(a)(?~\1)/.match("xaay")[1]
+
+  # It reads back through to_s, and free-spacing applies to its body.
+  assert_equal "a", Regexp.new(/(?~b)/.to_s).match("abc")[0]
+  assert_equal "a", Regexp.new("(?~ b )", Regexp::EXTENDED).match("abc")[0]
+  # /i folds the body, as it folds anything else.
+  assert_equal "", Regexp.new("(?~A)", Regexp::IGNORECASE).match("aab")[0]
+end
+
+assert("Regexp - an absent repeater the parser refuses") do
+  assert_raise(RegexpError) { Regexp.new("(?~a") }
+  assert_raise(RegexpError) { Regexp.new("(?~") }
+  # not a fixed-length construct, so not allowed in a lookbehind
+  assert_raise(RegexpError) { Regexp.new("(?<=(?~a))b") }
 end
 
 assert("Regexp - a lookbehind body of no fixed width says which it was") do

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -1036,3 +1036,24 @@ assert('Regexp - a word boundary sits beside any script') do
     assert_equal 0, (byte =~ /\A\B/)
   end
 end
+
+assert("Regexp - an absent repeater's run stops on a character boundary") do
+  skip unless __ENCODING__ == "UTF-8"
+
+  # The run may not hold the body's match, so it stops before the first byte
+  # of the character the match begins at, not one byte back from its end.
+  assert_equal "い", /(?~あ)/.match("いあう")[0]
+  assert_equal "", /(?~い)/.match("いあう")[0]
+  assert_equal "いあ", /(?~う)/.match("いあう")[0]
+  assert_equal "いあう", /(?~x)/.match("いあう")[0]
+  # and it gives the characters back one at a time, not the bytes
+  assert_equal "いあう", /(?~x)う/.match("いあう")[0]
+
+  # A binary subject is bytes, so the same pattern stops one byte into the
+  # character the match begins at.
+  if "".respond_to?(:force_encoding)
+    bin = "いあう".dup.force_encoding("ASCII-8BIT")
+    pat = Regexp.new("(?~\xE3\x81\x82".dup.force_encoding("ASCII-8BIT") + ")")
+    assert_equal 5, pat.match(bin)[0].bytesize
+  end
+end


### PR DESCRIPTION
## Summary

The absent repeater `(?~...)` was refused at parse, so `"a" =~ /(?~b)/` raised
`RegexpError` where CRuby answers `0`. Conditionals `(?(...))` are the only
`(?...)` form this engine still refuses.

## Changes

| File | What |
|---|---|
| `include/re_internal.h` | add `RE_ABSENT_START`, `RE_ABSENT`, `RE_ABSENT_END` |
| `src/re_compile.c` | read `(?~e)` in `compile_atom()`; teach `op_holds_code_index()`, `epsilon_path()` and `call_walk()` the three opcodes |
| `src/re_exec.c` | run the scan in `bt_match()`; add `RE_CP_ABSENT`, `RE_CP_ABSENT_ITER`, `RE_CP_ABSENT_BACK` |
| `test/regexp_syntax.rb` | tests for the construct and for the two spellings the parser refuses |
| `test/regexp_utf8.rb` | tests that the run stops on a character boundary |
| `README.md` | syntax list, engine note, limitation entry |

### A scan, not a sub-pattern

`(?~e)` matches the longest run of text from where it stands that holds no
match of `e`, and shorter runs of it on backtracking. The body is no part of
the match: it is run at one position after another to say where the run has
to stop, and no arrangement of the forks and jumps this engine already has
says that. Onigmo does not express it in its own instructions either, and
carries `OP_PUSH_ABSENT_POS` / `OP_ABSENT` / `OP_ABSENT_END` for it.

The three opcodes here are the same shape. `RE_ABSENT` is the head of one
round: it either takes an end and jumps past the group, or runs the body once
at the position it stands at and goes on at the next one. The state the scan
runs on (where the absent began, how far it may still reach) lives on the
choice point stack, so a failure that goes back past the absent drops it with
everything else, and an absent inside the body of another one nests without a
counter of its own.

### One choice point for every end

The ends the scan can answer with run from where the absent began to the
furthest it may reach, without a gap. So the round takes the furthest and
leaves a single choice point standing for all the shorter ones; taking that
one pushes the end below it.

Onigmo pushes an alternative per position instead, which this engine cannot
afford: `MRB_REGEXP_STACK_LIMIT` is 2,048 by default, so a scan over a longer
subject would stop at the limit rather than answer. `(?~b)` against 50,000
characters costs two choice points here.

### The body runs against a shortened subject

While the body runs, the subject ends where the absent may still reach. This
is CRuby's rule and not a shortcut: Onigmo keeps that reach in the same `end`
the rest of its executor measures against, so every instruction of the body
reads it, an assertion as much as a literal.

It decides a body that can match more than one length. `/(?~a+)/` against
`"aaa"` is `"a"`: the run being tested cuts `a+` down to the two characters
before it, which reports a stop one character earlier than the greedy match
over the whole subject would. Reading the body against the whole subject
answers `"aa"`, and a nested absent whose innermost body ends at `\z`, `\Z` or
`$` moves with it too.

## Behaviour

```ruby
"a" =~ /(?~b)/                 # was RegexpError, now 0
"foobarbaz"[/(?~bar)/]         # "fooba"
"aXbXc".scan(/(?~X)/)          # ["a", "", "b", "", "c", ""]
"abcd"[/a(?~x)d/]              # "abcd", the run given back a character at a time
/(?~)/.match("abc").begin(0)   # 3: a body matching empty where the absent
                               #    begins leaves it nothing there
```

A group inside the body captures nothing, since the body is a test and no part
of the match. CRuby keeps what a run of the body wrote for the groups Onigmo
has no restore for, so `/(?~(a)(b))/` against `"abc"` leaves `"a"` in group 1
there and `nil` here; where Onigmo does have one, as in `/(?~(a|b)+)/`, both
engines leave the group empty. `README.md` records it under Limitations.

`(?~|absent|exp)` and `(?~|absent)` are Onigmo syntax that CRuby's does not
carry: a `|` after `(?~` opens an alternative of the body like any other.
`/(?~|a|b)/` is this repeater over `|a|b`, which matches empty everywhere and
leaves the absent with nothing it can reach, in both engines.

## Speed

Nothing existing changes path. Four patterns that reach the engine the way
they did before, one per shape that picks the backtracking engine plus one
that stays on the Pike VM:

```ruby
s = "abcabc" * 500
1000.times { s =~ /(abc)\1/ }

s = "xxxxabxxxx" * 200
1000.times { s =~ /(?=ab)ab/ }

s = "aaab" * 300
1000.times { s =~ /(?>a+)b/ }

s = "the quick brown fox " * 200
1000.times { s =~ /qu[a-z]+k/ }
```

Callgrind Ir for the whole run, x86-64 gcc 13.3.0 -O3 (`bintest`). Wall clock
is not the measure here: the differences are under a tenth of a percent, which
this machine's clock does not resolve.

| Case | master | this PR | delta |
|---|---:|---:|---:|
| `/(abc)\1/` over 3 KB | 20,089,814 | 20,087,814 | -0.010% |
| `/(?=ab)ab/` over 2 KB | 18,853,718 | 18,846,718 | -0.037% |
| `/(?>a+)b/` over 1.2 KB | 19,909,235 | 19,910,227 | +0.005% |
| `/qu[a-z]+k/` over 4 KB | 24,486,440 | 24,515,445 | +0.119% |

Two controls that touch no regexp are -36 Ir apart, which is the constant this
table sits on. The Pike VM case carries the only reading above that: a literal
is compiled on every evaluation, and the switches this adds a case to are on
the compile path, so the 1,000 compiles pay about 29 Ir each.

The scan is O(subject) per start position, as Onigmo's is, so a pattern that
fails after the absent walks the subject once per position.
`MRB_REGEXP_STEP_LIMIT` bounds it as it bounds every other backtracking
pattern here.

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0, base `8c0a67dc8`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,375,686 | 1,378,102 | +2,416 |
| `ascii-ctype` | 1,361,846 | 1,364,390 | +2,544 |
| `byte-string` | 1,338,694 | 1,341,382 | +2,688 |
| `cxx_abi` | 1,408,713 | 1,410,953 | +2,240 |
| `full-debug` (-O0) | 1,966,758 | 1,968,710 | +1,952 |

All of it is the gem: in `bintest`, `re_exec.o` `.text` is +2,368 for the three
opcode cases and the two arms in the backtracking loop, `re_compile.o` is +48
for the parse arm and the three analysis walks, and `regexp.o` is unchanged.

## Testing

- `rake -m test` with `build_config/ci/gcc-clang.rb`: 8 runs, KO 0, Crash 0,
  Warning 0.
- `build_config/clang-asan.rb`: KO 0, Crash 0, and no sanitizer report over the
  corpus below.
- `mrbgems/mruby-regexp/tools/difftest/compare.rb`: 5,175 patterns, 93 known
  differences, no new ones.
- A corpus of 91,800 pattern and subject pairs, 27 wrappers over 85 bodies and
  40 subjects, compared against CRuby 4.0.6. Every case agrees on the span. The
  291 that differ are the captures above (218) and a `{n,m}` reading this
  engine already answers differently from CRuby (73), which `/(?:(?<=a)b?){2,3}/`
  against `"abc"` shows on master with no absent in it.
- A second corpus of 4,785 pairs over multibyte patterns and subjects on a
  UTF-8 build: no differences.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc 13.3.0 |
| binutils | GNU Binutils 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines, one per build of `build_config/ci/gcc-clang.rb`, with `-MMD -c`,
`-I` and `-o` dropped:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the absent repeater `(?~...)` in regular expressions.
  * Matches the longest text span containing no match of its pattern, with shorter spans tried during backtracking.
  * Preserves character boundaries when matching UTF-8 text.
  * Documented syntax, engine support, and capture behavior.

* **Tests**
  * Added coverage for matching behavior, quantifiers, alternation, captures, serialization, and UTF-8 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->