### PR TITLE
mruby-regexp: implement the conditional `(?(cond)yes|no)`

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -273,6 +273,12 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   refuses `(?(1)...)` there as it refuses `\1` and `\k<1>`, and reads the
   delimited spellings `(?(<1>)...)`, `(?(<-1>)...)` and `(?('1')...)` all the
   same. Here the number is read the way `\k<1>` reads it, and refused with it.
+- **A conditional's body is its own**: `(?(1)(?:b|c))` is `yes` = `(?:b|c)`
+  with no `no`. CRuby reads it as `(?(1)b|c)`: Onigmo's non-capturing group
+  leaves no node of its own, so an alternation that fills the body is taken
+  for the conditional's two bodies, and `(?(1)(?:b|c|d))` is refused as three
+  of them. A body the group does not fill, `(?(1)(?:b|c)x)`, and a group of
+  any other kind, `(?(1)(?i:b|c))`, are read alike by both.
 - **An empty iteration ends a repeat around a call too**, which is the rule
   every inline repeat here follows. Onigmo switches such repeats to a
   capture-tracking empty check that answers a few of them differently, among

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -37,6 +37,8 @@ simulation) with backtracking fallback.
 - `(?<!...)` negative lookbehind (fixed-length, per branch)
 - `(?>...)` atomic group
 - `(?~...)` absent repeater
+- `(?(n)yes|no)`, `(?(<name>)yes|no)`, `(?('name')yes|no)` conditional: `yes`
+  where the group has matched, `no` where it has not, `no` optional
 - `(?imx-imx)` options for the rest of the enclosing group
 - `(?imx-imx:...)` options for the group's own body
 
@@ -222,8 +224,8 @@ Regexp.new("(a)(?<b>b)\\1")
 Two engines, chosen automatically at compile time by pattern analysis.
 
 - **Pike VM (NFA simulation)** for patterns without backreferences, non-greedy
-  quantifiers, lookaround, atomic groups, absent repeaters or subexpression
-  calls. O(pattern x text), so it is immune to ReDoS.
+  quantifiers, lookaround, atomic groups, absent repeaters, conditionals or
+  subexpression calls. O(pattern x text), so it is immune to ReDoS.
 - **Backtracking engine** for the rest, whose state the Pike VM's threads have
   no stack to hold. It backtracks on a stack of its own on the heap, so a
   search spends a constant amount of C stack however long the subject is.
@@ -263,8 +265,14 @@ Every entry is a place this engine answers a pattern differently from CRuby.
   and so is a bare `\g` either way.
 - **No nest level on a backreference**: `\k<name+n>` and `\k<name-n>` ask for a
   capture memory per call level where this engine keeps one flat slot per
-  group, so they raise `RegexpError`. A plain `\k<name>` still works inside a
-  recursion, reading the pair the innermost completed invocation left.
+  group, so they raise `RegexpError`, and so does a conditional whose
+  condition spells one, `(?(<name+n>)...)`. A plain `\k<name>` still works
+  inside a recursion, reading the pair the innermost completed invocation
+  left, and so does `(?(<name>)...)`.
+- **A named pattern refuses a numbered condition in every spelling**: CRuby
+  refuses `(?(1)...)` there as it refuses `\1` and `\k<1>`, and reads the
+  delimited spellings `(?(<1>)...)`, `(?(<-1>)...)` and `(?('1')...)` all the
+  same. Here the number is read the way `\k<1>` reads it, and refused with it.
 - **An empty iteration ends a repeat around a call too**, which is the rule
   every inline repeat here follows. Onigmo switches such repeats to a
   capture-tracking empty check that answers a few of them differently, among

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -58,6 +58,16 @@ enum re_opcode {
   RE_WBOUND,     /* assert word boundary (\b) */
   RE_NWBOUND,    /* assert non-word boundary (\B) */
   RE_BACKREF,    /* backreference: a = group number, offset = 1 if case-insensitive */
+  RE_COND,       /* the conditional (?(cond)yes|no): a = the group the
+                    condition names, offset = where `no` begins. Goes on at
+                    pc + 1 where the group has matched, its capture pair
+                    being closed, and at `offset` where it has not; a group
+                    still open, or one a repetition has just re-entered,
+                    has not. Nothing is pushed: the choice is the captures'
+                    and a failure after it backtracks past it as past any
+                    straight-line instruction. `yes` ends with a jump past
+                    `no`, and with no `no` the offset is the text after the
+                    group. */
   RE_LOOKAHEAD,  /* positive lookahead: offset = end of sub-pattern */
   RE_NEG_LOOKAHEAD, /* negative lookahead: offset = end of sub-pattern */
   RE_LOOKBEHIND,     /* positive lookbehind: offset = end, a = 1 once the

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1922,6 +1922,158 @@ compile_look_body(re_compiler *c, mrb_bool negative)
   return emit(c, RE_LOOK_END, negative ? RE_LOOK_NEGATED : 0, cut);
 }
 
+/* Read the group a reference names, `<name>` or `'name'` with the parse
+   point on the opening delimiter, and answer its number: a name looks up
+   the first group defined under it so far, digits are an absolute number a
+   group written later may still satisfy, `-n` counts back over the groups
+   already open, and a nest level is refused. A number that names no group
+   is caught by mrb_re_compile() once the whole pattern is read; see
+   `max_backref`. */
+static int
+parse_group_ref(re_compiler *c)
+{
+  int close = (peek(c) == '<') ? '>' : '\'';
+  next_char(c);  /* skip < or ' */
+  const char *name = c->p;
+  while (peek(c) != close && peek(c) >= 0) {
+    /* The reference reads a name the same way a definition does, and stops
+       at a ')' the same way too, from the second byte on: \k<)> reaches the
+       group (?<)>x) opened, while \k<a)b> is `invalid group name`. */
+    if (peek(c) == ')' && c->p > name) {
+      compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                      name, (size_t)(c->src_end - name)));
+    }
+    next_char(c);
+  }
+  /* The end of the pattern ends the name the way a ')' does; see the
+     definition side for the pair. */
+  if (c->p == name) compile_error(c, "group name is empty");
+  /* A pattern that ends inside the name never closed it, so what was read
+     is not a name to look up: it is quoted back as the malformed one it
+     is. This comes before the level check below because an unclosed name
+     is not a level either. */
+  if (peek(c) != close) {
+    compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                    name, (size_t)(c->p - name)));
+  }
+  uint32_t name_len = (uint32_t)(c->p - name);
+
+  /* A `+` or `-` past the first byte ends a \k name and opens a nest
+     level: `\k<name+n>` reads the group as the enclosing recursion left
+     it n levels up, which is a feature of the subexpression calls this
+     engine refuses (see `\g` below), so the reference is refused with it.
+     The first byte is exempt because that is where the relative form's
+     sign stands: `\k<-1>` is the group one back, and `\k<-1-1>` is that
+     group at a level. Reading the sign as part of the name instead let a
+     reference reach a group CRuby's own numbering puts out of reach, since
+     a definition takes the sign into the name where a reference never
+     does: `(?<a-1>x)\k<a-1>` matched here and is `undefined name <a>`
+     there. Only digits stand behind the sign, so a level CRuby itself
+     refuses is a malformed name here as it is there, `\k<a+>` and
+     `\k<a+1x>` reaching the message the rest of this arm gives one. The
+     name is quoted as it was read; CRuby quotes it to the end of the
+     pattern instead, the way it does for every name its own scan ended.
+     The whole check comes before the length one below because the sign is
+     where the name ends, so a name long enough to fail that one is a
+     level first. */
+  uint32_t sign = 1;
+  while (sign < name_len && name[sign] != '+' && name[sign] != '-') sign++;
+  if (sign < name_len) {
+    mrb_bool numeric = (sign + 1 < name_len);
+    for (uint32_t i = sign + 1; numeric && i < name_len; i++) {
+      if (name[i] < '0' || name[i] > '9') numeric = FALSE;
+    }
+    if (numeric) compile_error(c, "backreference with nest level is not supported");
+    compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                    name, (size_t)name_len));
+  }
+
+  if (!RE_NAME_LEN_FITS(name_len)) compile_error(c, "group name too long");
+  next_char(c);  /* skip the closing > or ' */
+
+  int group = -1;
+  if (name_len > 0 && (name[0] == '-' || (name[0] >= '0' && name[0] <= '9'))) {
+    mrb_bool relative = (name[0] == '-');
+    uint32_t first = relative ? 1 : 0;
+
+    /* CRuby reads the whole name before converting it, so a name that is
+       not `-`? followed by digits is a malformed name whatever the digits
+       it does hold would come to: \k<99999999999999999999x> is `invalid
+       group name`, not `too big number`. A lone `-` is malformed too. */
+    mrb_bool numeric = (first < name_len);
+    for (uint32_t i = first; numeric && i < name_len; i++) {
+      if (name[i] < '0' || name[i] > '9') numeric = FALSE;
+    }
+
+    int n = 0;
+    for (uint32_t i = first; numeric && i < name_len; i++) {
+      int digit = name[i] - '0';
+      /* CRuby's scanner stops at RE_MAX_BACKREF_NUM, and a number past it
+         is too big rather than a reference to a group that is missing. */
+      if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
+      n = n * 10 + digit;
+    }
+    /* n == 0 names group 0, the whole match, which \k cannot reference */
+    if (!numeric || n == 0) {
+      compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                      name, (size_t)name_len));
+    }
+
+    if (relative) {
+      /* `\k<-n>` counts back from where it stands, so the groups it can
+         name are the ones already open; Onigmo resolves it the same way
+         (BACKREF_REL_TO_ABS) and refuses a relative forward reference.
+         The count is `num_groups` rather than `num_captures` because the
+         groups a named pattern demotes still count here, as they do
+         everywhere else the parse numbers a group; where nothing is
+         demoted the two agree, `num_groups` standing one below
+         `num_captures`, which counts group 0. The resolution comes before
+         the refusal below because CRuby reaches that refusal only once
+         the reference has resolved to a group the pattern has:
+         `(?<n>a)\k<-1>` is refused for being numbered, `(?<n>a)\k<-2>`
+         is out of range instead. */
+      group = (int)c->num_groups + 1 - n;
+      if (group < 1) compile_error(c, "invalid backref number/name");
+    }
+
+    /* CRuby rejects a numbered backreference in a named pattern whatever
+       its spelling, and it has to be rejected here too: once plain groups
+       stop consuming numbers, the check after the parse, which counts the
+       demoted groups, would silently accept a number naming a group that
+       no longer carries it. */
+    if (c->dont_capture) {
+      compile_error(c, "numbered backref/call is not allowed. (use name)");
+    }
+
+    if (!relative) {
+      /* The absolute form may name a group written later, `\k<1>(a)`
+         being as valid in CRuby as `\1(a)` is, so the number is only
+         recorded here and mrb_re_compile() checks it against the
+         pattern's group count once the parse is done. A number above
+         RE_MAX_CAPTURES names no group whatever the pattern goes on to
+         open, and is kept at that bound so the check still refuses it
+         while the number stays one a group field can hold. */
+      if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
+      if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
+      group = n;
+    }
+  }
+  else {
+    for (uint16_t i = 0; i < c->num_named; i++) {
+      if (c->pat->named_captures[i].name_len == name_len &&
+          memcmp(c->pat->named_captures[i].name, name, name_len) == 0) {
+        group = c->pat->named_captures[i].group;
+        break;
+      }
+    }
+    if (group < 1) {
+      compile_error_str(c, mrb_format(c->mrb, "undefined name <%l> reference",
+                                      name, (size_t)name_len));
+    }
+  }
+  return group;
+}
+
 /* Compile a single atom (character, class, group, etc.). Returns whether one
    was read: FALSE when what stands at the parse point is not an atom, either a
    quantifier metacharacter or the end of the sequence, neither of them
@@ -2316,145 +2468,7 @@ compile_atom(re_compiler *c)
          \k<2> (absolute) and \k<-1> (relative to the groups seen so far) are
          also accepted, like the \g/\k family in Onigmo. */
       next_char(c);  /* skip k */
-      int close = (peek(c) == '<') ? '>' : '\'';
-      next_char(c);  /* skip < or ' */
-      const char *name = c->p;
-      while (peek(c) != close && peek(c) >= 0) {
-        /* The reference reads a name the same way a definition does, and stops
-           at a ')' the same way too, from the second byte on: \k<)> reaches the
-           group (?<)>x) opened, while \k<a)b> is `invalid group name`. */
-        if (peek(c) == ')' && c->p > name) {
-          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                          name, (size_t)(c->src_end - name)));
-        }
-        next_char(c);
-      }
-      /* The end of the pattern ends the name the way a ')' does; see the
-         definition side for the pair. */
-      if (c->p == name) compile_error(c, "group name is empty");
-      /* A pattern that ends inside the name never closed it, so what was read
-         is not a name to look up: it is quoted back as the malformed one it
-         is. This comes before the level check below because an unclosed name
-         is not a level either. */
-      if (peek(c) != close) {
-        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                        name, (size_t)(c->p - name)));
-      }
-      uint32_t name_len = (uint32_t)(c->p - name);
-
-      /* A `+` or `-` past the first byte ends a \k name and opens a nest
-         level: `\k<name+n>` reads the group as the enclosing recursion left
-         it n levels up, which is a feature of the subexpression calls this
-         engine refuses (see `\g` below), so the reference is refused with it.
-         The first byte is exempt because that is where the relative form's
-         sign stands: `\k<-1>` is the group one back, and `\k<-1-1>` is that
-         group at a level. Reading the sign as part of the name instead let a
-         reference reach a group CRuby's own numbering puts out of reach, since
-         a definition takes the sign into the name where a reference never
-         does: `(?<a-1>x)\k<a-1>` matched here and is `undefined name <a>`
-         there. Only digits stand behind the sign, so a level CRuby itself
-         refuses is a malformed name here as it is there, `\k<a+>` and
-         `\k<a+1x>` reaching the message the rest of this arm gives one. The
-         name is quoted as it was read; CRuby quotes it to the end of the
-         pattern instead, the way it does for every name its own scan ended.
-         The whole check comes before the length one below because the sign is
-         where the name ends, so a name long enough to fail that one is a
-         level first. */
-      uint32_t sign = 1;
-      while (sign < name_len && name[sign] != '+' && name[sign] != '-') sign++;
-      if (sign < name_len) {
-        mrb_bool numeric = (sign + 1 < name_len);
-        for (uint32_t i = sign + 1; numeric && i < name_len; i++) {
-          if (name[i] < '0' || name[i] > '9') numeric = FALSE;
-        }
-        if (numeric) compile_error(c, "backreference with nest level is not supported");
-        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                        name, (size_t)name_len));
-      }
-
-      if (!RE_NAME_LEN_FITS(name_len)) compile_error(c, "group name too long");
-      next_char(c);  /* skip the closing > or ' */
-
-      int group = -1;
-      if (name_len > 0 && (name[0] == '-' || (name[0] >= '0' && name[0] <= '9'))) {
-        mrb_bool relative = (name[0] == '-');
-        uint32_t first = relative ? 1 : 0;
-
-        /* CRuby reads the whole name before converting it, so a name that is
-           not `-`? followed by digits is a malformed name whatever the digits
-           it does hold would come to: \k<99999999999999999999x> is `invalid
-           group name`, not `too big number`. A lone `-` is malformed too. */
-        mrb_bool numeric = (first < name_len);
-        for (uint32_t i = first; numeric && i < name_len; i++) {
-          if (name[i] < '0' || name[i] > '9') numeric = FALSE;
-        }
-
-        int n = 0;
-        for (uint32_t i = first; numeric && i < name_len; i++) {
-          int digit = name[i] - '0';
-          /* CRuby's scanner stops at RE_MAX_BACKREF_NUM, and a number past it
-             is too big rather than a reference to a group that is missing. */
-          if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
-          n = n * 10 + digit;
-        }
-        /* n == 0 names group 0, the whole match, which \k cannot reference */
-        if (!numeric || n == 0) {
-          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                          name, (size_t)name_len));
-        }
-
-        if (relative) {
-          /* `\k<-n>` counts back from where it stands, so the groups it can
-             name are the ones already open; Onigmo resolves it the same way
-             (BACKREF_REL_TO_ABS) and refuses a relative forward reference.
-             The count is `num_groups` rather than `num_captures` because the
-             groups a named pattern demotes still count here, as they do
-             everywhere else the parse numbers a group; where nothing is
-             demoted the two agree, `num_groups` standing one below
-             `num_captures`, which counts group 0. The resolution comes before
-             the refusal below because CRuby reaches that refusal only once
-             the reference has resolved to a group the pattern has:
-             `(?<n>a)\k<-1>` is refused for being numbered, `(?<n>a)\k<-2>`
-             is out of range instead. */
-          group = (int)c->num_groups + 1 - n;
-          if (group < 1) compile_error(c, "invalid backref number/name");
-        }
-
-        /* CRuby rejects a numbered backreference in a named pattern whatever
-           its spelling, and it has to be rejected here too: once plain groups
-           stop consuming numbers, the check after the parse, which counts the
-           demoted groups, would silently accept a number naming a group that
-           no longer carries it. */
-        if (c->dont_capture) {
-          compile_error(c, "numbered backref/call is not allowed. (use name)");
-        }
-
-        if (!relative) {
-          /* The absolute form may name a group written later, `\k<1>(a)`
-             being as valid in CRuby as `\1(a)` is, so the number is only
-             recorded here and mrb_re_compile() checks it against the
-             pattern's group count once the parse is done. A number above
-             RE_MAX_CAPTURES names no group whatever the pattern goes on to
-             open, and is kept at that bound so the check still refuses it
-             while the number stays one a group field can hold. */
-          if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
-          if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
-          group = n;
-        }
-      }
-      else {
-        for (uint16_t i = 0; i < c->num_named; i++) {
-          if (c->pat->named_captures[i].name_len == name_len &&
-              memcmp(c->pat->named_captures[i].name, name, name_len) == 0) {
-            group = c->pat->named_captures[i].group;
-            break;
-          }
-        }
-        if (group < 1) {
-          compile_error_str(c, mrb_format(c->mrb, "undefined name <%l> reference",
-                                          name, (size_t)name_len));
-        }
-      }
+      int group = parse_group_ref(c);
       emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
       c->has_backref = TRUE;
     }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -109,6 +109,7 @@ typedef struct {
 } re_compiler;
 
 static void compile_alt(re_compiler *c);  /* forward */
+static void compile_seq(re_compiler *c);  /* forward */
 
 /* Take the message as a String rather than as a C string, for the messages
    that quote a group name: the name is a length-counted slice of the pattern
@@ -192,7 +193,7 @@ op_holds_code_index(uint8_t op)
   case RE_JMP: case RE_SPLIT: case RE_SPLITNG:
   case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
   case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
-  case RE_ABSENT:
+  case RE_ABSENT: case RE_COND:
     return TRUE;
   default:
     return FALSE;
@@ -1923,8 +1924,10 @@ compile_look_body(re_compiler *c, mrb_bool negative)
 }
 
 /* Read the group a reference names, `<name>` or `'name'` with the parse
-   point on the opening delimiter, and answer its number: a name looks up
-   the first group defined under it so far, digits are an absolute number a
+   point on the opening delimiter, and answer its number. This is what
+   `\k` reads after its letter and what a conditional reads inside its
+   parentheses, and the two agree on every spelling: a name looks up the
+   first group defined under it so far, digits are an absolute number a
    group written later may still satisfy, `-n` counts back over the groups
    already open, and a nest level is refused. A number that names no group
    is caught by mrb_re_compile() once the whole pattern is read; see
@@ -2301,6 +2304,115 @@ compile_atom(re_compiler *c)
             compile_error(c, "undefined group option");
           }
         }
+        else if (c->p[1] == '(') {
+          /* The conditional (?(cond)yes|no): `yes` where the group `cond`
+             names has matched, `no` where it has not, and `no` is empty
+             where it is left out. The condition is a group reference in the
+             spellings a backreference takes, `(1)`, `(<name>)` and
+             `('name')`, and a group has matched when its capture pair is
+             closed: one still open, the conditional standing inside it, has
+             not, and neither has one a repetition has just re-entered (see
+             RE_SAVE in bt_match()). That is Onigmo's reading too.
+
+             The number form is read here rather than by parse_group_ref():
+             the digits run to the ')' with no delimiter of their own, and
+             CRuby refuses the sign that gives the relative forms, so what is
+             read is digits or a malformed name. Every check the absolute
+             form makes there is made here in the same order, the count
+             check coming after the parse as it does for `\1(a)`, so
+             `(?(1)b|c)(a)` is as valid as that is. A named pattern refuses
+             the number as it refuses `\1`.
+
+             Two branches at most: a third `|` is `invalid conditional
+             pattern`, as in CRuby, so the bodies are read one sequence at a
+             time rather than through compile_alt(), which would take every
+             `|`. The bodies nest a level as a group's would, and the
+             count is kept the way compile_alt() keeps it.
+
+             One instruction carries the test and the layout is a fork's
+             with the choice made by the captures instead of pushed: RE_COND
+             goes on at pc + 1 where the group has matched and at `offset`
+             where it has not, `yes` ends with a jump past `no`, and with no
+             `no` the head's offset is the text after the group. */
+          next_char(c); next_char(c);  /* skip ?( */
+          int group = 0;
+          int cond = peek(c);
+          if (cond < 0) {
+            /* `(?(` and nothing more: CRuby answers for the prefix, not for
+               the condition it never began. */
+            compile_error(c, "undefined group option");
+          }
+          if (cond == '<' || cond == '\'') {
+            group = parse_group_ref(c);
+            /* A name closed by its delimiter and then something other than
+               the ')': CRuby's answer is the prefix's, as above. */
+            if (peek(c) != ')') compile_error(c, "undefined group option");
+          }
+          else if (cond >= '0' && cond <= '9') {
+            const char *digits = c->p;
+            while (peek(c) != ')' && peek(c) >= 0) next_char(c);
+            uint32_t dlen = (uint32_t)(c->p - digits);
+            mrb_bool numeric = TRUE;
+            for (uint32_t i = 0; numeric && i < dlen; i++) {
+              if (digits[i] < '0' || digits[i] > '9') numeric = FALSE;
+            }
+            /* A condition the pattern ends inside is quoted back the way a
+               name the pattern ends inside is, and so is one that is not
+               all digits, as in parse_group_ref(). */
+            if (!numeric || peek(c) < 0) {
+              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                              digits, (size_t)dlen));
+            }
+            int n = 0;
+            for (uint32_t i = 0; i < dlen; i++) {
+              int digit = digits[i] - '0';
+              if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
+              n = n * 10 + digit;
+            }
+            /* Group 0 is the whole match, which is never closed while the
+               pattern runs, and CRuby refuses it as it refuses `\k<0>`. */
+            if (n == 0) {
+              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                              digits, (size_t)dlen));
+            }
+            if (c->dont_capture) {
+              compile_error(c, "numbered backref/call is not allowed. (use name)");
+            }
+            if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
+            if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
+            group = n;
+          }
+          else {
+            /* Anything else in the condition's place, a bare name, a signed
+               number, nothing at all: CRuby refuses the condition rather
+               than reading it as a name. */
+            compile_error(c, "invalid conditional pattern");
+          }
+          next_char(c);  /* skip the ')' closing the condition */
+
+          uint32_t head = emit(c, RE_COND, (uint8_t)group, 0);
+          if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
+            compile_error(c, "parse depth limit over");
+          }
+          compile_seq(c);
+          if (peek(c) == '|') {
+            next_char(c);
+            uint32_t skip = emit(c, RE_JMP, 0, 0);
+            c->pat->code[head].offset = (uint16_t)c->code_len;
+            compile_seq(c);
+            if (peek(c) == '|') compile_error(c, "invalid conditional pattern");
+            c->pat->code[skip].offset = (uint16_t)c->code_len;
+          }
+          else {
+            c->pat->code[head].offset = (uint16_t)c->code_len;
+          }
+          c->depth--;
+          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+          next_char(c);
+          c->needs_backtrack = TRUE;  /* the Pike VM's threads carry no test of their captures */
+          c->flags = saved_flags;
+          break;
+        }
         else if (c->p[1] == '#') {
           /* preprocess_pattern() removes a terminated comment group before
              the parser runs, so one reaching here was never closed, which
@@ -2309,12 +2421,11 @@ compile_atom(re_compiler *c)
         }
         else {
           /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?'name' (?> (?~ (?imx forms. Comment groups
-             (?#...) never get here either, having been removed by
-             preprocess_pattern(). Conditionals (?(...)) are not implemented.
-             Raise here rather than falling through to the capturing-group
-             path, which would leave the stray `?` for compile_seq to spin on
-             forever (A1). */
+             (?<= (?<! (?<name> (?'name' (?> (?~ (?( (?imx forms. Comment
+             groups (?#...) never get here either, having been removed by
+             preprocess_pattern(). Raise here rather than falling through to
+             the capturing-group path, which would leave the stray `?` for
+             compile_seq to spin on forever (A1). */
           if (c->p[1] == '<') {
             /* `(?<` and nothing more, the only way a '<' reaches here: the
                pattern ends before the character that tells a lookbehind
@@ -3465,6 +3576,7 @@ first_set_walk(const re_inst *code, uint32_t code_len,
       pc = code[pc].offset;
       continue;
     case RE_SPLIT:
+    case RE_COND:  /* either body may run first; the walk cannot know which */
       /* both branches: pc+1 and offset */
       if (!first_set_walk(code, code_len, classes, code[pc].offset, bm, seen))
         return FALSE;
@@ -3547,7 +3659,8 @@ anchor_walk(const re_inst *code, uint32_t code_len, uint32_t pc, uint8_t *seen)
       pc = code[pc].offset;
       continue;
     case RE_SPLIT:
-    case RE_SPLITNG: {
+    case RE_SPLITNG:
+    case RE_COND: {  /* a fork to this walk: both bodies are paths */
       uint8_t other = anchor_walk(code, code_len, code[pc].offset, seen);
       if (other == RE_ANCHOR_NONE) return RE_ANCHOR_NONE;
       uint8_t mine = anchor_walk(code, code_len, pc + 1, seen);
@@ -3605,6 +3718,7 @@ epsilon_path(const re_inst *code, uint32_t code_len, uint32_t pc, uint32_t goal,
       break;
     case RE_SPLIT:
     case RE_SPLITNG:
+    case RE_COND:  /* either body may be the one that runs */
       if (epsilon_path(code, code_len, code[pc].offset, goal, seen, mark)) return TRUE;
       pc++;
       break;
@@ -3761,6 +3875,7 @@ call_walk(const re_inst *code, uint32_t code_len, uint32_t start,
         pc = in.offset;
         continue;
       case RE_SPLIT: case RE_SPLITNG:
+      case RE_COND:  /* a fork to this walk: both bodies are paths */
         stack[top++] = in.offset;
         pc++;
         continue;

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -1431,6 +1431,27 @@ bt_match(bt_state *m, const char *sp, uint32_t pc)
       }
       break;
 
+    case RE_COND:
+      {
+        /* The group has matched when its pair is closed, which is the test
+           RE_BACKREF makes before it reads one: an open group holds a start
+           and no end (see RE_SAVE), and a group nothing has entered holds
+           neither. No choice point: which body runs is settled by the
+           captures as they stand, and a failure inside the body backtracks
+           past this instruction to whatever was pushed before it, which is
+           what may change the captures and bring the search back here with
+           the other answer. */
+        int group = inst.a;
+        if (group * 2 + 1 < ncap &&
+            captures[group * 2] >= 0 && captures[group * 2 + 1] >= 0) {
+          pc++;
+        }
+        else {
+          pc = inst.offset;
+        }
+      }
+      break;
+
     case RE_LOOKAHEAD:
     case RE_NEG_LOOKAHEAD:
     case RE_LOOKBEHIND:

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -1010,9 +1010,10 @@ assert("Regexp - patterns that used to hang the compiler now raise (A1)") do
   # Regexp.new is used so the pattern reaches the regexp compiler directly,
   # bypassing the literal validation the parser performs on /.../ literals.
 
-  # (?X) with an unsupported X: conditionals (?(...)) are not implemented
-  # (inline options (?i)/(?i:...) and the absent repeater (?~...) now are).
-  assert_raise(RegexpError) { Regexp.new("(?(<x>)a|b)") }
+  # A `(?` prefix the pattern ends inside. (?X) with an X that names no
+  # group option is refused the same way; every X CRuby reads is now read
+  # here too, inline options, the absent repeater and conditionals among
+  # them.
   assert_raise(RegexpError) { Regexp.new("(?") }
   assert_raise(RegexpError) { Regexp.new("(?<") }
 
@@ -1768,6 +1769,134 @@ assert("Regexp - an absent repeater the parser refuses") do
   assert_raise(RegexpError) { Regexp.new("(?~") }
   # not a fixed-length construct, so not allowed in a lookbehind
   assert_raise(RegexpError) { Regexp.new("(?<=(?~a))b") }
+end
+
+assert("Regexp - conditional (?(cond)yes|no)") do
+  need_backtracking_stack
+  # `yes` runs where the group the condition names has matched and `no`
+  # where it has not, and the choice is made afresh each time the search
+  # comes back through it: with the `a` taken the pattern asks for `b`,
+  # and once the search gives the `a` back it asks for `c`.
+  assert_equal 0, /(a)?(?(1)b|c)/ =~ "ab"
+  assert_equal 0, /(a)?(?(1)b|c)/ =~ "c"
+  assert_equal 1, /(a)?(?(1)b|c)/ =~ "ac"
+  assert_nil /(a)?(?(1)b|c)/ =~ "b"
+  assert_equal ["a"], /(a)?(?(1)b|c)/.match("ab").captures
+  assert_equal [nil], /(a)?(?(1)b|c)/.match("ac").captures
+  # A body left out is empty: with no `no` an unmatched group asks for
+  # nothing, and `(?(1)|c)` asks for nothing where the group matched.
+  assert_equal "", /(a)?(?(1)b)/.match("b")[0]
+  assert_equal "ab", /(a)?(?(1)b)/.match("ab")[0]
+  assert_equal "a", /(a)?(?(1)|c)/.match("ab")[0]
+  assert_equal "c", /(a)?(?(1)|c)/.match("c")[0]
+  assert_equal "a", /(a)?(?(1))/.match("a")[0]
+
+  # The condition names a group in the spellings a backreference takes.
+  assert_equal "ab", /(?<x>a)?(?(<x>)b|c)/.match("ab")[0]
+  assert_equal "c", /(?<x>a)?(?('x')b|c)/.match("c")[0]
+  assert_equal "ab", /(a)?(?(<1>)b|c)/.match("ab")[0]
+  assert_equal "ab", /(a)?(?(<-1>)b|c)/.match("ab")[0]
+  assert_equal "ab", /(a)?(?(01)b|c)/.match("ab")[0]
+  # Two groups under one name: the condition reads the first, as \k does.
+  assert_nil /(?<x>a)?(?<x>b)(?(<x>)c|d)/ =~ "bc"
+  assert_equal "bd", /(?<x>a)?(?<x>b)(?(<x>)c|d)/.match("bd")[0]
+  # The number may name a group written later, as `\1(a)` may; that group
+  # has not matched by the time the condition is asked.
+  assert_nil /(?(1)b|c)(a)/ =~ "ba"
+  assert_equal "ca", /(?(1)b|c)(a)/.match("ca")[0]
+
+  # A group has matched once its pair is closed. Inside itself it has
+  # not, and a repetition that took the group in an earlier iteration
+  # still holds it, so `(?:(x)|y)+` against "xyd" is asked for `c` at the
+  # start and finds its match at the `y`, where the group is untouched.
+  assert_nil /(a(?(1)b|c))/ =~ "ab"
+  assert_equal "ac", /(a(?(1)b|c))/.match("ac")[0]
+  assert_equal "yxc", /(?:(x)|y)+(?(1)c|d)/.match("yxc")[0]
+  assert_equal "yd", /(?:(x)|y)+(?(1)c|d)/.match("xyd")[0]
+  assert_equal 1, /(?:(x)|y)+(?(1)c|d)/ =~ "xyd"
+  # A called group is open while the call runs, as it is for \k.
+  assert_equal "xzxz", /(?<r>x(?(<r>)y|z))\g<r>/.match("xzxz")[0]
+  assert_nil /(?<r>x(?(<r>)y|z))\g<r>/ =~ "xzxy"
+
+  # Quantified, it repeats as any atom does, and either body may be a
+  # sequence holding anything a sequence may, a conditional included.
+  assert_equal "abb", /(a)?(?(1)b|c)*/.match("abb")[0]
+  assert_equal "ccc", /(a)?(?(1)b|c)+/.match("ccc")[0]
+  assert_equal "abb", /(a)?(?(1)b|c){2}/.match("abb")[0]
+  assert_equal "a", /(a)?(?(1)b|c)??/.match("ab")[0]
+  assert_equal "abbx", /(a)?(?(1)b|c)*+x/.match("abbx")[0]
+  assert_equal "ac", /(a)?(?(1)(b|c)|d)/.match("ac")[0]
+  # A group that fills the body is the body, `yes` here with no `no`.
+  # CRuby reads `(?(1)(?:b|c))` as `(?(1)b|c)`, Onigmo's non-capturing group
+  # leaving no node of its own; see README.
+  assert_equal "ac", /(a)?(?(1)(?:b|c))/.match("ac")[0]
+  assert_equal "", /(a)?(?(1)(?:b|c))/.match("c")[0]
+  assert_equal "ad", /(a)?(?(1)(?:b|c|d))/.match("ad")[0]
+  assert_equal "ax", /(a)?(b)?(?(1)(?(2)w|x)|(?(2)y|z))/.match("ax")[0]
+  assert_equal "z", /(a)?(b)?(?(1)(?(2)w|x)|(?(2)y|z))/.match("z")[0]
+  assert_equal "abb", /(a)?(?(1)(b)|c)\2/.match("abb")[0]
+  assert_equal "a", /(a)?(?=(?(1)b|c))/.match("ab")[0]
+  assert_equal "ab", /(a)?(?>(?(1)b|c))/.match("ab")[0]
+
+  # It reads back through to_s, and free-spacing applies to the bodies.
+  assert_equal "ab", Regexp.new(/(a)?(?(1)b|c)/.to_s).match("ab")[0]
+  assert_equal "ab", Regexp.new("(a)? (?(1) b | c )", Regexp::EXTENDED).match("ab")[0]
+  # /i folds the bodies, as it folds anything else.
+  assert_equal "aB", Regexp.new("(a)?(?(1)b|c)", Regexp::IGNORECASE).match("aB")[0]
+end
+
+assert("Regexp - a conditional the parser refuses") do
+  # The condition is a group number, or a name in its delimiters. Anything
+  # else standing there is `invalid conditional pattern`, the signed forms
+  # among them since their sign has no delimiter to stand in, and so is a
+  # third body.
+  ["(a)?(?(x)b|c)", "(a)?(?(-1)b|c)", "(a)?(?(+1)b|c)", "(a)?(?()b|c)",
+   "(a)?(?( 1)b|c)", "(a)?(?(1)b|c|d)", "(a)?(?(1)b||c)",
+   "(a)?(?(1)b|c|)"].each do |src|
+    assert_raise_with_message(RegexpError,
+                              "invalid conditional pattern: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+  # Free-spacing reaches the bodies and not the condition.
+  assert_raise_with_message(RegexpError,
+                            "invalid conditional pattern: /(a)?(?( 1 )b|c)/x") do
+    Regexp.new("(a)?(?( 1 )b|c)", Regexp::EXTENDED)
+  end
+
+  # A number is checked against the groups the whole pattern has, as a
+  # backreference's is; group 0 is never closed while the pattern runs.
+  { "(a)?(?(2)b|c)" => "invalid backref number/name",
+    "(?(1)b|c)" => "invalid backref number/name",
+    "(a)?(?(<-2>)b|c)" => "invalid backref number/name",
+    "(a)?(?(0)b|c)" => "invalid group name <0>",
+    "(a)?(?(00)b|c)" => "invalid group name <00>",
+    "(a)?(?(999999999999)b|c)" => "too big number",
+    "(a)?(?(<y>)b|c)" => "undefined name <y> reference",
+    "(?(<n>)b|c)(?<n>x)" => "undefined name <n> reference",
+    "(?<x>a)?(?(1)b|c)" => "numbered backref/call is not allowed. (use name)",
+    "(?<x>a)?(?(<x-1>)b|c)" => "backreference with nest level is not supported",
+    "(?(<>)b|c)" => "group name is empty",
+    "(a)?(?(1" => "invalid group name <1>",
+    "(a)?(?(1x)b|c)" => "invalid group name <1x>",
+    "(a)?(?(<x)b|c)" => "invalid group name <x)b|c)>",
+    "(a)?(?(1)" => "end pattern with unmatched parenthesis",
+    "(a)?(?(1)b|c" => "end pattern with unmatched parenthesis",
+    "(?(" => "undefined group option",
+    "(?<x>a)?(?(<x>b|c)" => "undefined group option" }.each do |src, msg|
+    assert_raise_with_message(RegexpError, "#{msg}: /#{src}/", src) do
+      Regexp.new(src)
+    end
+  end
+  # A named pattern refuses the numbered spellings in their delimiters too,
+  # where CRuby reads them; see README.
+  assert_raise(RegexpError) { Regexp.new("(?<x>a)?(?(<1>)b|c)") }
+  assert_raise(RegexpError) { Regexp.new("(?<x>a)?(?(<-1>)b|c)") }
+  # not a fixed-length construct, so not allowed in a lookbehind
+  assert_raise_with_message(RegexpError,
+                            "invalid pattern in look-behind: /(a)?(?<=(?(1)b|c))x/") do
+    Regexp.new("(a)?(?<=(?(1)b|c))x")
+  end
 end
 
 assert("Regexp - a lookbehind body of no fixed width says which it was") do


### PR DESCRIPTION
## Summary

The conditional `(?(cond)yes|no)` was refused at parse, so `"ab" =~ /(a)?(?(1)b|c)/`
raised `RegexpError` where CRuby answers `0`. It was the last `(?...)` form
CRuby reads that this engine did not.

## Changes

| File | What |
|---|---|
| `include/re_internal.h` | add `RE_COND` |
| `src/re_compile.c` | move the `\k` reference reader into `parse_group_ref()`; read `(?(cond)yes\|no)` in `compile_atom()`; teach `op_holds_code_index()`, `first_set_walk()`, `anchor_walk()`, `epsilon_path()` and `call_walk()` the opcode |
| `src/re_exec.c` | take the branch in `bt_match()` |
| `test/regexp_syntax.rb` | tests for the construct and for what the parser refuses |
| `README.md` | syntax list, engine note, three limitation entries |

### One instruction, no choice point

`RE_COND` goes on at the next instruction where the group its condition names
has matched and at its offset where it has not, so the layout is a fork's with
the choice made by the captures rather than pushed: `yes` ends with a jump past
`no`, and with no `no` the offset is the text after the group. A group has
matched when its capture pair is closed, which is the test `RE_BACKREF` already
makes before it reads one. That is Onigmo's reading too: a group the
conditional stands inside has not matched, and neither has one a repetition has
just re-entered.

Nothing is pushed for the choice. A failure inside a body backtracks past the
conditional to whatever was pushed before it, which is what may change the
captures and bring the search back with the other answer:

```ruby
"ac" =~ /(a)?(?(1)b|c)/   # 1: with the `a` taken the pattern asks for `b`,
                          #    and once the search gives it back, for `c`
```

The Pike VM does not run it. Its threads carry captures but no test of them,
so the pattern goes to the backtracking engine, as one with a backreference
does.

### The condition is read as a backreference is

`(?(<name>)...)` and `(?('name')...)` take every spelling `\k` takes: a name
looks up the first group defined under it so far, digits are an absolute
number, `-n` counts back over the groups already open. The reader `\k` used
inline moves into `parse_group_ref()` and both call it, which is the first
commit. The bare number `(?(1)...)` has no delimiter of its own and CRuby
refuses a sign there, so it is read in the arm with the same checks in the
same order, the count check coming once the whole pattern is read: `(?(1)b|c)(a)`
is as valid as `\1(a)`.

More than two bodies is `invalid conditional pattern`, as in CRuby, which is
why the bodies are read one sequence at a time rather than as an alternation.
A lookbehind refuses the construct, as CRuby does.

## Behaviour

```ruby
"ab" =~ /(a)?(?(1)b|c)/                 # was RegexpError, now 0
"c" =~ /(a)?(?(1)b|c)/                  # 0
"b" =~ /(a)?(?(1)b|c)/                  # nil
/(a)?(?(1)b)/.match("b")[0]             # "": no `no` asks for nothing
/(?<x>a)?(?(<x>)b|c)/.match("ab")[0]    # "ab"
/(a(?(1)b|c))/ =~ "ab"                  # nil: inside itself the group is open
/(?<r>x(?(<r>)y|z))\g<r>/ =~ "xzxz"     # 0: and so is a called group
```

Three readings differ from CRuby, and `README.md` records each under
Limitations:

- A named pattern refuses a numbered condition in every spelling. CRuby refuses
  `(?(1)...)` there as it refuses `\1` and `\k<1>`, and reads `(?(<1>)...)`,
  `(?(<-1>)...)` and `(?('1')...)` all the same. Here the number is read the way
  `\k<1>` reads it, and refused with it.
- A conditional's body is its own: `(?(1)(?:b|c))` is `yes` = `(?:b|c)` with no
  `no`. CRuby reads it as `(?(1)b|c)`, Onigmo's non-capturing group leaving no
  node of its own, so an alternation that fills the body is taken for the two
  bodies and `(?(1)(?:b|c|d))` is refused as three of them.
- A nest level in the condition, `(?(<name+n>)...)`, is refused as it is on
  `\k`.

## Speed

Nothing existing changes path. The four cases of #7464, one per shape that
picks the backtracking engine plus one that stays on the Pike VM:

```ruby
s = "abcabc" * 500
1000.times { s =~ /(abc)\1/ }

s = "xxxxabxxxx" * 200
1000.times { s =~ /(?=ab)ab/ }

s = "aaab" * 300
1000.times { s =~ /(?>a+)b/ }

s = "the quick brown fox " * 200
1000.times { s =~ /qu[a-z]+k/ }
```

Callgrind Ir for the whole run, x86-64 gcc 13.3.0 -O3 (`bintest`). Wall clock
is not the measure here: the differences are hundredths of a percent, which
this machine's clock does not resolve.

| Case | master | this PR | delta |
|---|---:|---:|---:|
| `/(abc)\1/` over 3 KB | 19,814,861 | 19,811,791 | -0.015% |
| `/(?=ab)ab/` over 2 KB | 18,564,230 | 18,564,230 | 0 |
| `/(?>a+)b/` over 1.2 KB | 19,636,843 | 19,632,843 | -0.020% |
| `/qu[a-z]+k/` over 4 KB | 24,266,155 | 24,264,155 | -0.008% |

Two controls that touch no regexp are bit-identical between the two builds.
The readings below zero are on the compile path, where a literal is compiled
on every evaluation and the switches this adds a case to are laid out anew:
2 to 4 Ir per compile.

What the construct itself costs, same build, `"ab" * 300` matched 1,000 times:

| Case | Ir |
|---|---:|
| `/(?:(a)?(?(1)b\|c))+/` | 159,559,766 |
| `/(?:ab\|c)+/` | 361,120,899 |

The alternation stays on the Pike VM, which advances every thread at every
character; the conditional sends the pattern to the backtracking engine, which
walks this subject once. The conditional's choice itself is one branch per
iteration.

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0, base `6955f2afb`:

| Build | master | this PR | delta |
|---|---:|---:|---:|
| `bintest` | 1,378,102 | 1,379,142 | +1,040 |
| `ascii-ctype` | 1,364,390 | 1,365,366 | +976 |
| `byte-string` | 1,341,382 | 1,342,470 | +1,088 |
| `cxx_abi` | 1,410,953 | 1,412,041 | +1,088 |
| `no-float` | 1,303,870 | 1,304,910 | +1,040 |
| `no-bigint` | 1,262,726 | 1,263,766 | +1,040 |
| `full-debug` (-O0) | 1,968,710 | 1,970,118 | +1,408 |

All of it is the gem: in `bintest`, `re_compile.o` `.text` is +1,008 for the
parse arm, the reader now standing as a function of its own, and the four
analysis walks; `re_exec.o` is +32 for the case in the backtracking loop;
`regexp.o` is unchanged.

## Testing

- `rake -m test` with `build_config/ci/gcc-clang.rb`: 8 runs, KO 0, Crash 0,
  Warning 0.
- `build_config/clang-asan.rb`: KO 0, Crash 0, and no sanitizer report over the
  corpus below, whose answers are bit-identical to the gcc build's.
- `mrbgems/mruby-regexp/tools/difftest/compare.rb`: 5,175 patterns, 93 known
  differences, no new ones.
- A corpus of 35,280 patterns, 12 group-defining prefixes by 6 condition
  spellings by 14 body pairs by 3 forms by 7 suffixes under `//` and `/i`, each
  against 25 subjects, compared against CRuby 4.0.6: 530,250 pattern and subject
  pairs and 14,070 refusals. Every difference is one of the three readings
  above: 2,016 patterns are the numbered condition in a named pattern, refused
  here and read there, and 486 are `(?(cond)(?:x|y))`, one body here and two
  there.
- 207 hand-written pairs covering the spellings, the refusals and their
  messages, `/x`, `/i`, quantifiers, nesting, recursion and lookaround, the same
  way.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-30-generic |
| CPU | AMD Ryzen 9 5950X |
| C compiler | gcc 13.3.0 |
| binutils | GNU Binutils 2.47.20260726 |
| valgrind | valgrind-3.27.1 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines, one per build of `build_config/ci/gcc-clang.rb`, with `-MMD -c`,
`-I` and `-o` dropped:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRB_NO_FLOAT -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/witty-rolling-pebble=." -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for conditional regular-expression patterns, including numbered and named capture conditions.
  - Conditional branches now select different matching paths based on whether the referenced capture group matched.

- **Documentation**
  - Updated pattern syntax documentation with conditional-expression formats and engine support.
  - Documented current limitations for named and numbered conditional references.

- **Tests**
  - Added coverage for conditional matching, nesting, quantifiers, lookarounds, formatting options, and invalid syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->