### PR TITLE
build: let a port hand headers to the gem it serves, and let mruby-dir use them

### DIFF
--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -417,7 +417,9 @@ int mrb_hal_dir_chroot(mrb_state *mrb, const char *path);
 One macro guards the prototype, the port's implementation and the
 method definition in `src/`, so a port that declares a capability and
 forgets to implement it fails to link, and one that declares nothing
-owes nothing.
+owes nothing. `mruby-dir` carries such a header under
+`ports/posix/include/` and `ports/win/include/`, and its README lists
+what each declares.
 
 Only `include/` is exported. A header anywhere else under
 `ports/<name>/` is the port's own, reached by its sources through a

--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -393,6 +393,58 @@ Host builds auto-detect `:posix` or `:win` when `conf.ports` is
 not set. Sources outside `ports/` (i.e. `src/`) are always
 compiled regardless of the port selection.
 
+### What a Port Declares
+
+The selected port's `ports/<name>/include/` directory is an include
+path, for the gem's own sources and for every gem that depends on
+it, as the gem's own `include/` is. That is where a port says what
+it implements: a header of feature macros, which the gem's HAL
+header includes and its `src/` sources read. Whether a method exists
+is the port's to answer, since the port is the only thing that
+knows, and `src/` asks the macro rather than the platform:
+
+```c
+/* ports/posix/include/dir_hal_features.h */
+#define MRB_HAL_DIR_HAS_CHROOT
+
+/* include/dir_hal.h */
+#include "dir_hal_features.h"
+#ifdef MRB_HAL_DIR_HAS_CHROOT
+int mrb_hal_dir_chroot(mrb_state *mrb, const char *path);
+#endif
+```
+
+One macro guards the prototype, the port's implementation and the
+method definition in `src/`, so a port that declares a capability and
+forgets to implement it fails to link, and one that declares nothing
+owes nothing.
+
+Only `include/` is exported. A header anywhere else under
+`ports/<name>/` is the port's own, reached by its sources through a
+relative include and by nothing else, the way a header under `src/`
+is the gem's own; it is neither on another gem's include path nor
+written into the amalgamated `mruby.h`.
+
+A name a port exports is its gem's alone. The name is searched on
+the include path of every gem that depends on the port's gem, where
+the other dependencies' headers sit too, so the build refuses a
+build in which another gem exports the same name, from its
+`include/` or from its port, rather than let the compiler pick
+whichever it finds first. The bundled ports name the header after
+the HAL header it serves, `<short>_hal_features.h` beside
+`<short>_hal.h`.
+
+The macros are the port's to define and nobody else's. A build that
+wants less than the port offers uses the gem's veto define where the
+gem provides one, which the HAL header applies after the port has
+spoken; a build that defines an
+`MRB_HAL_*_HAS_*` macro itself on a port that does not implement it
+gets an undefined `mrb_hal_*` at link time, which is the port's
+answer. A build that supplies the HAL from its own sources, with no
+bundled port and no provider gem, puts its own `<short>_hal_features.h`
+on the include path with `conf.cc.include_paths` and declares there
+what its sources implement.
+
 ### External HAL Provider Gems
 
 A third-party gem may replace another gem's bundled port at build
@@ -417,14 +469,20 @@ When a matching HAL provider gem is present in the build, the
 target gem's `ports/<conf.ports>/` sources are dropped from the
 build automatically. The HAL provider's own sources supply the
 implementation instead, avoiding duplicate symbol errors at link
-time. Loading two gems that match the same `hal-<short>-*`
-prefix is a build error.
+time, and its `include/` takes the port's `include/` place as the
+include path the feature header is found on, whether or not a
+bundled port matched the build. Loading two gems that match the same
+`hal-<short>-*` prefix is a build error, and so is a provider that
+leaves out a header the port it replaces exports, since the target's
+HAL header includes that header by name.
 
-The naming convention is the only signal -- no spec attribute,
-no `add_dependency` flag is required. A gem author who wants to
-contribute an additional bundled port upstream sends a PR adding
-`<target-gem>/ports/<name>/`; a gem author who prefers to ship
-out of tree publishes a `hal-<short>-<conf>` gem instead.
+The naming convention is the only signal -- no spec attribute and
+no HAL-specific `add_dependency` option is required. The ordinary
+dependency on the target gem still is, since the provider includes
+the target's HAL header. A gem author who wants to contribute an
+additional bundled port upstream sends a PR adding
+`<target-gem>/ports/<name>/`; a gem author who prefers to ship out
+of tree publishes a `hal-<short>-<conf>` gem instead.
 
 ## C Extension
 

--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -359,14 +359,24 @@ module MRuby
       end
     end
 
+    # The directories a gem's exported headers are found under, in the
+    # order they are written: the selected port's include/ first, since the
+    # gem's HAL header includes the port's feature header and has to come
+    # after it.  A header elsewhere under ports/<name>/ is the port's own
+    # and is not written here.
+    def gem_header_roots(gem)
+      [gem.port_include_dir, "#{gem.dir}/include"].compact
+        .select { |d| File.directory?(d) }
+    end
+
     def write_gem_headers(f)
       main_library_gems.each do |gem|
-        gem_include = "#{gem.dir}/include"
-        next unless File.directory?(gem_include)
+        roots = gem_header_roots(gem)
+        next if roots.empty?
 
-        paths = Dir.glob("#{gem_include}/**/*.h")
-        order_gem_headers(paths, gem_include).each do |path|
-          rel_path = path.sub("#{gem_include}/", "")
+        paths = roots.flat_map { |root| Dir.glob("#{root}/**/*.h") }
+        order_gem_headers(paths, roots).each do |path|
+          rel_path = header_rel_path(path, roots)
           # X-macro tables are inlined at each include site instead
           next if gem_xmacro_path(rel_path, '"')
           write_header_content(f, "#{gem.name}: #{rel_path}", path)
@@ -415,9 +425,22 @@ module MRuby
     # includes (e.g. mrc_ccontext.h <-> mrc_pool.h) form cycles that the real
     # build resolves with include guards; a DFS post-order breaks them stably
     # by skipping headers already on the current path.
-    def order_gem_headers(paths, gem_include)
+    # The name a header is included by: its path under whichever of
+    # `roots` holds it.
+    def header_rel_path(path, roots)
+      root = roots.find { |r| path.start_with?("#{r}/") }
+      root ? path.sub("#{root}/", "") : path
+    end
+
+    # `paths` in an order every header follows the ones it includes, when
+    # those are among `paths` themselves.  A header is named by its path
+    # under whichever of `roots` it sits in, so the port's feature header
+    # and the HAL header that includes it order the same way two headers
+    # under include/ do.
+    def order_gem_headers(paths, roots)
+      roots = Array(roots)
       by_name = {}
-      paths.each { |p| by_name[p.sub("#{gem_include}/", "")] = p }
+      paths.each { |p| by_name[header_rel_path(p, roots)] = p }
 
       deps = {}
       by_name.each do |rel, path|
@@ -492,12 +515,12 @@ module MRuby
     def write_compiler_headers(f, gems)
       f.puts "/* ======== Compiler headers ======== */"
       gems.each do |gem|
-        gem_include = "#{gem.dir}/include"
-        next unless File.directory?(gem_include)
+        roots = gem_header_roots(gem)
+        next if roots.empty?
 
-        paths = Dir.glob("#{gem_include}/**/*.h")
-        order_gem_headers(paths, gem_include).each do |path|
-          rel_path = path.sub("#{gem_include}/", "")
+        paths = roots.flat_map { |root| Dir.glob("#{root}/**/*.h") }
+        order_gem_headers(paths, roots).each do |path|
+          rel_path = header_rel_path(path, roots)
           # X-macro tables are inlined at each include site instead
           next if gem_xmacro_path(rel_path, '"')
           write_header_content(f, "#{gem.name}: #{rel_path}", path)

--- a/lib/mruby/gem.rb
+++ b/lib/mruby/gem.rb
@@ -25,7 +25,8 @@ module MRuby
       alias :author= :authors=
 
       attr_accessor :rbfiles, :objs
-      attr_reader :port_objs
+      attr_reader :port_objs, :port_dir
+      attr_accessor :port_include_dir
       attr_writer :test_objs, :test_rbfiles
       attr_accessor :test_args, :test_preload
 
@@ -67,12 +68,23 @@ module MRuby
         # a port for the earlier names.  These objs are tracked
         # separately so List#resolve_external_hal! can drop them when
         # an external HAL provider (gem named hal-<short>-*) is loaded.
+        #
+        # The port's include/ is an include path for the gem's own sources
+        # and for any gem that depends on it: a port declares what it
+        # implements in a header there, and the gem's HAL header reads it.
+        # Anything else under ports/<name>/ is the port's own, seen by its
+        # sources alone, as src/ is to the gem.
         @port_objs = []
+        @port_dir = nil
+        @port_include_dir = nil
         build.effective_ports.each do |port|
           port_dir = "#{@dir}/ports/#{port}"
           if File.directory?(port_dir)
             @port_objs = srcs_to_objs("ports/#{port}")
             @objs += @port_objs
+            @port_dir = port_dir
+            port_include = "#{port_dir}/include"
+            @port_include_dir = port_include if File.directory?(port_include)
             break
           end
         end
@@ -113,12 +125,21 @@ module MRuby
         @skip_test
       end
 
+      # The headers the selected port exports, by the names a source includes
+      # them under.  With no port selected, everything any bundled port
+      # exports: a provider standing in for all of them answers for all.
+      def port_exported_headers
+        roots = @port_dir ? ["#{@port_dir}/include"] : Dir.glob("#{@dir}/ports/*/include")
+        roots.flat_map { |r| Dir.glob("#{r}/**/*.h").map { |h| h.sub("#{r}/", "") } }.uniq.sort
+      end
+
       def setup_compilers
         (core? ? [@cc, *(@cxx if build.cxx_exception_enabled?)] : compilers).each do |compiler|
           compiler.define_rules build_dir, @dir, @build.exts.presym_preprocessed
           compiler.define_rules build_dir, @dir, @build.exts.object
           compiler.defines << %Q[MRBGEM_#{funcname.upcase}_VERSION=#{version}]
           compiler.include_paths << "#{@dir}/include" if File.directory? "#{@dir}/include"
+          compiler.include_paths << @port_include_dir if @port_include_dir
         end
 
         define_gem_init_builder if @generate_functions
@@ -497,11 +518,17 @@ module MRuby
       # HAL provider for the gem whose name's last `-`-separated
       # segment is <short> (e.g., hal-task-glib provides the HAL for
       # mruby-task).  The target gem's ports/* sources are dropped
-      # from its object list -- the matching gem supplies the
-      # implementation.  Two or more matches is a build error.
+      # from its object list, and the provider's include/ takes the
+      # port's include/ place on every include path the port's would
+      # have been on: the matching gem supplies the implementation and
+      # the declarations that go with it, whether or not a bundled port
+      # matched this build.  Two or more matches is a build error, and
+      # so is a provider that leaves out a header the port it replaces
+      # exports, since the target's HAL header includes that header by
+      # name and no build could then find it.
       def resolve_external_hal!
         each do |target|
-          next if target.port_objs.nil? || target.port_objs.empty?
+          next unless File.directory?("#{target.dir}/ports")
           short = target.name.split('-').last
           pattern = /\Ahal-#{Regexp.escape(short)}-.+\z/
           overriders = select { |g| g != target && g.name =~ pattern }
@@ -510,7 +537,48 @@ module MRuby
             fail "Multiple HAL providers for '#{target.name}': " +
                  overriders.map(&:name).join(", ")
           end
+          provider = overriders.first
+          provider_include = "#{provider.dir}/include"
+          missing = target.port_exported_headers.reject { |h| File.exist?("#{provider_include}/#{h}") }
+          unless missing.empty?
+            fail "HAL provider '#{provider.name}' for '#{target.name}' does not export " +
+                 missing.join(", ") + ", which the port it replaces does"
+          end
           target.objs.reject! { |o| target.port_objs.include?(o) }
+          target.port_include_dir = provider_include
+        end
+      end
+
+      # A header a port exports is included by name, and the name is
+      # searched on the include path of every gem that depends on the
+      # port's gem, where the other dependencies' headers sit too.  So a
+      # name a port exports is its gem's alone: another gem exporting the
+      # same one, from its include/ or from its port, is a build error
+      # rather than whichever file the compiler happens to find first,
+      # and so is a gem whose own include/ exports a name its port does.
+      def check_exported_header_names
+        owners = Hash.new { |h, k| h[k] = [] }
+        each do |g|
+          roots = ["#{g.dir}/include", g.port_include_dir].compact.uniq
+          roots.select { |d| File.directory?(d) }.each do |root|
+            Dir.glob("#{root}/**/*.h").each do |path|
+              owners[path.sub("#{root}/", "")] << [g, root]
+            end
+          end
+        end
+        each do |g|
+          next unless g.port_include_dir
+          Dir.glob("#{g.port_include_dir}/**/*.h").each do |path|
+            name = path.sub("#{g.port_include_dir}/", "")
+            others = owners[name].reject { |_, root| root == g.port_include_dir }
+            next if others.empty?
+            also = others.sort_by { |og, _| og == g ? 0 : 1 }.map do |og, root|
+              next "again from #{root.relative_path}" if og == g
+              "so does '#{og.name}' from #{root.relative_path}"
+            end
+            fail "'#{g.name}' exports #{name} from " +
+                 "#{g.port_include_dir.relative_path}, and #{also.join(", ")}"
+          end
         end
       end
 
@@ -613,6 +681,7 @@ module MRuby
 
         @ary = tsort_dependencies gem_table.keys, gem_table, true
 
+        check_exported_header_names
         each(&:setup_build)
         each(&:setup_compilers)
 
@@ -630,11 +699,15 @@ module MRuby
           # as circular dependency has already detected in the caller.
           import_include_paths(dep_g)
 
-          # Add dependency's include/ to compiler paths (for inter-gem use)
+          # Add dependency's include/ to compiler paths (for inter-gem use),
+          # and its port's include/ with it: a HAL header the dependency
+          # exports reads the port's feature header, so a gem that includes
+          # the one has to find the other.
           dep_include = "#{dep_g.dir}/include"
-          if File.directory?(dep_include)
+          [dep_include, dep_g.port_include_dir].compact.each do |inc|
+            next unless File.directory?(inc)
             g.compilers.each do |compiler|
-              compiler.include_paths << dep_include
+              compiler.include_paths << inc
               compiler.include_paths.uniq!
             end
           end

--- a/mrbgems/mruby-dir/README.md
+++ b/mrbgems/mruby-dir/README.md
@@ -17,6 +17,22 @@ Dir class for mruby. Supported methods are:
 `#seek`
 `#tell`
 
+## What the port declares
+
+Whether a method exists is the port's to say, since the port is what a build
+names and a `hal-dir-<conf>` gem may stand in for the bundled ones. Each port
+publishes a `dir_hal_features.h` in its `include/`, which
+`include/dir_hal.h` reads before it declares anything. One macro there guards the prototype, the
+port's implementation and the method definition, so a capability the port does
+not declare has no method at all rather than one that fails, and
+`respond_to?` answers false. A port that declares a capability it does not
+implement fails to link.
+
+| macro                  | methods    | posix             | win |
+| ---------------------- | ---------- | ----------------- | --- |
+| `MRB_HAL_DIR_HAS_SEEK` | `Dir#seek` | o, not on Android |     |
+| `MRB_HAL_DIR_HAS_TELL` | `Dir#tell` | o, not on Android |     |
+
 ## License
 
 Copyright (c) 2012 Internet Initiative Japan Inc.

--- a/mrbgems/mruby-dir/README.md
+++ b/mrbgems/mruby-dir/README.md
@@ -3,6 +3,7 @@
 Dir class for mruby. Supported methods are:
 
 `.chdir`
+`.chroot`
 `.delete`
 `.entries`
 `.exist?`
@@ -28,10 +29,11 @@ not declare has no method at all rather than one that fails, and
 `respond_to?` answers false. A port that declares a capability it does not
 implement fails to link.
 
-| macro                  | methods    | posix             | win |
-| ---------------------- | ---------- | ----------------- | --- |
-| `MRB_HAL_DIR_HAS_SEEK` | `Dir#seek` | o, not on Android |     |
-| `MRB_HAL_DIR_HAS_TELL` | `Dir#tell` | o, not on Android |     |
+| macro                    | methods      | posix                    | win |
+| ------------------------ | ------------ | ------------------------ | --- |
+| `MRB_HAL_DIR_HAS_SEEK`   | `Dir#seek`   | o, not on Android        |     |
+| `MRB_HAL_DIR_HAS_TELL`   | `Dir#tell`   | o, not on Android        |     |
+| `MRB_HAL_DIR_HAS_CHROOT` | `Dir.chroot` | o, not on Android or DOS |     |
 
 ## License
 

--- a/mrbgems/mruby-dir/include/dir_hal.h
+++ b/mrbgems/mruby-dir/include/dir_hal.h
@@ -79,8 +79,10 @@ int mrb_hal_dir_chdir(mrb_state *mrb, const char *path);
 /* Get current working directory as UTF-8. Returns 0 on success, -1 on error. */
 int mrb_hal_dir_getcwd(mrb_state *mrb, char *buf, size_t size);
 
-/* Change root directory (privileged operation). Returns -1 if unsupported (sets errno to ENOSYS). */
+#ifdef MRB_HAL_DIR_HAS_CHROOT
+/* Change root directory (privileged operation). Returns 0 on success, -1 on error (sets errno). */
 int mrb_hal_dir_chroot(mrb_state *mrb, const char *path);
+#endif
 
 /* Check if path is a directory. Returns 1 if directory, 0 if not. */
 int mrb_hal_dir_is_directory(mrb_state *mrb, const char *path);

--- a/mrbgems/mruby-dir/include/dir_hal.h
+++ b/mrbgems/mruby-dir/include/dir_hal.h
@@ -13,6 +13,18 @@
 
 #include <mruby.h>
 
+/*
+ * What the port implements
+ *
+ * The port publishes it in a header under its include/, and the build puts
+ * that directory on the include path of this gem and of every gem that
+ * depends on it.  Whether a method exists is the port's to say, because the
+ * port is what a build names: a cross build has no host to detect one from,
+ * and a `hal-dir-<conf>` gem may stand in for the bundled ports altogether.
+ * What each macro says, and what it guards, is written where it is defined.
+ */
+#include "dir_hal_features.h"
+
 MRB_BEGIN_DECL
 
 /*
@@ -38,14 +50,18 @@ const char* mrb_hal_dir_read(mrb_state *mrb, mrb_dir_handle *dir);
 void mrb_hal_dir_rewind(mrb_state *mrb, mrb_dir_handle *dir);
 
 /*
- * Optional Operations (may not be available on all platforms)
+ * Operations a port declares in its dir_hal_features.h
  */
 
-/* Seek to position in directory. Returns -1 if unsupported (sets errno to ENOSYS). */
+#ifdef MRB_HAL_DIR_HAS_SEEK
+/* Seek to position in directory. Returns 0 on success, -1 on error (sets errno). */
 int mrb_hal_dir_seek(mrb_state *mrb, mrb_dir_handle *dir, long pos);
+#endif
 
-/* Get current position in directory. Returns -1 if unsupported (sets errno to ENOSYS). */
+#ifdef MRB_HAL_DIR_HAS_TELL
+/* Get current position in directory. Returns the position, -1 on error (sets errno). */
 long mrb_hal_dir_tell(mrb_state *mrb, mrb_dir_handle *dir);
+#endif
 
 /*
  * Filesystem Operations

--- a/mrbgems/mruby-dir/ports/posix/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/posix/dir_hal.c
@@ -62,37 +62,27 @@ mrb_hal_dir_rewind(mrb_state *mrb, mrb_dir_handle *handle)
 }
 
 /*
- * Optional Operations
+ * Operations this port declares in dir_hal_features.h
  */
 
+#ifdef MRB_HAL_DIR_HAS_SEEK
 int
 mrb_hal_dir_seek(mrb_state *mrb, mrb_dir_handle *handle, long pos)
 {
-#if defined(__ANDROID__)
-  /* Android doesn't have reliable seekdir */
-  (void)mrb; (void)handle; (void)pos;
-  errno = ENOSYS;
-  return -1;
-#else
   (void)mrb;
   seekdir(handle->dir, pos);
   return 0;
-#endif
 }
+#endif
 
+#ifdef MRB_HAL_DIR_HAS_TELL
 long
 mrb_hal_dir_tell(mrb_state *mrb, mrb_dir_handle *handle)
 {
-#if defined(__ANDROID__)
-  /* Android doesn't have reliable telldir */
-  (void)mrb; (void)handle;
-  errno = ENOSYS;
-  return -1;
-#else
   (void)mrb;
   return telldir(handle->dir);
-#endif
 }
+#endif
 
 /*
  * Filesystem Operations

--- a/mrbgems/mruby-dir/ports/posix/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/posix/dir_hal.c
@@ -116,19 +116,14 @@ mrb_hal_dir_getcwd(mrb_state *mrb, char *buf, size_t size)
   return getcwd(buf, size) ? 0 : -1;
 }
 
+#ifdef MRB_HAL_DIR_HAS_CHROOT
 int
 mrb_hal_dir_chroot(mrb_state *mrb, const char *path)
 {
-#if defined(__ANDROID__) || defined(__MSDOS__)
-  /* Not available on these platforms */
-  (void)mrb; (void)path;
-  errno = ENOSYS;
-  return -1;
-#else
   (void)mrb;
   return chroot(path);
-#endif
 }
+#endif
 
 int
 mrb_hal_dir_is_directory(mrb_state *mrb, const char *path)

--- a/mrbgems/mruby-dir/ports/posix/include/dir_hal_features.h
+++ b/mrbgems/mruby-dir/ports/posix/include/dir_hal_features.h
@@ -1,0 +1,23 @@
+/*
+** dir_hal_features.h - what the POSIX port of mruby-dir implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/dir_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in dir_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_DIR_HAL_FEATURES_H
+#define MRUBY_DIR_HAL_FEATURES_H
+
+/* seekdir(3) and telldir(3): `Dir#seek` and `Dir#tell`.  Android's are not
+   reliable. */
+#if !defined(__ANDROID__)
+# define MRB_HAL_DIR_HAS_SEEK
+# define MRB_HAL_DIR_HAS_TELL
+#endif
+
+#endif /* MRUBY_DIR_HAL_FEATURES_H */

--- a/mrbgems/mruby-dir/ports/posix/include/dir_hal_features.h
+++ b/mrbgems/mruby-dir/ports/posix/include/dir_hal_features.h
@@ -20,4 +20,9 @@
 # define MRB_HAL_DIR_HAS_TELL
 #endif
 
+/* chroot(2): `Dir.chroot`.  Android forbids it and DJGPP has none. */
+#if !defined(__ANDROID__) && !defined(__MSDOS__)
+# define MRB_HAL_DIR_HAS_CHROOT
+#endif
+
 #endif /* MRUBY_DIR_HAL_FEATURES_H */

--- a/mrbgems/mruby-dir/ports/win/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/win/dir_hal.c
@@ -270,15 +270,6 @@ mrb_hal_dir_getcwd(mrb_state *mrb, char *buf, size_t size)
 }
 
 int
-mrb_hal_dir_chroot(mrb_state *mrb, const char *path)
-{
-  /* Not available on Windows */
-  (void)mrb; (void)path;
-  errno = ENOSYS;
-  return -1;
-}
-
-int
 mrb_hal_dir_is_directory(mrb_state *mrb, const char *path)
 {
   struct _stat sb;

--- a/mrbgems/mruby-dir/ports/win/dir_hal.c
+++ b/mrbgems/mruby-dir/ports/win/dir_hal.c
@@ -186,28 +186,6 @@ mrb_hal_dir_rewind(mrb_state *mrb, mrb_dir_handle *handle)
 }
 
 /*
- * Optional Operations
- */
-
-int
-mrb_hal_dir_seek(mrb_state *mrb, mrb_dir_handle *handle, long pos)
-{
-  /* Not supported on Windows */
-  (void)mrb; (void)handle; (void)pos;
-  errno = ENOSYS;
-  return -1;
-}
-
-long
-mrb_hal_dir_tell(mrb_state *mrb, mrb_dir_handle *handle)
-{
-  /* Not supported on Windows */
-  (void)mrb; (void)handle;
-  errno = ENOSYS;
-  return -1;
-}
-
-/*
  * Filesystem Operations
  */
 

--- a/mrbgems/mruby-dir/ports/win/include/dir_hal_features.h
+++ b/mrbgems/mruby-dir/ports/win/include/dir_hal_features.h
@@ -1,0 +1,19 @@
+/*
+** dir_hal_features.h - what the Windows port of mruby-dir implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/dir_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in dir_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_DIR_HAL_FEATURES_H
+#define MRUBY_DIR_HAL_FEATURES_H
+
+/* A FindNextFile() walk has no position to read or return to: `Dir#seek`
+   and `Dir#tell` are left undefined rather than defined to fail. */
+
+#endif /* MRUBY_DIR_HAL_FEATURES_H */

--- a/mrbgems/mruby-dir/ports/win/include/dir_hal_features.h
+++ b/mrbgems/mruby-dir/ports/win/include/dir_hal_features.h
@@ -16,4 +16,7 @@
 /* A FindNextFile() walk has no position to read or return to: `Dir#seek`
    and `Dir#tell` are left undefined rather than defined to fail. */
 
+/* No chroot(2), or anything standing for it: `Dir.chroot` is likewise
+   undefined. */
+
 #endif /* MRUBY_DIR_HAL_FEATURES_H */

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -378,6 +378,7 @@ mrb_dir_rewind(mrb_state *mrb, mrb_value self)
  *   d.seek(pos)       #=> #<Dir:testdir>
  *   d.read            #=> "."
  */
+#ifdef MRB_HAL_DIR_HAS_SEEK
 static mrb_value
 mrb_dir_seek(mrb_state *mrb, mrb_value self)
 {
@@ -391,12 +392,15 @@ mrb_dir_seek(mrb_state *mrb, mrb_value self)
   }
   mrb_get_args(mrb, "i", &pos);
   if (mrb_hal_dir_seek(mrb, mdir->handle, (long)pos) == -1) {
-    if (errno == ENOSYS) {
-      mrb_raise(mrb, E_NOTIMP_ERROR, "dirseek() unreliable on your system");
-    }
+    mrb_sys_fail(mrb, "seekdir");
   }
   return self;
 }
+#else
+/* this port has no directory position: unimplemented, and named as such so
+   `respond_to?` can answer false */
+# define mrb_dir_seek mrb_notimplement_m
+#endif
 
 /*
  * call-seq:
@@ -410,6 +414,7 @@ mrb_dir_seek(mrb_state *mrb, mrb_value self)
  *   d.read   #=> "."
  *   d.tell   #=> 1
  */
+#ifdef MRB_HAL_DIR_HAS_TELL
 static mrb_value
 mrb_dir_tell(mrb_state *mrb, mrb_value self)
 {
@@ -423,12 +428,13 @@ mrb_dir_tell(mrb_state *mrb, mrb_value self)
   }
   pos = mrb_hal_dir_tell(mrb, mdir->handle);
   if (pos == -1) {
-    if (errno == ENOSYS) {
-      mrb_raise(mrb, E_NOTIMP_ERROR, "dirtell() unreliable on your system");
-    }
+    mrb_sys_fail(mrb, "telldir");
   }
   return mrb_fixnum_value((mrb_int)pos);
 }
+#else
+# define mrb_dir_tell mrb_notimplement_m
+#endif
 
 /*
  * call-seq:

--- a/mrbgems/mruby-dir/src/dir.c
+++ b/mrbgems/mruby-dir/src/dir.c
@@ -218,6 +218,7 @@ mrb_dir_chdir(mrb_state *mrb, mrb_value klass)
  *
  *   Dir.chroot("/production/secure/root")
  */
+#ifdef MRB_HAL_DIR_HAS_CHROOT
 static mrb_value
 mrb_dir_chroot(mrb_state *mrb, mrb_value self)
 {
@@ -227,14 +228,16 @@ mrb_dir_chroot(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "z", &path);
   res = mrb_hal_dir_chroot(mrb, path);
   if (res == -1) {
-    if (errno == ENOSYS) {
-      mrb_raise(mrb, E_NOTIMP_ERROR, "chroot() unreliable on your system");
-    }
     mrb_sys_fail(mrb, path);
   }
 
   return mrb_fixnum_value(res);
 }
+#else
+/* this port cannot change the root: unimplemented, and named as such so
+   `respond_to?` can answer false */
+# define mrb_dir_chroot mrb_notimplement_m
+#endif
 
 static mrb_bool
 skip_name_p(const char *name)


### PR DESCRIPTION
## Summary

A gem's `ports/<name>/` directory held the sources the build picks for the selected port and nothing that could be read from it: the gem's own `src/`, and every gem depending on that gem, saw `include/` alone. Whether a method exists is the port's to decide, since the port is what a build names and a cross build has no host to detect the platform from, yet a port had no file the rest of the gem could read that decision from.

The selected port's `include/` is now an include path for the gem's own compilers and for the compilers of every gem that depends on that gem, so a port can publish a feature header the gem's HAL header includes; the amalgam writes that header ahead of the gem's own. `mruby-dir` is the first gem to use it: each port declares in its `include/dir_hal_features.h` what it implements, one macro guards the prototype, the port's implementation and the method definition, and the three Windows stubs and three Android `ENOSYS` arms whose only job was to refuse are deleted along with the errno translation in `src/` that stood in for the port's answer. `mruby-io` and `mruby-socket` follow in their own PRs.

## Changes

| File | What |
| --- | --- |
| `lib/mruby/gem.rb` | `port_dir`, `port_include_dir` (the port's `include/`), `port_exported_headers`; the directory is pushed to the gem's compilers and to each dependant's; `check_exported_header_names` refuses a name exported by two gems, or by a gem's own `include/` and its port at once; `resolve_external_hal!` wires a `hal-<short>-<conf>` provider's `include/` whether or not a bundled port matched, and refuses a provider that leaves out a header the port it replaces exports |
| `lib/mruby/amalgam.rb` | `gem_header_roots`, `header_rel_path`; the port's headers are written before `include/` and ordered with them |
| `doc/guides/mrbgems.md` | the mechanism, illustrated with `dir_hal_features.h` |
| `mruby-dir/ports/{posix,win}/include/dir_hal_features.h` | new; `MRB_HAL_DIR_HAS_SEEK`, `_TELL`, `_CHROOT` |
| `mruby-dir/include/dir_hal.h` | includes the feature header; guards the prototypes of `mrb_hal_dir_seek()`, `_tell()`, `_chroot()` |
| `mruby-dir/ports/{posix,win}/dir_hal.c` | the POSIX implementations are guarded by the feature macros, and lose their `__ANDROID__` and `__MSDOS__` arms; the three Windows stubs are deleted |
| `mruby-dir/src/dir.c` | `Dir#seek`, `Dir#tell`, `Dir.chroot` follow the macros; a failure raises `SystemCallError` |
| `mruby-dir/README.md` | a "What the port declares" section with the table of macros |

### The build hands the port's headers to the gem

The selected port's `ports/<name>/include/` is an include path for the gem's own compilers and for the compilers of every gem that depends on that gem, so a port can publish a feature header the gem's HAL header includes. Only that directory is exported: a header elsewhere under `ports/<name>/` is the port's own, as one under `src/` is the gem's, and neither the include paths nor the amalgam see it. A name a port exports is its gem's alone, since it is searched on the include path of every dependant beside the other dependencies' headers; a build in which another gem exports the same name, from its `include/` or from its port, is refused rather than left to the compiler to settle by whichever file it finds first. The bundled ports name the header after the HAL header it serves, `<short>_hal_features.h` beside `<short>_hal.h`.

An external `hal-<short>-<conf>` provider gem takes the port's place in the build, and its `include/` takes the port's `include/` place on the path. It does so whether or not a bundled port matched the build: what used to skip a target with no port sources to drop is now a test for a `ports/` directory, so a cross build without `conf.ports` wires the provider too. A provider that leaves out a header the port it replaces exports is refused at setup, since the HAL header includes that header by name and the build would otherwise stop at the first `#include`.

The macros are the port's to define and nobody else's. A build that wants less than the port offers uses the gem's veto define where the gem provides one, which the HAL header applies after the port has spoken; a build that defines an `MRB_HAL_*_HAS_*` itself on a port that does not implement it gets an undefined `mrb_hal_*` at link time; a build that supplies the HAL from its own sources, with no port and no provider gem, puts its own `<short>_hal_features.h` on the include path with `conf.cc.include_paths`.

The amalgam wrote a gem's headers from `include/` alone; it now writes the selected port's ahead of them and orders the whole set by what includes what, so the HAL header reads the feature header there as it does in a normal compile.

### One macro, three consumers

Each bundled port of `mruby-dir` ships a `dir_hal_features.h`. A macro defined there guards the prototype in `dir_hal.h`, the implementation in the port, and the method definition in `dir.c`, so a port that declares a capability without implementing it fails to link, and a port that declares nothing owes nothing: the method is defined as `mrb_notimplement_m`, so `respond_to?` answers false and a call raises `NotImplementedError`. The platform test is written once, in the port's header: `__ANDROID__` for seekdir(3) and telldir(3), `__ANDROID__` and `__MSDOS__` for chroot(2). The Windows port declares none of the three, and says in its header why: a `FindNextFile()` walk has no position, and there is no chroot(2).

### What the stubs hid

`mrb_hal_dir_seek()` and `mrb_hal_dir_tell()` returned `-1` with `ENOSYS`, and `dir.c` translated that one errno into `NotImplementedError` while letting every other failure through as a position of `-1` or a seek that had not happened. `mrb_hal_dir_chroot()` on Windows, Android and DJGPP set `ENOSYS` the same way. All of it goes with the stubs: what remains of a failure is a real one, and `dir.c` raises it as the `SystemCallError` it is.

## Behaviour

On Linux, macOS and the BSDs, nothing observable changes but this:

- a `Dir#seek` or `Dir#tell` whose call fails raises `SystemCallError`. It returned `self` or `-1` for every errno but `ENOSYS`, and raised `NotImplementedError` for that one.
- a `Dir.chroot` that fails with `ENOSYS` raises `Errno::ENOSYS` rather than `NotImplementedError`. Every other errno raised `SystemCallError` before and still does.

On Windows, `Dir#seek`, `Dir#tell` and `Dir.chroot` still raise `NotImplementedError`, but `respond_to?` now answers false for each. On Android the same holds for the three, and on DJGPP for `Dir.chroot`.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory at the same path with `rake`; base is 85102880c.

| build | base | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,379,798 | 1,379,606 | −192 |
| ascii-ctype | 1,366,886 | 1,366,694 | −192 |
| byte-string | 1,342,870 | 1,342,678 | −192 |
| cxx_abi | 1,413,161 | 1,412,953 | −208 |
| no-float | 1,305,566 | 1,305,374 | −192 |
| no-bigint | 1,264,422 | 1,264,230 | −192 |
| full-debug (-O0) | 1,971,446 | 1,971,318 | −128 |

The whole of it is `mruby-dir/src/dir.o`, 3,161 to 2,969: the three `ENOSYS` translations. The POSIX `dir_hal.o` is 437 bytes on both sides, since on this port every macro is declared and the guards select the code that was there. The build mechanism itself compiles nothing; the base column already holds every gem the head does. The Windows binary loses the three stubs; it was not measured here.

## Testing

Every commit was built from an empty directory and run with `rake -m test` on the host (mrbtest 2,614 / bintest 130, KO 0 / Crash 0 at each of the four), and `prek run --from-ref <sha>^ --to-ref <sha>` passed at each, with `prettier --check` on every Markdown file a commit touches. The numbers below are the branch head.

- host (`build_config/default.rb`): mrbtest 2,614 (OK 2,546 / Skip 68) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`): mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1)
- `build_config/cross-mingw-winetest.rb` under wine: mrbtest 2,838 (OK 2,792 / Skip 46), bintest 100 (OK 92 / Skip 8), KO 0 / Crash 0; the skips for `Dir#seek` and `Dir#tell` read "unimplemented on this machine", which is the mark speaking
- `rake amalgam`, then `gcc -fsyntax-only` over the generated `mruby.c`: no errors; the port's `dir_hal_features.h` is written into `mruby.h` ahead of the `dir_hal.h` that includes it
- a stand-in provider gem `hal-dir-fake` (the POSIX `dir_hal.c` copied into its `src/`, depending on `mruby-dir`), four builds:
  - without `include/`: refused at setup, `HAL provider 'hal-dir-fake' for 'mruby-dir' does not export dir_hal_features.h, which the port it replaces does`
  - with `include/dir_hal_features.h`: mrbtest 852 (OK 844 / Skip 8), the port's objects absent from `compile_commands.json`, the provider's `include/` on the compile line of `mruby-dir/src/dir.c` and the port's not
  - `MRuby::CrossBuild` without `conf.ports`, so no bundled port matches: builds, the provider's `include/` on the path
  - the bundled port made header-only (`ports/posix/dir_hal.c` moved aside, its `include/` left): builds, mrbtest 852 (OK 844 / Skip 8), the provider's objects in the build and its `include/` on the compile line; a port with headers and no sources is replaced like any other
- a second gem made to export a name a port already exports (`mrbgems/mruby-io/include/dir_hal_features.h` touched into the default build): refused at setup, `'mruby-dir' exports dir_hal_features.h from mrbgems/mruby-dir/ports/posix/include, and so does 'mruby-io' from mrbgems/mruby-io/include`

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

| | |
| --- | --- |
| OS | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| mingw | x86_64-w64-mingw32-gcc (GCC) 13-win32, wine-11.0 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-dir/src/dir.c` from each build's `compile_commands.json`, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-dir/src/dir.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_DIR_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-dir/src/dir.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Directory capabilities now reflect platform support at build time.
  - Unsupported `Dir#seek`, `Dir#tell`, and `Dir.chroot` methods are reported as unavailable.
  - Platform ports can declare supported directory features through exported headers.

- **Bug Fixes**
  - External HAL providers are validated for required headers.
  - Conflicting exported header names now produce a build error.
  - Port-provided headers are included during compilation.

- **Documentation**
  - Added guidance on port declarations, exported headers, HAL providers, and directory capability availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->