### PR TITLE
build: write `compile_commands.json` without a build

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -33,11 +33,15 @@ inside of the mruby source root. To generate and execute the test tools call
 `rake test`. To clean all build files call `rake clean`. To see full command
 line on build, call `rake -v`.
 
-Every target ends its build by writing a `compile_commands.json` of its own
-compiles into its build directory, for editors and clang tools, out of the
-command lines it records beside its objects. No tracer such as `bear` is
-involved. `rake compile_commands.json` is that same build, asked for by the
-name of the file it leaves behind. A target says
+Every target has a `compile_commands.json` of its own compiles in its build
+directory, for editors and clang tools, written out of the rules it compiles
+by. A rule says everything a compile is before it runs, so
+`rake compile_commands.json` writes the database without building anything:
+a fresh checkout has one before its first compile, and no tracer such as
+`bear` is involved. A build writes it again as it ends, since the sources a
+build generates join the database once they are there, and so does what the
+build compiled that no rule declares, the test driver `rake test` loads for
+one, out of the command lines recorded beside its objects. A target says
 `conf.disable_compile_commands` to keep none.
 
 A database in a build directory is what `clangd --compile-commands-dir` and
@@ -52,7 +56,7 @@ that one first. Where the order is fixed for another reason,
 `conf.enable_compile_commands default: true` names the target instead; no
 configuration in this tree needs it.
 
-A source no build in the tree compiled, one of a gem the configuration leaves
+A source no build in the tree compiles, one of a gem the configuration leaves
 out for instance, has no entry; `compile_flags.txt` and `.clangd` at the
 source root are what answer for those.
 

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -98,6 +98,7 @@ module MRuby
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :libdir_name
     attr_reader :defines
     attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
+    attr_reader :compile_rules
     attr_reader :build_root
     attr_reader :install_excludes, :port_names
 
@@ -166,6 +167,7 @@ module MRuby
         @gems = MRuby::Gem::List.new
         @libmruby_core_objs = []
         @libmruby_objs = [@libmruby_core_objs]
+        @compile_rules = []
         @enable_libmruby = true
         @build_mrbtest_lib_only = false
         @cxx_exception_enabled = false
@@ -662,6 +664,22 @@ EOS
         end
       end
       objects.uniq
+    end
+
+    # The compiler and the source a compile of +outfile+ runs with, or nothing
+    # where no rule of this build compiles it.
+    #
+    # The source is the one Rake resolved the rule of the output to, the
+    # first prerequisite of its task and the one the rule hands +run+; the
+    # rule is then known by that output and that source (see
+    # +Command::Compiler::Rule+), and the compiler is the rule's. A compile
+    # written out as a +file+ task by hand is no rule, and has no answer here.
+    def compile_of(outfile)
+      task = Rake.application.lookup(outfile) || Rake.application.enhance_with_matching_rule(outfile)
+      return nil unless task
+      source = task.prerequisites.first
+      rule = @compile_rules.find { |r| r.compiles?(outfile, source) }
+      [rule.compiler, source] if rule
     end
 
     def define_installer_outline(src, dst)

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -634,6 +634,36 @@ EOS
       end
     end
 
+    # The objects the products of this build are made from: every object
+    # under the build directory that a product depends on, however far down.
+    #
+    # The objects of the +mrbc+ build this build makes for itself are left
+    # out. They are the same sources compiled with the defines of a bootstrap
+    # compiler, and that build is no target the config asked for. The +mrbc+
+    # a cross build borrows from another target sits under that target's
+    # directory, and is left out by that.
+    #
+    # Walking the prerequisites resolves the rule of every object on the way,
+    # so this is asked once every target is declared: the products of one
+    # target reach the objects of another (a build reaches the +mrbc+ build it
+    # generated), and a rule resolved for those objects must see the same
+    # include paths as the compile that follows it.
+    def objects
+      build_dir = "#{@build_dir}/"
+      donor = "#{@mrbc_build.build_dir}/" if @mrbc_build
+      objects = []
+      @products.each do |product|
+        Rake::Task[product].all_prerequisite_tasks.each do |task|
+          name = task.name
+          next unless File.extname(name) == @exts.object
+          next unless name.start_with?(build_dir)
+          next if donor && name.start_with?(donor)
+          objects << name
+        end
+      end
+      objects.uniq
+    end
+
     def define_installer_outline(src, dst)
       file dst => src do
         _pp "GEN", src.relative_path, dst.relative_path

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -30,6 +30,12 @@ module MRuby
       "\"#{s}\""
     end
 
+    # The command line +_run+ runs: the command, and +options+ with +params+
+    # filled in.
+    def command_line(options, params={})
+      "#{build.filename(command)} #{options % params}"
+    end
+
     private
     # Run the command, from +chdir+ where one is given.
     #
@@ -39,7 +45,7 @@ module MRuby
     # have one working directory between them, while a directory given here
     # belongs to the one child it is given to.
     def _run(options, params={}, chdir: nil)
-      cmd = "#{build.filename(command)} #{options % params}"
+      cmd = command_line(options, params)
       chdir ? sh(cmd, chdir: chdir) : sh(cmd)
     end
   end
@@ -296,23 +302,36 @@ module MRuby
 
     def run(outfile, infile, _defines=[], _include_paths=[], _flags=[])
       mkdir_p File.dirname(outfile)
-      flags = compile_flags(outfile, _defines, _include_paths, _flags)
-      if object_ext?(outfile)
-        label = @label
-        opts = compile_options
-      else
-        label = "CPP"
-        opts = preprocess_options
-      end
+      opts, params = compile_invocation(outfile, infile, _defines, _include_paths, _flags)
+      label = object_ext?(outfile) ? @label : "CPP"
       _pp label, infile.relative_path, outfile.relative_path
-      _run opts, {
-        flags: flags,
-        infile: filename(build.compile_path(infile)),
-        outfile: filename(build.compile_path(outfile)),
-      }, chdir: (MRUBY_ROOT if build.compile_relative?)
+      _run opts, params, chdir: (MRUBY_ROOT if build.compile_relative?)
       # Recorded after the compile, so that a compile that failed leaves
       # nothing claiming a configuration its output was not built with.
-      File.write(flags_file(outfile), flags_record(opts, flags))
+      File.write(flags_file(outfile), flags_record(opts, params[:flags]))
+    end
+
+    # The command line +run+ runs to compile +outfile+ from +infile+, for
+    # whoever wants it without the compile being run: the compilation
+    # database is written from it.
+    def compile_command(outfile, infile)
+      command_line(*compile_invocation(outfile, infile))
+    end
+
+    # A rule +define_rules+ defined, kept so that what the rule compiles, and
+    # with which compiler, can be asked without the rule being run.
+    Rule = Struct.new(:matcher, :source_of, :compiler_of) do
+      # Whether this rule is the one that compiles +outfile+ from +source+.
+      # The rules of a build differ in the output they match and in the
+      # source they look for beside it, so the two names together name one
+      # rule.
+      def compiles?(outfile, source)
+        matcher.match?(outfile) && source_of.call(outfile) == source
+      end
+
+      def compiler
+        compiler_of.call
+      end
     end
 
     # Define the rules that build the outputs under +build_dir+ from the
@@ -350,6 +369,7 @@ module MRuby
           ] do |t|
             compiler_of.call.run t.name, t.prerequisites.first
           end
+          build.compile_rules << Rule.new(generated_file_matcher, source_of, compiler_of)
         end
       end
     end
@@ -541,6 +561,19 @@ module MRuby
       flags = all_flags(_defines, _include_paths, _flags, compiled: true)
       flags += " -DMRB_PRESYM_SCANNING" unless object_ext?(outfile)
       flags
+    end
+
+    # The options a compile of +outfile+ from +infile+ runs with, and the
+    # parameters that fill them in: the compile options for an object, the
+    # preprocess options for the preprocessed source the presym scan reads.
+    def compile_invocation(outfile, infile, _defines=[], _include_paths=[], _flags=[])
+      options = object_ext?(outfile) ? compile_options : preprocess_options
+      params = {
+        flags: compile_flags(outfile, _defines, _include_paths, _flags),
+        infile: filename(build.compile_path(infile)),
+        outfile: filename(build.compile_path(outfile)),
+      }
+      [options, params]
     end
 
     def object_ext?(path)

--- a/lib/mruby/compile_commands.rb
+++ b/lib/mruby/compile_commands.rb
@@ -1,21 +1,29 @@
+require "fileutils"
 require "json"
 
 module MRuby
   # The compilation database (+compile_commands.json+) of a build, made from
-  # what the build already writes about itself.
+  # the rules the build compiles by, and from what the build has compiled
+  # besides.
   #
-  # Every compile leaves two files beside its output: +<output>.flags+, the
-  # command line it ran with (see +MRuby::Command::Compiler#run+), and
+  # A rule is the whole of a compile before it runs: which source the object
+  # is made from, which compiler makes it and with what flags. So the
+  # database is written from the rules, and asks for no compile to have run:
+  # a checkout has its database before its first build, and a tool that
+  # traces the compiles instead, +bear+ or +compiledb+ or an +strace+
+  # wrapper, is not needed and is not asked for.
+  #
+  # What a build compiled that no rule of the config declares is answered
+  # for by the record each compile leaves beside its output: +<output>.flags+,
+  # the command line it ran with (see +MRuby::Command::Compiler#run+), and
   # +<output>.d+, the files it read, whose first name is the source it
-  # compiled. The two together are an entry of the database, so nothing has
-  # to watch the build run to write one. A tool that traces the compiles
-  # instead, +bear+ or +compiledb+ or an +strace+ wrapper, is not needed and
-  # is not asked for.
+  # compiled. The test driver `rake test` loads is such a compile, and so is
+  # an object of a gem the config has since dropped.
   #
-  # What the database holds is what the build compiled. A source that no
-  # build in this directory has reached, a gem the config leaves out or a
-  # port for another platform, has no record and so no entry; the +.clangd+
-  # and +compile_flags.txt+ of the tree are what answer for those.
+  # A source no build in this directory compiles, a gem the config leaves
+  # out or a port for another platform, has no rule and no record, and so no
+  # entry; the +.clangd+ and +compile_flags.txt+ of the tree are what answer
+  # for those.
   class CompileCommands
     # The keys of a +.flags+ record, in the order it writes them.
     RECORD_KEYS = %w[command options flags].freeze
@@ -36,15 +44,10 @@ module MRuby
     # to read that build finds it: what clangd's +compile-commands-dir+
     # option names is a directory, so a cross build's flags are one option
     # away without the config or the environment being changed at all.
-    #
-    # A build that has compiled nothing is passed over rather than handed an
-    # empty database, since its build directory may not even be there yet.
     def self.write
       speaks_for_tree = target
       keepers.each do |build|
         database = new(build)
-        next if database.count.zero?
-
         write_one(database, database.path, "#{database.count} entries")
         next unless build.equal?(speaks_for_tree)
 
@@ -114,8 +117,14 @@ module MRuby
     # so that a language server watching it does not reindex the tree after
     # a build that compiled nothing. The same database is written to more
     # than one path, so what it holds is worked out once.
+    #
+    # The directory is made where it is not there yet: before the first
+    # build, the build directory is not.
     def write(path)
-      File.write(path, json) unless File.exist?(path) && File.read(path) == json
+      return if File.exist?(path) && File.read(path) == json
+
+      FileUtils.mkdir_p File.dirname(path)
+      File.write(path, json)
     end
 
     # How many entries the database holds.
@@ -123,17 +132,27 @@ module MRuby
       entries.size
     end
 
-    # The entries for the objects this build has compiled, ordered by the
-    # source they compile so that two runs over the same build directory
-    # write the same file.
+    # The entries of the database, ordered by the source they compile so
+    # that two runs over the same build directory write the same file.
+    #
+    # The objects the rules declare come first, from the rules, and the
+    # objects the build directory holds besides come from their records.
+    # A declared object has a record too once it is compiled, and the two
+    # say the same thing: an object whose flags no longer match what its
+    # build would compile it with is removed and made again (see
+    # +Command::Compiler#discard_foreign_output+), so the record beside a
+    # declared object is always the rule's own account. The rule answers
+    # for it and the record is passed over.
     def entries
       @entries ||= begin
-        list = records.map { |outfile| entry(outfile) }.compact
+        list = objects.filter_map { |outfile| rule_entry(outfile) }
+        declared = list.to_h { |e| [e["output"], true] }
+        list.concat(records.reject { |o| declared[o] }.filter_map { |o| record_entry(o) })
         list.sort_by! { |e| [e["file"], e["output"]] }
-        # One source is compiled once here, but a build directory that holds
-        # a nested build keeps a record for each. The first is the one the
-        # sort settled on, and a database with two answers for a file has
-        # none.
+        # One source is compiled once here, but an object a rule no longer
+        # declares may sit beside the one it moved to. The first is the one
+        # the sort settled on, and a database with two answers for a file
+        # has none.
         list.uniq! { |e| e["file"] }
         list
       end
@@ -145,18 +164,71 @@ module MRuby
       @json ||= JSON.pretty_generate(entries) << "\n"
     end
 
+    # The objects this build compiles: those its products are made from, and
+    # the test objects of its gems. `rake test` compiles those by the rules
+    # the gems defined when the config was read, but the test driver that
+    # links them is a gem loaded only then, so no product reaches them.
+    def objects
+      objects = @build.objects
+      objects += @build.gems.flat_map(&:test_objs) if @build.test_enabled?
+      objects
+    end
+
+    # The entry for an object from the rule that compiles it, or nothing
+    # where no rule does or its source is not there. A source the build
+    # generates is not there before the build has run, and a database that
+    # answers for a file that is not there helps nobody.
+    def rule_entry(outfile)
+      compiler, source = @build.compile_of(outfile)
+      return nil unless compiler
+
+      entry(source, outfile) { compiler.compile_command(outfile, source) }
+    end
+
+    # The entry for an object from the record beside it, or nothing where
+    # the record cannot be read or no longer describes a compile that could
+    # be run. A source that has been renamed or deleted is still named by
+    # the records of the object it used to be compiled to, and answering
+    # for a file that is not there helps nobody.
+    def record_entry(outfile)
+      record = read_record("#{outfile}.flags")
+      return nil unless record
+      infile = source_of(outfile)
+      return nil unless infile
+
+      entry(infile, outfile) { command_line(record, infile, outfile) }
+    end
+
+    # The entry for +outfile+ compiled from +infile+, with the command line
+    # the block gives, or nothing where the source is not there.
+    #
+    # The rule and the record name the source the way the compile is given
+    # it, which is the name it has from the tree where the build compiles by
+    # those names. The command keeps that name, since it is the command that
+    # is run and `directory` says what it is written against, while `file`
+    # is answered in full: it is what a tool matches the file it has open
+    # against, and it has that one by its path.
+    def entry(infile, outfile)
+      path = File.absolute_path(infile, MRUBY_ROOT)
+      return nil unless File.exist?(path)
+
+      {
+        "directory" => MRUBY_ROOT,
+        "file" => path,
+        "command" => yield,
+        "output" => outfile,
+      }
+    end
+
     # The objects this build directory holds, named by the record beside
     # them.
     #
     # Every one of them is walked, and not only those the build has just
     # compiled or still declares. An entry earns its place by being true, not
-    # by having been built a moment ago: an object whose flags no longer match
-    # what its build would compile it with is removed and made again (see
-    # +Command::Compiler#discard_foreign_output+), so every object a build
-    # declares carries a record of how that build compiles it, and an object
-    # left behind by a gem the config has since dropped carries the last true
-    # account of how this tree compiled that source. The second is worth more
-    # to a language server than the nothing that dropping it would leave.
+    # by having been built a moment ago: an object left behind by a gem the
+    # config has since dropped carries the last true account of how this
+    # tree compiled that source, which is worth more to a language server
+    # than the nothing that dropping it would leave.
     #
     # An object that is gone answers for nothing, so its record is passed
     # over rather than believed.
@@ -172,37 +244,11 @@ module MRuby
       paths.map { |path| path.sub(/\.flags\z/, "") }.select { |o| File.exist?(o) }
     end
 
-    # The entry for an object, or nothing where the record cannot be read or
-    # no longer describes a compile that could be run. A source that has been
-    # renamed or deleted is still named by the records of the object it used
-    # to be compiled to, and answering for a file that is not there helps
-    # nobody.
-    def entry(outfile)
-      record = read_record("#{outfile}.flags")
-      return nil unless record
-      infile = source_of(outfile)
-      return nil unless infile
-      # The record and the dependency file name the source the way the compile
-      # was given it, which is the name it has from the tree where the build
-      # compiles by those names. The command keeps that name, since it is the
-      # command that was run and `directory` says what it was written against,
-      # while `file` is answered in full: it is what a tool matches the file it
-      # has open against, and it has that one by its path.
-      path = File.absolute_path(infile, MRUBY_ROOT)
-      return nil unless File.exist?(path)
-
-      {
-        "directory" => MRUBY_ROOT,
-        "file" => path,
-        "command" => command_line(record, infile, outfile),
-        "output" => outfile,
-      }
-    end
-
     # The command line of the compile, put back together the way
-    # +MRuby::Command#_run+ builds it. The record keeps the options apart
-    # from the flags they carry, and names neither file, so the two names
-    # come from the output the record sits beside and the source it read.
+    # +MRuby::Command#command_line+ builds it. The record keeps the options
+    # apart from the flags they carry, and names neither file, so the two
+    # names come from the output the record sits beside and the source it
+    # read.
     def command_line(record, infile, outfile)
       params = {
         :flags => record["flags"],

--- a/tasks/compile_commands.rake
+++ b/tasks/compile_commands.rake
@@ -1,18 +1,23 @@
 require_relative '../lib/mruby/compile_commands'
 
-# The database says what the compiles of the build were, so it is written
-# where the build ends. `:build` has prerequisites and no action of its own,
-# and Rake runs the prerequisites of a task before its actions, so this runs
-# once every product is up to date, whatever order the task files load in.
-task :build do
+# The database is written from the rules of the build, so it needs no build
+# to be written. Asking for it by name writes it and nothing else: a checkout
+# has its database before its first compile.
+desc "write the compile_commands.json of every build, without building"
+task "compile_commands.json" do
   MRuby::CompileCommands.write
 end
 
-# Asking for the database by name is asking for the build that writes it.
-desc "build, and write the compile_commands.json of the build"
-task "compile_commands.json" => :all
-
 task :compile_commands => "compile_commands.json"
+
+# A build writes it again as it ends, since the sources a build generates
+# join the database once they are there. `:build` has prerequisites and no
+# action of its own, and Rake runs the prerequisites of a task before its
+# actions, so this runs once every product is up to date, whatever order the
+# task files load in.
+task :build do
+  MRuby::CompileCommands.write
+end
 
 # The database is one of the things the build leaves behind, and it answers
 # for objects that are about to be gone. The one each build keeps of its own

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -1,15 +1,7 @@
-all_prerequisites = ->(task_name, prereqs) do
-  Rake::Task[task_name].prerequisites.each do |prereq_name|
-    next if prereqs[prereq_name]
-    prereqs[prereq_name] = true
-    all_prerequisites.(Rake::Task[prereq_name].name, prereqs)
-  end
-end
-
-# Every target first, before the walk below resolves a rule: the products of
-# one target reach the objects of another (a build reaches the mrbc build it
-# generated), and a rule resolved for those objects must see the same include
-# paths as the compile that follows it.
+# Every target first, before `build.objects` below resolves a rule: the
+# products of one target reach the objects of another (a build reaches the
+# mrbc build it generated), and a rule resolved for those objects must see
+# the same include paths as the compile that follows it.
 MRuby.each_target do |build|
   include_dir = "#{build.build_dir}/include"
   build.compilers.each{|c| c.include_paths << include_dir}
@@ -31,20 +23,9 @@ MRuby.each_target do |build|
 
   presym = build.presym
 
-  prereqs = {}
-  ppps = []
-  build_dir = "#{build.build_dir}/"
-  mrbc_build_dir = "#{build.mrbc_build.build_dir}/" if build.mrbc_build
-  build.products.each{|product| all_prerequisites.(product, prereqs)}
-  prereqs.each_key do |prereq|
-    next unless File.extname(prereq) == build.exts.object
-    next unless prereq.start_with?(build_dir)
-    next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
-    ppp = prereq.ext(build.exts.presym_preprocessed)
-    if Rake.application.lookup(ppp) ||
-       Rake.application.enhance_with_matching_rule(ppp)
-      ppps << ppp
-    end
+  objects = build.objects
+  ppps = objects.map { |obj| obj.ext(build.exts.presym_preprocessed) }.select do |ppp|
+    Rake.application.lookup(ppp) || Rake.application.enhance_with_matching_rule(ppp)
   end
 
   presym_task = file presym.list_path => ppps do
@@ -97,11 +78,8 @@ MRuby.each_target do |build|
   # build's presym scanning chain (before :gensym completes), e.g.:
   #   - internal sub-builds (mrbc) triggered by their parent build
   #   - the mrbc build generated for a cross build that has none to borrow
-  prereqs.each_key do |prereq|
-    next unless File.extname(prereq) == build.exts.object
-    next unless prereq.start_with?(build_dir)
-    next if mrbc_build_dir && prereq.start_with?(mrbc_build_dir)
-    file prereq => presym_proxy
+  objects.each do |obj|
+    file obj => presym_proxy
   end
 
   task gensym: presym.list_path


### PR DESCRIPTION
## Summary

The compilation database was written from the records the compiles leave beside their objects (#7395), so a checkout had none until it was built. A second worktree of the same tree, opened in an editor, paid a full build to be read, and nothing that build made was going to be run.

A rule says everything a compile is before it runs: which source the object is made from, with which compiler and with what flags. The database is written from the rules now. `rake compile_commands.json` builds nothing and writes it in well under a second, a fresh checkout has its database before its first compile, and the build directory is made for it where it is not there yet. The records keep answering for what no rule declares, the test driver `rake test` loads and the objects of a gem the config has since dropped, and a build still writes the database as it ends, since the sources it generates join it once they are there. Over one build directory the two say the same thing for every object both know: 258 entries after `rake test`, none differing.

## Changes

| File | What |
| --- | --- |
| `lib/mruby/build.rb` | `objects`, the walk `presym.rake` did over the prerequisites of the products, asked for by name; `compile_rules`, the rules `define_rules` keeps; `compile_of`, the compiler and the source of an output |
| `lib/mruby/build/command.rb` | `Command#command_line`, the line `_run` runs; `Compiler::Rule`, one per Rake rule `define_rules` defines; `compile_command`, the line a compile of an output runs; `run` shares `compile_invocation` with it |
| `lib/mruby/compile_commands.rb` | entries from the rules for the objects the build declares, from the records for the rest; the directory is made where it is not there yet |
| `tasks/compile_commands.rake` | `compile_commands.json` no longer depends on `all` |
| `tasks/presym.rake` | reads `build.objects` |
| `doc/guides/compile.md` | the paragraph on the database |

### The rules are kept

`define_rules` hands Rake a rule with a block, and Rake keeps the block and nothing else, so nothing could ask what a rule would compile without running it. Each rule is now kept beside its Rake rule as a `Compiler::Rule`: the pattern of the outputs it makes, the source it looks for beside one, and the compiler it compiles with. The source of an output is the one Rake resolved the rule to, the first prerequisite of the output's task and the one the rule hands `run`; the rule is known by that output and that source together, since the rules of a build differ in one or the other, and the compiler is the rule's.

The command line of a compile is put together in one place and can be asked for on its own. `run` and `compile_command` share `compile_invocation`, so what the build runs and what the database says it runs are one thing rather than two that agree.

### What no rule declares

The test objects of the gems are compiled by the rules the gems define when the config is read, and only the driver that links them, `mruby-test`, is a gem `rake test` loads after `all`. The database lists them from the start; what it cannot list before `rake test` are the driver's own sources and the generated `gem_test.c` of each gem, and those come from their records once they are there, as does an object left behind by a gem the config has since dropped. An object a rule declares has a record too once it is compiled, and the two say the same thing, since an object whose record no longer matches its rule is removed and made again (#7236); the rule answers for it and the record is passed over.

### The walk is the build's

`presym.rake` walked the prerequisites of every product to find the objects a build compiles, and was the only reader of that list. The walk is `Build#objects` now, Rake's own `all_prerequisite_tasks` under the same filter: the objects under the build directory, those of the `mrbc` build the build makes for itself left out. The presym list a fresh build writes is byte for byte the one it wrote before.

## Behaviour

- `rake compile_commands.json` builds nothing. It was `rake all` asked for by another name.
- Before the first build, the database holds every tracked source the config compiles: 152 entries for `build_config/default.rb`, 14 of them the `test/*.c` of the gems. A source the build generates, `mrblib.c` or a gem's `gem_init.c`, joins once the build has written it, and the build directory is created to hold the database.
- After a build, the database is what it was: the same entries, the same command lines, 258 of 258 after `rake test`.
- A build that has compiled nothing was skipped rather than handed an empty database; it is written now, since the rules give it entries.

## Speed

Wall clock of `rake`, `build_config/default.rb`, gcc, `CCACHE_DISABLE=1`, the same build directory path on both sides; base is c85303be2.

| | base | this PR |
| --- | ---: | ---: |
| `rake compile_commands.json`, empty build directory, three runs | 57.7 / 73.6 / 78.7 s | 1.00 / 1.01 / 1.05 s |
| `rake`, empty build directory | 59.2 s | 63.6 s |
| `rake` with nothing to do, five runs | 0.66 to 1.15 s | 0.84 to 0.91 s |

The first row is the point: the base builds the tree to write the database, this writes it. The other two are the full build and the no-op run, each of which writes the database as it ends, from the rules and the records now where it read the records alone; both sit inside the spread of the base's own runs.

## Size

Nothing compiled changes. Every one of the 183 objects of the default build but `src/version.o`, which carries the commit, has the same md5 on both sides, and `libmruby.a` and `bin/mruby` differ by that object alone.

## Testing

Every commit was built on its own and `prek run --all-files` passed at each, with `prettier --check` on `doc/guides/compile.md`. The first commit, which moves the walk out of `presym.rake`, was built from an empty directory and the presym list it wrote compared byte for byte with the one the branch head wrote. The numbers below are the branch head.

- host (`build_config/default.rb`), `rake -m test`: mrbtest 2,616 (OK 2,548 / Skip 68) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`), `rake -m test`: mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1); every build writes its database and the tree's copy is `full-debug`'s
- the base's `lib/mruby/compile_commands.rb` loaded beside this one under another name and both asked about the same build directory after `rake test`: 258 entries each, every `file` in both, every entry equal
- `rake compile_commands.json` in an empty build directory, with nothing built: `default.rb` 152 entries; `ci/gcc-clang.rb` seven databases (151 to 163 entries) and the tree's from `full-debug`; `boxing.rb` nine and the tree's from `boxing-word-m64-i64`; `host-debug.rb` 163; `cross-32bit.rb` 68; `cross-mingw.rb` 136; `gctest.rb` 73; `host-nofloat.rb` 136
- written twice over the same directory, the second run leaves the mtime alone; `MRUBY_CDB_TARGET=bogus` is refused as before
- a source touched after the build compiles once more through `run`, and the database the build then writes is the one it wrote before

## Environment

<details>
<summary>Host, compilers, and a compile line</summary>

| | |
| --- | --- |
| OS | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| Rake | 13.3.1 |

The entry for `mrbgems/mruby-array-ext/src/array.c` of `build_config/default.rb`, as `rake compile_commands.json` writes it into an empty build directory, and as the build then writes it again: the two are the same line. The entry names the tree and the build directory in full; they are written as `/home/takumi/mruby` and `/tmp/build` here, since the tree sits in a git worktree and the build directory under a longer name in `/tmp`.

```console
gcc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/mruby=." -ffile-prefix-map="/tmp/build=build" -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK -I"include" -I"/tmp/build/host/include" -o "/tmp/build/host/mrbgems/mruby-array-ext/src/array.o" "mrbgems/mruby-array-ext/src/array.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `compile_commands.json` can now be generated without building the project.
  - A compilation database is available from a fresh checkout and includes applicable compile commands.
  - Builds refresh the database afterward to include generated sources and additional compilation steps.

- **Documentation**
  - Updated guidance clarifies when the compilation database is generated and what the related tasks do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->