### PR TITLE
build_config: let nintendo_switch.rb load

### DIFF
--- a/build_config/nintendo_switch.rb
+++ b/build_config/nintendo_switch.rb
@@ -13,14 +13,14 @@ MRuby::CrossBuild.new('nintendo_switch_32bit') do |conf|
     cc.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
     cc.include_paths += include_paths
     cc.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
-    cc.defines += 'NN_SDK_BUILD_RELEASE'
+    cc.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.cxx do |cxx|
     cxx.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
     cxx.include_paths += include_paths
     cxx.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
-    cxx.defines += 'NN_SDK_BUILD_RELEASE'
+    cxx.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.archiver do |archiver|
@@ -49,7 +49,7 @@ MRuby::CrossBuild.new('nintendo_switch_64bit') do |conf|
     cc.include_paths += include_paths
     cc.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cc.flags << '--target=aarch64-nintendo-nx-elf'
-    cc.defines += 'NN_SDK_BUILD_RELEASE'
+    cc.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.cxx do |cxx|
@@ -57,7 +57,7 @@ MRuby::CrossBuild.new('nintendo_switch_64bit') do |conf|
     cxx.include_paths += include_paths
     cxx.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cxx.flags << '--target=aarch64-nintendo-nx-elf'
-    cxx.defines += 'NN_SDK_BUILD_RELEASE'
+    cxx.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.archiver do |archiver|

--- a/build_config/nintendo_switch.rb
+++ b/build_config/nintendo_switch.rb
@@ -2,33 +2,33 @@
 # Tested on windows
 MRuby::CrossBuild.new('nintendo_switch_32bit') do |conf|
   conf.toolchain :clang
-  NINTENDO_SDK_PATH = ENV['NINTENDO_SDK_ROOT']
+  sdk_path = ENV['NINTENDO_SDK_ROOT']
 
   include_paths = [
-    "#{NINTENDO_SDK_PATH}/Include",
-    "#{NINTENDO_SDK_PATH}/Common/Configs/Targets/NX-NXFP2-a32/Include"
+    "#{sdk_path}/Include",
+    "#{sdk_path}/Common/Configs/Targets/NX-NXFP2-a32/Include"
   ]
 
   conf.cc do |cc|
-    cc.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
+    cc.command = "#{sdk_path}/Compilers/NX/bin/nx-clang++"
     cc.include_paths += include_paths
     cc.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cc.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.cxx do |cxx|
-    cxx.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
+    cxx.command = "#{sdk_path}/Compilers/NX/bin/nx-clang++"
     cxx.include_paths += include_paths
     cxx.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cxx.defines << 'NN_SDK_BUILD_RELEASE'
   end
 
   conf.archiver do |archiver|
-    archiver.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/nx/armv7l/bin/llvm-ar"
+    archiver.command = "#{sdk_path}/Compilers/NX/nx/armv7l/bin/llvm-ar"
   end
 
   conf.linker do |linker|
-    linker.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/nx/armv7l/bin/clang++"
+    linker.command = "#{sdk_path}/Compilers/NX/nx/armv7l/bin/clang++"
     linker.libraries = []
   end
 
@@ -37,15 +37,15 @@ end
 
 MRuby::CrossBuild.new('nintendo_switch_64bit') do |conf|
   conf.toolchain :clang
-  NINTENDO_SDK_PATH = ENV['NINTENDO_SDK_ROOT']
+  sdk_path = ENV['NINTENDO_SDK_ROOT']
 
   include_paths = [
-    "#{NINTENDO_SDK_PATH}/Include",
-    "#{NINTENDO_SDK_PATH}/Common/Configs/Targets/NX-NXFP2-a64/Include"
+    "#{sdk_path}/Include",
+    "#{sdk_path}/Common/Configs/Targets/NX-NXFP2-a64/Include"
   ]
 
   conf.cc do |cc|
-    cc.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
+    cc.command = "#{sdk_path}/Compilers/NX/bin/nx-clang++"
     cc.include_paths += include_paths
     cc.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cc.flags << '--target=aarch64-nintendo-nx-elf'
@@ -53,7 +53,7 @@ MRuby::CrossBuild.new('nintendo_switch_64bit') do |conf|
   end
 
   conf.cxx do |cxx|
-    cxx.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/bin/nx-clang++"
+    cxx.command = "#{sdk_path}/Compilers/NX/bin/nx-clang++"
     cxx.include_paths += include_paths
     cxx.flags += ['-fpic -fno-short-enums -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fomit-frame-pointer -fno-vectorize -funsigned-char -O2 -g -mno-implicit-float']
     cxx.flags << '--target=aarch64-nintendo-nx-elf'
@@ -61,11 +61,11 @@ MRuby::CrossBuild.new('nintendo_switch_64bit') do |conf|
   end
 
   conf.archiver do |archiver|
-    archiver.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/nx/aarch64/bin/llvm-ar"
+    archiver.command = "#{sdk_path}/Compilers/NX/nx/aarch64/bin/llvm-ar"
   end
 
   conf.linker do |linker|
-    linker.command = "#{NINTENDO_SDK_PATH}/Compilers/NX/nx/aarch64/bin/clang++"
+    linker.command = "#{sdk_path}/Compilers/NX/nx/aarch64/bin/clang++"
     linker.libraries = []
   end
 


### PR DESCRIPTION
## Summary

`build_config/nintendo_switch.rb` has not loaded since ad09c3951 added it. Each of its four `cc.defines += 'NN_SDK_BUILD_RELEASE'` lines is `Array#+` with a String on the right, which raises `TypeError` in the first `conf.cc` block, before either Switch build is declared. The four lines now append with `<<`, as every other configuration does, and both builds carry the define. With the file loading, the second commit takes the `already initialized constant` warning off it: the SDK root was assigned to the constant `NINTENDO_SDK_PATH` once per build, and is now a local of each build's block.

## Changes

| Commit                                                                   | What                                                                                                                               |
| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
| build_config: append the Nintendo Switch define with `<<`                | `cc.defines += '...'` and `cxx.defines += '...'` become `<<`, 4 lines                                                              |
| build_config: hold the Nintendo SDK root in a local of each Switch build | `NINTENDO_SDK_PATH = ENV[...]` in each build becomes the local `sdk_path`, beside the `include_paths` local the file already keeps |

## Behaviour

```console
$ MRUBY_CONFIG=build_config/nintendo_switch.rb rake -T
rake aborted!
TypeError: no implicit conversion of String into Array (TypeError)

    cc.defines += 'NN_SDK_BUILD_RELEASE'
                  ^^^^^^^^^^^^^^^^^^^^^^
```

is now the task list, without the two `already initialized constant NINTENDO_SDK_PATH` lines the first commit alone would print, and `nintendo_switch_32bit` and `nintendo_switch_64bit` each have `NN_SDK_BUILD_RELEASE` in the defines of their `cc` and `cxx`. The commands and include paths each build ends up with are the same strings as before. No other configuration is touched.

## Testing

Loaded the configuration through `rake -T` at each commit, and printed the defines, compiler command and include paths of each target from the loaded Rakefile under `ruby -w`. The SDK itself is not needed to reach the failure or to see the fix: the file fails while the build is being declared, ahead of any compiler being run.

## Environment

<details>

- Ruby 4.0.6, rake 13.3.1, Linux x86_64
- base c85303be2

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Nintendo Switch build configurations for more consistent SDK handling.
  - Preserved the appropriate ARMv7 and AArch64 architecture settings for 32-bit and 64-bit builds.
  - Maintained platform-specific compiler, linker, archiver, and include path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->