### PR TITLE
mruby-regexp: read the subject in one place

### DIFF
--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -24,7 +24,7 @@ static void regexp_free(mrb_state *mrb, void *ptr) {
   mrb_re_free(mrb, (mrb_regexp_pattern*)ptr);
 }
 
-static mrb_bool re_binary_string_p(mrb_value str);
+static mrb_bool re_pattern_binary(mrb_value str);
 
 static const struct mrb_data_type regexp_type = { "Regexp", regexp_free };
 
@@ -163,7 +163,7 @@ re_initialize(mrb_state *mrb, mrb_value self, mrb_value pattern, uint32_t flags)
   DATA_PTR(self) = pat;
 
   mrb_re_compile(mrb, pat, RSTRING_PTR(pattern), RSTRING_LEN(pattern), flags,
-                 re_binary_string_p(pattern));
+                 re_pattern_binary(pattern));
 
   /* Store named captures as a hash of name -> [group, ...]. A name may be
      given to several groups, and each keeps its own number, so the table
@@ -363,38 +363,44 @@ re_char_to_byte(mrb_state *mrb, mrb_value str, mrb_int char_off)
   return byte_off;
 }
 
+/* Whether a pattern is compiled by byte, which is the one thing
+   mrb_re_compile() asks of the string it is handed. A subject is read by
+   re_subject_binary() below. */
 static mrb_bool
-re_binary_string_p(mrb_value str)
+re_pattern_binary(mrb_value str)
 {
   return RSTR_BINARY_P(RSTRING(str));
 }
 
-/* CRuby refuses a search whose subject holds a byte that spells no character,
-   and mruby answers for it. Refuse it here too, so that a program moved from
-   one to the other is told about the subject rather than handed a result the
-   other would not have produced.
+/* How a search reads `str`: TRUE when by byte. This is the one place a
+   subject is read, and every search takes what it answers.
+
+   CRuby refuses a search whose subject holds a byte that spells no character,
+   and mruby answers for it. A subject read by character is refused here too,
+   so that a program moved from one to the other is told about the subject
+   rather than handed a result the other would not have produced.
 
    A binary string is exempt because it is indexed by byte throughout, so its
-   bytes make no claim that could be broken. A quoted String pattern is exempt
-   for a narrower reason: CRuby searches for a literal byte by byte and reads
+   bytes make no claim that could be broken. `unread` exempts a subject for a
+   narrower reason: CRuby searches for a quoted String byte by byte and reads
    the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
-   answers there while the same call with `/b/` is refused. re_sub_lit() and
-   re_gsub_lit() never ask, having no compiled pattern to ask on behalf of,
-   and the searches a literal reaches with one take a `literal` argument to
-   say so.
+   answers there while the same call with `/b/` is refused. The searches a
+   literal reaches set it, apart from `scan` and `split`, which CRuby refuses
+   a literal on as well.
 
-   The check walks the whole subject, so every entry point below runs it on
-   the subject it is handed, and the loops that search per match (`scan`,
-   `split`, the gsub walks) ask again each turn: core remembers a string it
-   has read as valid UTF-8, so every turn after the first costs a flag test
-   and not a walk, and only a block that rewrote the receiver pays a new
+   The check walks the whole subject, so every entry point below reads the
+   subject it is handed, and the loops that search per match (`scan`,
+   `split`, the gsub walks) read it again each turn: core remembers a string
+   it has read as valid UTF-8, so every turn after the first costs a flag
+   test and not a walk, and only a block that rewrote the receiver pays a new
    one. */
-static void
-re_check_encoding(mrb_state *mrb, mrb_value str)
+static mrb_bool
+re_subject_binary(mrb_state *mrb, mrb_value str, mrb_bool unread)
 {
-  if (!mrb_str_valid_encoding_p(mrb, str)) {
+  if (!unread && !mrb_str_valid_encoding_p(mrb, str)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid byte sequence in UTF-8");
   }
+  return RSTR_BINARY_P(RSTRING(str));
 }
 
 /* Create MatchData from captures, and make it the match the globals
@@ -466,10 +472,15 @@ re_check_exec_error(mrb_state *mrb, int n)
 
 /* Internal: execute match and create MatchData.
    Returns MatchData on match, nil on no match.
-   Publishes the match as $~, and clears it on a miss. */
+   Publishes the match as $~, and clears it on a miss.
+   `unread` is passed on to re_subject_binary(), and is asked first, so that
+   a subject it refuses is refused before the pattern is looked at. `literal`
+   says what the MatchData records (below); the two part only in `scan`. */
 static mrb_value
-exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool literal)
+exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos,
+           mrb_bool unread, mrb_bool literal)
 {
+  mrb_bool binary = re_subject_binary(mrb, str, unread);
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
 
@@ -477,7 +488,7 @@ exec_match(mrb_state *mrb, mrb_value self, mrb_value str, mrb_int pos, mrb_bool 
   int captures[RE_MAX_CAPTURES * 2];
   memset(captures, -1, sizeof(int) * cap_size);
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos,
-                     captures, cap_size, re_binary_string_p(str));
+                     captures, cap_size, binary);
   re_check_exec_error(mrb, ncap);
 
   if (ncap == 0) {
@@ -513,8 +524,7 @@ regexp_match(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
 
-  re_check_encoding(mrb, str);
-  md = exec_match(mrb, self, str, pos, FALSE);
+  md = exec_match(mrb, self, str, pos, FALSE, FALSE);
   if (!mrb_nil_p(md) && !mrb_nil_p(block)) {
     return mrb_yield(mrb, block, md);
   }
@@ -545,8 +555,7 @@ re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool lit
     clear_match_globals(mrb);
     return mrb_nil_value();
   }
-  if (!literal) re_check_encoding(mrb, str);
-  return exec_match(mrb, re, str, pos, literal);
+  return exec_match(mrb, re, str, pos, literal, literal);
 }
 
 /*
@@ -568,7 +577,7 @@ re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool lit
 static mrb_value
 re_byte_rsearch(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int limit)
 {
-  re_check_encoding(mrb, str);
+  mrb_bool binary = re_subject_binary(mrb, str, FALSE);
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (!pat) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
@@ -576,7 +585,7 @@ re_byte_rsearch(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int limit)
   int cap_size = pat->num_captures * 2;
   int captures[RE_MAX_CAPTURES * 2];
   int ncap = mrb_re_rexec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), limit,
-                          captures, cap_size, re_binary_string_p(str));
+                          captures, cap_size, binary);
   re_check_exec_error(mrb, ncap);
   if (ncap == 0) {
     clear_match_globals(mrb);
@@ -598,10 +607,10 @@ exec_match_p(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos)
 
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  mrb_bool binary = re_subject_binary(mrb, str, FALSE);
 
   int ncap = mrb_re_exec(mrb, pat, RSTRING_PTR(str), RSTRING_LEN(str), pos, NULL, 0,
-                         re_binary_string_p(str));
+                         binary);
   re_check_exec_error(mrb, ncap);
   return mrb_bool_value(ncap > 0);
 }
@@ -631,9 +640,7 @@ regexp_match_op(mrb_state *mrb, mrb_value self)
     return mrb_nil_value();
   }
   str = match_operand(mrb, str);
-  re_check_encoding(mrb, str);
-
-  mrb_value md = exec_match(mrb, self, str, 0, FALSE);
+  mrb_value md = exec_match(mrb, self, str, 0, FALSE, FALSE);
   if (mrb_nil_p(md)) return mrb_nil_value();
 
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
@@ -655,9 +662,7 @@ regexp_case_match(mrb_state *mrb, mrb_value self)
 
   pat = DATA_GET_PTR(mrb, self, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) return mrb_false_value();
-  re_check_encoding(mrb, str);
-
-  md = exec_match(mrb, self, str, 0, FALSE);
+  md = exec_match(mrb, self, str, 0, FALSE, FALSE);
   return mrb_bool_value(!mrb_nil_p(md));
 }
 
@@ -856,7 +861,7 @@ re_fold_leading_group(mrb_state *mrb, mrb_value src, const char **ptrp, mrb_int 
     /* n counts ':' and ')' as well as what lies between, which may be empty:
        "(?:)" is a group around nothing. */
     if (n >= 2 && *p == ':' && p[n-1] == ')' &&
-        re_compiles_alone(mrb, p + 1, n - 2, on, re_binary_string_p(src))) {
+        re_compiles_alone(mrb, p + 1, n - 2, on, re_pattern_binary(src))) {
       flags = on;
       ptr = p + 1;
       len = n - 2;
@@ -1418,7 +1423,7 @@ re_subject_reads_as(mrb_state *mrb, mrb_value str, mrb_value mdv)
   mrb_value src = md->source;
   mrb_int len = RSTRING_LEN(src);
   if (RSTRING_LEN(str) != len) return FALSE;
-  if (re_binary_string_p(str) != re_binary_string_p(src)) return FALSE;
+  if (re_subject_binary(mrb, str, TRUE) != re_subject_binary(mrb, src, TRUE)) return FALSE;
   const char *p = RSTRING_PTR(str), *q = RSTRING_PTR(src);
   return p == q || memcmp(p, q, (size_t)len) == 0;
 }
@@ -1804,11 +1809,11 @@ has_backslash(const char *s, mrb_int len)
    result holds the subject alone and the replacement says nothing about it.
    This is where CRuby lands on every pair it accepts. */
 static void
-re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
-                mrb_bool spliced)
+re_mark_spliced(mrb_state *mrb, mrb_value result, mrb_value subject,
+                mrb_value replacement, mrb_bool spliced)
 {
-  if (!re_binary_string_p(subject)) {
-    if (!spliced || !re_binary_string_p(replacement)) return;
+  if (!re_subject_binary(mrb, subject, TRUE)) {
+    if (!spliced || !RSTR_BINARY_P(RSTRING(replacement))) return;
     const char *p = RSTRING_PTR(replacement);
     const char *e = p + RSTRING_LEN(replacement);
     while (p < e && !(*p & 0x80)) p++;
@@ -1829,14 +1834,13 @@ re_gsub_str(mrb_state *mrb, mrb_value re, mrb_value str, mrb_value replacement)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  mrb_bool binary = re_subject_binary(mrb, str, FALSE);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
   const char *rep = RSTRING_PTR(replacement);
   mrb_int rep_len = RSTRING_LEN(replacement);
   mrb_bool need_expand = has_backslash(rep, rep_len);
-  mrb_bool binary = re_binary_string_p(str);
 
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
@@ -1904,7 +1908,7 @@ re_gsub_str(mrb_state *mrb, mrb_value re, mrb_value str, mrb_value replacement)
     clear_match_globals(mrb);
   }
 
-  re_mark_spliced(result, str, replacement, last_ncap > 0);
+  re_mark_spliced(mrb, result, str, replacement, last_ncap > 0);
   return result;
 }
 
@@ -1918,7 +1922,7 @@ re_sub_str(mrb_state *mrb, mrb_value re, mrb_value str, mrb_value replacement)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  mrb_bool binary = re_subject_binary(mrb, str, FALSE);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
@@ -1929,7 +1933,7 @@ re_sub_str(mrb_state *mrb, mrb_value re, mrb_value str, mrb_value replacement)
   int captures[RE_MAX_CAPTURES * 2];
   memset(captures, -1, sizeof(int) * cap_size);
 
-  int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, re_binary_string_p(str));
+  int n = mrb_re_exec(mrb, pat, s, slen, 0, captures, cap_size, binary);
   re_check_exec_error(mrb, n);
   if (n == 0) {
     clear_match_globals(mrb);
@@ -1957,7 +1961,7 @@ re_sub_str(mrb_state *mrb, mrb_value re, mrb_value str, mrb_value replacement)
   }
 
   create_matchdata(mrb, re, str, captures, cap_size);
-  re_mark_spliced(result, str, replacement, TRUE);
+  re_mark_spliced(mrb, result, str, replacement, TRUE);
   return result;
 }
 
@@ -2041,7 +2045,7 @@ re_gsub_lit(mrb_state *mrb, mrb_value lit, mrb_value str, mrb_value replacement,
   const char *rep = RSTRING_PTR(replacement);
   mrb_int rep_len = RSTRING_LEN(replacement);
   mrb_bool need_expand = has_backslash(rep, rep_len);
-  mrb_bool binary = re_binary_string_p(str);
+  mrb_bool binary = re_subject_binary(mrb, str, TRUE);
 
   mrb_int beg = re_lit_search(s, slen, p, plen, 0);
   if (beg < 0) {
@@ -2090,7 +2094,7 @@ re_gsub_lit(mrb_state *mrb, mrb_value lit, mrb_value str, mrb_value replacement,
   if (pos < slen) re_cat_bytes(mrb, result, s + pos, slen - pos, binary);
 
   re_lit_matchdata(mrb, str, captures[0], captures[1]);
-  re_mark_spliced(result, str, replacement, TRUE);
+  re_mark_spliced(mrb, result, str, replacement, TRUE);
   return result;
 }
 
@@ -2104,7 +2108,7 @@ re_sub_lit(mrb_state *mrb, mrb_value lit, mrb_value str, mrb_value replacement, 
   mrb_int slen = RSTRING_LEN(str);
   const char *rep = RSTRING_PTR(replacement);
   mrb_int rep_len = RSTRING_LEN(replacement);
-  mrb_bool binary = re_binary_string_p(str);
+  mrb_bool binary = re_subject_binary(mrb, str, TRUE);
 
   mrb_int beg = re_lit_search(s, slen, RSTRING_PTR(lit), RSTRING_LEN(lit), 0);
   if (beg < 0) {
@@ -2127,7 +2131,7 @@ re_sub_lit(mrb_state *mrb, mrb_value lit, mrb_value str, mrb_value replacement, 
   if (end < slen) re_cat_bytes(mrb, result, s + end, slen - end, binary);
 
   re_lit_matchdata(mrb, str, beg, end);
-  re_mark_spliced(result, str, replacement, TRUE);
+  re_mark_spliced(mrb, result, str, replacement, TRUE);
   return result;
 }
 
@@ -2190,9 +2194,8 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal,
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  if (!literal) re_check_encoding(mrb, str);
 
-  mrb_bool binary = re_binary_string_p(str);
+  mrb_bool binary = re_subject_binary(mrb, str, literal);
   int cap_size = pat->num_captures * 2;
   int captures[RE_MAX_CAPTURES * 2];
   mrb_value result = mrb_str_new_capa(mrb, RSTRING_LEN(str));
@@ -2224,13 +2227,12 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal,
        rewrote in place are read from where they are now, since the write can
        have moved the buffer; whether they are read by byte can have changed
        with them (`s.replace(s.b)`), and so can whether they spell characters
-       at all, which the next search asks as `__byte_search` would. */
+       at all, which is asked again here as `__byte_search` would ask it. */
     if (RSTRING_LEN(str) != slen) {
       mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
     }
-    if (!literal) re_check_encoding(mrb, str);
     s = RSTRING_PTR(str);
-    binary = re_binary_string_p(str);
+    binary = re_subject_binary(mrb, str, literal);
 
     /* After the block and not before it, as in CRuby: the bytes before the
        match are taken from the receiver as the block left it. */
@@ -2276,7 +2278,7 @@ re_gsub_walk(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal,
   else {
     /* The closing search of `str_gsub`, on the receiver as the block left it,
        which publishes what it finds or clears the globals for a miss. */
-    exec_match(mrb, re, str, last, literal);
+    exec_match(mrb, re, str, last, literal, literal);
   }
   return result;
 }
@@ -2289,11 +2291,10 @@ re_scan_ary(mrb_state *mrb, mrb_value re, mrb_value str, mrb_bool literal)
 {
   mrb_regexp_pattern *pat = DATA_GET_PTR(mrb, re, &regexp_type, mrb_regexp_pattern);
   if (re_uninitialized_p(pat)) mrb_raise(mrb, E_ARGUMENT_ERROR, "uninitialized Regexp");
-  re_check_encoding(mrb, str);
+  mrb_bool binary = re_subject_binary(mrb, str, FALSE);
 
   const char *s = RSTRING_PTR(str);
   mrb_int slen = RSTRING_LEN(str);
-  mrb_bool binary = re_binary_string_p(str);
   int ncap = pat->num_captures;
   int cap_size = ncap * 2;
   int captures[RE_MAX_CAPTURES * 2];
@@ -2964,8 +2965,7 @@ str_scan_m(mrb_state *mrb, mrb_value self)
     if (RSTRING_LEN(self) != len) {
       mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
     }
-    re_check_encoding(mrb, self);
-    mrb_value md = exec_match(mrb, pattern, self, pos, literal);
+    mrb_value md = exec_match(mrb, pattern, self, pos, FALSE, literal);
     if (mrb_nil_p(md)) break;
     last = pos;
     last_md = md;
@@ -2990,8 +2990,7 @@ str_scan_m(mrb_state *mrb, mrb_value self)
       if (RSTRING_LEN(self) != len) {
         mrb_raise(mrb, E_RUNTIME_ERROR, "string modified");
       }
-      re_check_encoding(mrb, self);
-      exec_match(mrb, pattern, self, last, literal);
+      exec_match(mrb, pattern, self, last, FALSE, literal);
     }
   }
   return self;
@@ -3027,7 +3026,8 @@ str_split_m(mrb_state *mrb, mrb_value self)
   /* The real type, which an argument redefining `nil?` or `is_a?` cannot
      steer, and the same reading `Module#===` would give the pair. */
   if (mrb_nil_p(pattern) || mrb_string_p(pattern)) {
-    if (limit != 1) re_check_encoding(mrb, self);
+    /* Read for the refusal alone: core's `split` searches the literal. */
+    if (limit != 1) (void)re_subject_binary(mrb, self, FALSE);
     mrb_value split_args[2] = { pattern, mrb_int_value(mrb, limit) };
     return mrb_funcall_argv(mrb, self, MRB_SYM(__split), limit_given ? 2 : 1, split_args);
   }
@@ -3043,7 +3043,7 @@ str_split_m(mrb_state *mrb, mrb_value self)
   mrb_int field_start = 0, search_pos = 0;
   mrb_int len = RSTRING_LEN(self);
   mrb_int count = 0;
-  mrb_bool binary = re_binary_string_p(self);
+  mrb_bool binary = re_subject_binary(mrb, self, FALSE);
   int ai = mrb_gc_arena_save(mrb);
 
   while (search_pos <= len) {
@@ -3053,8 +3053,7 @@ str_split_m(mrb_state *mrb, mrb_value self)
       mrb_ary_push(mrb, result, tail);
       return result;
     }
-    re_check_encoding(mrb, self);
-    mrb_value md = exec_match(mrb, pattern, self, search_pos, FALSE);
+    mrb_value md = exec_match(mrb, pattern, self, search_pos, FALSE, FALSE);
     if (mrb_nil_p(md)) break;
     mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
     mrb_int ms = m->captures[0], me = m->captures[1];
@@ -3293,8 +3292,7 @@ str_byteindex_m(mrb_state *mrb, mrb_value self)
      where the C method asks it too, so an offset outside the subject stays a
      miss rather than becoming an error. */
   mrb_str_check_byte_pos(mrb, self, pos);
-  re_check_encoding(mrb, self);
-  mrb_value md = exec_match(mrb, pattern, self, pos, FALSE);
+  mrb_value md = exec_match(mrb, pattern, self, pos, FALSE, FALSE);
   if (mrb_nil_p(md)) return mrb_nil_value();
   mrb_match_data *m = DATA_GET_PTR(mrb, md, &matchdata_type, mrb_match_data);
   return mrb_int_value(mrb, m->captures[0]);

--- a/mrbgems/mruby-regexp/src/regexp.c
+++ b/mrbgems/mruby-regexp/src/regexp.c
@@ -380,7 +380,7 @@ re_binary_string_p(mrb_value str)
    the subject as UTF-8 nowhere along the way, so `"a\x80b".sub("b", "!")`
    answers there while the same call with `/b/` is refused. re_sub_lit() and
    re_gsub_lit() never ask, having no compiled pattern to ask on behalf of,
-   and the searches a literal reaches with one take a `checked` argument to
+   and the searches a literal reaches with one take a `literal` argument to
    say so.
 
    The check walks the whole subject, so every entry point below runs it on
@@ -556,7 +556,7 @@ re_search(mrb_state *mrb, mrb_value re, mrb_value str, mrb_int pos, mrb_bool lit
  *
  * The three callers work in byte space and clamp the limit into the subject
  * first, so there is no position normalization and no operand conversion
- * here. Nor is there a `checked`: none of the three has a quoted String
+ * here. Nor is there a `literal`: none of the three has a quoted String
  * pattern to reach here with, a String argument being the form each of them
  * leaves to the C method it captured.
  *
@@ -1821,7 +1821,7 @@ re_mark_spliced(mrb_value result, mrb_value subject, mrb_value replacement,
  * gsub core with a String replacement and no block.
  *
  * A compiled pattern only: a String pattern is a literal and reaches
- * re_gsub_lit() instead, which is why there is no `checked` here to say that
+ * re_gsub_lit() instead, which is why there is no `literal` here to say that
  * the subject was left unread.
  */
 static mrb_value
@@ -2162,7 +2162,7 @@ sub_piece(mrb_state *mrb, mrb_value block, mrb_value hash, mrb_value matched)
  * replacement forms, `hash` standing where the block call would be when it
  * is given.
  *
- * `checked` carries the same meaning as in re_search().
+ * `literal` carries the same meaning as in re_search().
  *
  * The loop yields from C the way CRuby's does: every match is published
  * before the block sees it, which is why a MatchData is built per turn.

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -893,6 +893,7 @@ assert("Regexp - a subject whose bytes are not UTF-8 is refused") do
   broken.sub("b", "!")
   assert_equal broken.index("b"), $~.begin(0)
   assert_raise(ArgumentError) { broken.scan("b") }
+  assert_raise(ArgumentError) { broken.scan("b") {} }
 
   # `split` is the other exception, and it takes every pattern with it: CRuby
   # refuses a String, a nil and the awk form as well as a Regexp. A String


### PR DESCRIPTION
## Summary

A search reads two things of its subject, whether it is indexed by byte and, where it is not, whether its bytes spell characters, and regexp.c asked them in two helpers from different frames. `re_subject_binary()` now answers both and is the one place a subject is read.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-regexp/src/regexp.c` | `re_subject_binary()` added; `re_check_encoding()` removed; `re_binary_string_p()` renamed `re_pattern_binary()` and kept for the compiler alone; `exec_match()` takes `unread`; `re_mark_spliced()` takes `mrb` |
| `mrbgems/mruby-regexp/test/regexp_utf8.rb` | pins that the block form of `String#scan` refuses a broken subject on a String pattern |

### The two readings were asked apart

`re_binary_string_p()` read the flag and `re_check_encoding()` walked the bytes, and the entry points called them from different frames: `Regexp#match` checked the subject and `exec_match()` read its flag, the gsub walk did both again after every block in two lines, and each of `sub` and `gsub` read the flag once more at the end to mark what it built. `re_subject_binary()` does both in one call, and `exec_match()` asks it before it looks at the pattern, which is the order every caller kept between the two checks, so the raise keeps its place: `Regexp.allocate.match("\x80")` still reports the subject, as CRuby does, and `Regexp.allocate === "\x80"` still raises TypeError before the subject is read, as it does for a sound subject.

### The flag is `unread`, not `literal`

`scan` and `split` refuse a broken subject on a String pattern as CRuby does, and hand `literal` to `exec_match()` only to keep the Regexp off the MatchData, so the two cannot share a flag. A search that leaves the subject unread says so with `unread`; the two part only in `scan`. The suite pinned `broken.scan("b")` and not the block form, which is the one that would have slipped, so a line is added.

### What stays out

The compiler reads a pattern's flag to know whether to compile it by byte, and a pattern has no check to skip (`Regexp.new("\x80")` is accepted), so that reading keeps its own name, `re_pattern_binary()`. The bytes of the subject, `RSTRING_PTR` and `RSTRING_LEN`, are not part of this.

## Size

`.text` of `bin/mruby`, `size -A`, the seven builds of `build_config/ci/gcc-clang.rb`, base `de3f37630`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,375,686 | 1,375,174 | −512 |
| `ascii-ctype` | 1,361,846 | 1,361,334 | −512 |
| `byte-string` | 1,338,694 | 1,338,054 | −640 |
| `cxx_abi` | 1,408,713 | 1,408,137 | −576 |
| `no-float` | 1,301,454 | 1,300,958 | −496 |
| `no-bigint` | 1,260,310 | 1,259,798 | −512 |
| `full-debug` (-O0) | 1,966,758 | 1,966,790 | +32 |

All of it is `regexp.o`: gcc no longer inlines `re_mark_spliced()` into its four callers once it takes `mrb`, and the callers of `exec_match()` no longer carry the check inline.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds, with clang and with gcc: KO 0, Crash 0 in each.

Forty-one calls on `"a\x80b"` (every entry point with a Regexp and with a String pattern, `split` with and without `limit`, `Regexp.allocate` against a broken and a sound subject, a gsub block that rebinds the receiver with `String#b` and one that writes a stray byte into it) print the same on master's `bin/mruby` and this branch's.

## Environment

<details>
<summary>Machine and compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic x86_64 |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| clang | Homebrew clang 23.1.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `regexp.c` as the size builds ran them, `-I` and `-o` dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-regexp/src/regexp.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-regexp/src/regexp.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved regular expression handling for text and binary data across matching, substitution, scanning, splitting, indexing, and partitioning.
  - Invalid UTF-8 subjects are now consistently rejected during regular expression searches, including block-based scanning.
  - Literal-string searches continue to operate in byte-oriented mode where appropriate.
  - Replacement results now preserve the correct encoding based on the subject being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->