### PR TITLE
mruby-io: let the port say what it implements

### DIFF
--- a/doc/guides/mrbgems.md
+++ b/doc/guides/mrbgems.md
@@ -417,9 +417,9 @@ int mrb_hal_dir_chroot(mrb_state *mrb, const char *path);
 One macro guards the prototype, the port's implementation and the
 method definition in `src/`, so a port that declares a capability and
 forgets to implement it fails to link, and one that declares nothing
-owes nothing. `mruby-dir` carries such a header under
-`ports/posix/include/` and `ports/win/include/`, and its README lists
-what each declares.
+owes nothing. A bundled gem that carries such a header keeps it
+under `ports/posix/include/` and `ports/win/include/`, and its README
+lists what each port declares.
 
 Only `include/` is exported. A header anywhere else under
 `ports/<name>/` is the port's own, reached by its sources through a
@@ -438,8 +438,8 @@ the HAL header it serves, `<short>_hal_features.h` beside
 
 The macros are the port's to define and nobody else's. A build that
 wants less than the port offers uses the gem's veto define where the
-gem provides one, which the HAL header applies after the port has
-spoken; a build that defines an
+gem provides one (`MRB_NO_IO_POPEN` for `mruby-io`), which the HAL
+header applies after the port has spoken; a build that defines an
 `MRB_HAL_*_HAS_*` macro itself on a port that does not implement it
 gets an undefined `mrb_hal_*` at link time, which is the port's
 answer. A build that supplies the HAL from its own sources, with no

--- a/mrbgems/mruby-io/README.md
+++ b/mrbgems/mruby-io/README.md
@@ -185,17 +185,23 @@ not declare has no method at all rather than one that fails, and
 `respond_to?` answers false. A port that declares a capability it does not
 implement fails to link.
 
-| macro                         | methods                         | posix             | win |
-| ----------------------------- | ------------------------------- | ----------------- | --- |
-| `MRB_HAL_IO_HAS_SYMLINK`      | `File.symlink`, `File.readlink` | o                 |     |
-| `MRB_HAL_IO_HAS_FLOCK`        | `File#flock`                    | o, not on Solaris | o   |
-| `MRB_HAL_IO_HAS_STAT_FIFO`    | `FileTest.pipe?`                | o                 |     |
-| `MRB_HAL_IO_HAS_STAT_SYMLINK` | `FileTest.symlink?`             | o                 |     |
-| `MRB_HAL_IO_HAS_STAT_SOCKET`  | `FileTest.socket?`              | o                 |     |
+| macro                          | methods                         | posix             | win |
+| ------------------------------ | ------------------------------- | ----------------- | --- |
+| `MRB_HAL_IO_HAS_SYMLINK`       | `File.symlink`, `File.readlink` | o                 |     |
+| `MRB_HAL_IO_HAS_FLOCK`         | `File#flock`                    | o, not on Solaris | o   |
+| `MRB_HAL_IO_HAS_STAT_FIFO`     | `FileTest.pipe?`                | o                 |     |
+| `MRB_HAL_IO_HAS_STAT_SYMLINK`  | `FileTest.symlink?`             | o                 |     |
+| `MRB_HAL_IO_HAS_STAT_SOCKET`   | `FileTest.socket?`              | o                 |     |
+| `MRB_HAL_IO_HAS_SPAWN_PROCESS` | `IO.popen`                      | o, not on iOS     | o   |
 
 The three `STAT` macros name no port function. They say which file kinds the
 `st_mode` from `mrb_hal_io_stat()` can hold, and the predicate each guards
 reads that kind through the `MRB_IO_S_IS*` macros of `io_hal.h`.
+
+`MRB_NO_IO_POPEN` is a build's veto: a configuration that defines it gets the
+gem without `IO.popen` whatever the port could do, `io_hal.h` undefining
+`MRB_HAL_IO_HAS_SPAWN_PROCESS` after the port has spoken. Either way `IO.popen`
+raises `NotImplementedError` and `IO.respond_to?(:_popen)` answers false.
 
 ## License
 

--- a/mrbgems/mruby-io/README.md
+++ b/mrbgems/mruby-io/README.md
@@ -174,6 +174,21 @@ Add the line below to your build configuration.
 If your (non Windows) platform does not support `getpwnam(3)` for some reason, define `MRB_IO_NO_PWNAM`.
 See [mruby#5358](https://github.com/mruby/mruby/issues/5358).
 
+## What the port declares
+
+Whether a method exists is the port's to say, since the port is what a build
+names and a `hal-io-<conf>` gem may stand in for the bundled ones. Each port
+publishes an `io_hal_features.h` in its `include/`, which
+`include/io_hal.h` reads before it declares anything. One macro there guards the prototype, the
+port's implementation and the method definition, so a capability the port does
+not declare has no method at all rather than one that fails, and
+`respond_to?` answers false. A port that declares a capability it does not
+implement fails to link.
+
+| macro                    | methods                         | posix | win |
+| ------------------------ | ------------------------------- | ----- | --- |
+| `MRB_HAL_IO_HAS_SYMLINK` | `File.symlink`, `File.readlink` | o     |     |
+
 ## License
 
 Copyright (c) 2013 Internet Initiative Japan Inc.

--- a/mrbgems/mruby-io/README.md
+++ b/mrbgems/mruby-io/README.md
@@ -185,10 +185,17 @@ not declare has no method at all rather than one that fails, and
 `respond_to?` answers false. A port that declares a capability it does not
 implement fails to link.
 
-| macro                    | methods                         | posix             | win |
-| ------------------------ | ------------------------------- | ----------------- | --- |
-| `MRB_HAL_IO_HAS_SYMLINK` | `File.symlink`, `File.readlink` | o                 |     |
-| `MRB_HAL_IO_HAS_FLOCK`   | `File#flock`                    | o, not on Solaris | o   |
+| macro                         | methods                         | posix             | win |
+| ----------------------------- | ------------------------------- | ----------------- | --- |
+| `MRB_HAL_IO_HAS_SYMLINK`      | `File.symlink`, `File.readlink` | o                 |     |
+| `MRB_HAL_IO_HAS_FLOCK`        | `File#flock`                    | o, not on Solaris | o   |
+| `MRB_HAL_IO_HAS_STAT_FIFO`    | `FileTest.pipe?`                | o                 |     |
+| `MRB_HAL_IO_HAS_STAT_SYMLINK` | `FileTest.symlink?`             | o                 |     |
+| `MRB_HAL_IO_HAS_STAT_SOCKET`  | `FileTest.socket?`              | o                 |     |
+
+The three `STAT` macros name no port function. They say which file kinds the
+`st_mode` from `mrb_hal_io_stat()` can hold, and the predicate each guards
+reads that kind through the `MRB_IO_S_IS*` macros of `io_hal.h`.
 
 ## License
 

--- a/mrbgems/mruby-io/README.md
+++ b/mrbgems/mruby-io/README.md
@@ -185,9 +185,10 @@ not declare has no method at all rather than one that fails, and
 `respond_to?` answers false. A port that declares a capability it does not
 implement fails to link.
 
-| macro                    | methods                         | posix | win |
-| ------------------------ | ------------------------------- | ----- | --- |
-| `MRB_HAL_IO_HAS_SYMLINK` | `File.symlink`, `File.readlink` | o     |     |
+| macro                    | methods                         | posix             | win |
+| ------------------------ | ------------------------------- | ----------------- | --- |
+| `MRB_HAL_IO_HAS_SYMLINK` | `File.symlink`, `File.readlink` | o                 |     |
+| `MRB_HAL_IO_HAS_FLOCK`   | `File#flock`                    | o, not on Solaris | o   |
 
 ## License
 

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -13,6 +13,18 @@
 
 #include <mruby.h>
 
+/*
+ * What the port implements
+ *
+ * The port publishes it in a header under its include/, and the build puts
+ * that directory on the include path of this gem and of every gem that
+ * depends on it.  Whether a method exists is the port's to say, because the
+ * port is what a build names: a cross build has no host to detect one from,
+ * and a `hal-io-<conf>` gem may stand in for the bundled ports altogether.
+ * What each macro says, and what it guards, is written where it is defined.
+ */
+#include "io_hal_features.h"
+
 MRB_BEGIN_DECL
 
 /*
@@ -171,6 +183,7 @@ int mrb_hal_io_unlink(mrb_state *mrb, const char *path);
  */
 int mrb_hal_io_rename(mrb_state *mrb, const char *oldpath, const char *newpath);
 
+#ifdef MRB_HAL_IO_HAS_SYMLINK
 /**
  * Create a symbolic link
  *
@@ -191,6 +204,7 @@ int mrb_hal_io_symlink(mrb_state *mrb, const char *target, const char *linkpath)
  * @return Number of bytes placed in buf, -1 on error (sets errno)
  */
 mrb_int mrb_hal_io_readlink(mrb_state *mrb, const char *path, char *buf, size_t bufsize);
+#endif /* MRB_HAL_IO_HAS_SYMLINK */
 
 /**
  * Resolve pathname to absolute path

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -22,8 +22,15 @@
  * port is what a build names: a cross build has no host to detect one from,
  * and a `hal-io-<conf>` gem may stand in for the bundled ports altogether.
  * What each macro says, and what it guards, is written where it is defined.
+ *
+ * MRB_NO_IO_POPEN is a build's veto over process creation: a configuration
+ * that defines it gets a gem with no `IO.popen` whatever the port could do.
  */
 #include "io_hal_features.h"
+
+#ifdef MRB_NO_IO_POPEN
+# undef MRB_HAL_IO_HAS_SPAWN_PROCESS
+#endif
 
 MRB_BEGIN_DECL
 
@@ -373,6 +380,7 @@ int mrb_hal_io_pipe(mrb_state *mrb, int fds[2]);
  * HAL Interface - Process Operations
  */
 
+#ifdef MRB_HAL_IO_HAS_SPAWN_PROCESS
 /**
  * Spawn a new process
  *
@@ -395,15 +403,24 @@ int mrb_hal_io_spawn_process(mrb_state *mrb, const char *cmd,
                                int *pid);
 
 /**
- * Wait for process to change state
+ * Wait for a process mrb_hal_io_spawn_process() started
+ *
+ * The pid is the one that function handed out, whatever it stands for on
+ * this port (a process ID on POSIX, a process handle on Windows): the gem
+ * never reads it, and the port owes it the wait and whatever release it
+ * needs afterwards. The status is the host's raw wait status, the value
+ * WEXITSTATUS() reads on this host and the one Process::Status is built
+ * from; on Windows that is the exit code itself. A wait a signal cut short
+ * returns -1 with errno EINTR, and the gem retries it as it does a read.
  *
  * @param mrb mruby state
  * @param pid Process ID to wait for
- * @param status Output parameter for exit status
+ * @param status Output parameter for the raw wait status
  * @param options Wait options (0 for blocking wait)
  * @return Process ID on success, -1 on error (sets errno)
  */
 int mrb_hal_io_waitpid(mrb_state *mrb, int pid, int *status, int options);
+#endif /* MRB_HAL_IO_HAS_SPAWN_PROCESS */
 
 /*
  * HAL Interface - I/O Multiplexing

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -58,7 +58,18 @@ typedef struct mrb_io_timeval {
 typedef struct mrb_io_fdset mrb_io_fdset;
 
 /*
- * File mode constants (POSIX-style)
+ * File mode
+ *
+ * The encoding of mrb_io_stat's st_mode, and of the mode `File.chmod`,
+ * `File.umask` and the creation mode of mrb_hal_io_open() hand down.  These
+ * numbers are the HAL's own: POSIX fixes the names S_IFMT, S_IFLNK, S_IRUSR
+ * and the rest, and the S_IS*() macros that read them, but not the values
+ * behind any of them.  So a port tests the host's mode with the host's own
+ * macros and writes the answer in these terms, and maps them back for a
+ * mode handed down; the gem above reads and writes nothing else.  The
+ * permission bits are the numbers a Ruby program writes, as in
+ * File.chmod(0644, path), so the language fixes them, and a port whose host
+ * numbers them otherwise maps them in both directions.
  */
 
 /* File type masks */
@@ -79,6 +90,23 @@ typedef struct mrb_io_fdset mrb_io_fdset;
 #define MRB_IO_S_ISFIFO(m) (((m) & MRB_IO_S_IFMT) == MRB_IO_S_IFIFO)
 #define MRB_IO_S_ISLNK(m)  (((m) & MRB_IO_S_IFMT) == MRB_IO_S_IFLNK)
 #define MRB_IO_S_ISSOCK(m) (((m) & MRB_IO_S_IFMT) == MRB_IO_S_IFSOCK)
+
+/* Permission bits */
+#define MRB_IO_S_ISUID  0004000  /* Set user ID on execution */
+#define MRB_IO_S_ISGID  0002000  /* Set group ID on execution */
+#define MRB_IO_S_ISVTX  0001000  /* Restricted deletion (sticky) */
+#define MRB_IO_S_IRWXU  0000700  /* Read, write, execute by owner */
+#define MRB_IO_S_IRUSR  0000400  /* Read by owner */
+#define MRB_IO_S_IWUSR  0000200  /* Write by owner */
+#define MRB_IO_S_IXUSR  0000100  /* Execute by owner */
+#define MRB_IO_S_IRWXG  0000070  /* Read, write, execute by group */
+#define MRB_IO_S_IRGRP  0000040  /* Read by group */
+#define MRB_IO_S_IWGRP  0000020  /* Write by group */
+#define MRB_IO_S_IXGRP  0000010  /* Execute by group */
+#define MRB_IO_S_IRWXO  0000007  /* Read, write, execute by others */
+#define MRB_IO_S_IROTH  0000004  /* Read by others */
+#define MRB_IO_S_IWOTH  0000002  /* Write by others */
+#define MRB_IO_S_IXOTH  0000001  /* Execute by others */
 
 /* File lock constants */
 #define MRB_IO_LOCK_SH 1  /* Shared lock */
@@ -256,7 +284,7 @@ const char* mrb_hal_io_gethome(mrb_state *mrb, const char *username);
  * @param mrb mruby state
  * @param path File path (UTF-8)
  * @param flags Open flags (O_RDONLY, O_WRONLY, O_RDWR, etc.)
- * @param mode Creation mode (used if O_CREAT is set)
+ * @param mode Creation mode (used if O_CREAT is set), in the MRB_IO_S_I* bits
  * @return File descriptor on success, -1 on error (sets errno)
  */
 int mrb_hal_io_open(mrb_state *mrb, const char *path, int flags, mrb_int mode);

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -154,6 +154,7 @@ mrb_int mrb_hal_io_umask(mrb_state *mrb, mrb_int mask);
  */
 int mrb_hal_io_ftruncate(mrb_state *mrb, int fd, mrb_int length);
 
+#ifdef MRB_HAL_IO_HAS_FLOCK
 /**
  * Apply or remove advisory lock on file
  *
@@ -163,6 +164,7 @@ int mrb_hal_io_ftruncate(mrb_state *mrb, int fd, mrb_int length);
  * @return 0 on success, -1 on error (sets errno)
  */
 int mrb_hal_io_flock(mrb_state *mrb, int fd, int operation);
+#endif /* MRB_HAL_IO_HAS_FLOCK */
 
 /**
  * Delete a file

--- a/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
@@ -30,4 +30,13 @@
 #define MRB_HAL_IO_HAS_STAT_SYMLINK
 #define MRB_HAL_IO_HAS_STAT_SOCKET
 
+/* fork(2) and execl(3), and waitpid(2) for the child: `IO.popen`.  iOS
+   lets no process run another, whatever the configuration asks for. */
+#if defined(__APPLE__)
+# include <TargetConditionals.h>
+#endif
+#if !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+# define MRB_HAL_IO_HAS_SPAWN_PROCESS
+#endif
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
@@ -1,0 +1,19 @@
+/*
+** io_hal_features.h - what the POSIX port of mruby-io implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/io_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in io_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_IO_HAL_FEATURES_H
+#define MRUBY_IO_HAL_FEATURES_H
+
+/* symlink(2) and readlink(2): `File.symlink` and `File.readlink`. */
+#define MRB_HAL_IO_HAS_SYMLINK
+
+#endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
@@ -16,4 +16,9 @@
 /* symlink(2) and readlink(2): `File.symlink` and `File.readlink`. */
 #define MRB_HAL_IO_HAS_SYMLINK
 
+/* flock(2): `File#flock`.  Solaris and Illumos have no flock(2). */
+#if !defined(sun) && !defined(__sun)
+# define MRB_HAL_IO_HAS_FLOCK
+#endif
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/posix/include/io_hal_features.h
@@ -21,4 +21,13 @@
 # define MRB_HAL_IO_HAS_FLOCK
 #endif
 
+/* The file kinds mrb_hal_io_stat() and mrb_hal_io_lstat() can name in
+   st_mode, beyond a regular file and a directory: `FileTest.pipe?`,
+   `FileTest.symlink?` and `FileTest.socket?`.  Each guards the predicate
+   that reads the kind, and the arm that writes it where io_hal.c maps
+   the kinds one by one. */
+#define MRB_HAL_IO_HAS_STAT_FIFO
+#define MRB_HAL_IO_HAS_STAT_SYMLINK
+#define MRB_HAL_IO_HAS_STAT_SOCKET
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/posix/io_hal.c
+++ b/mrbgems/mruby-io/ports/posix/io_hal.c
@@ -37,6 +37,61 @@
  * Helper Functions
  */
 
+/* POSIX requires the file type constants to be usable in `#if`, so whether
+   this host numbers the type as the HAL does is settled here rather than
+   assumed.  Where it does, the field carries across as it is; where it does
+   not, the kind is tested with the S_IS*() macros, which are what POSIX
+   actually guarantees.  Neither host pays for the other. */
+#if defined(S_IFMT)   && S_IFMT   == MRB_IO_S_IFMT   && \
+    defined(S_IFREG)  && S_IFREG  == MRB_IO_S_IFREG  && \
+    defined(S_IFDIR)  && S_IFDIR  == MRB_IO_S_IFDIR  && \
+    defined(S_IFCHR)  && S_IFCHR  == MRB_IO_S_IFCHR  && \
+    defined(S_IFBLK)  && S_IFBLK  == MRB_IO_S_IFBLK  && \
+    defined(S_IFIFO)  && S_IFIFO  == MRB_IO_S_IFIFO  && \
+    defined(S_IFLNK)  && S_IFLNK  == MRB_IO_S_IFLNK  && \
+    defined(S_IFSOCK) && S_IFSOCK == MRB_IO_S_IFSOCK
+# define MRB_IO_TYPE_IS_HAL_TYPE
+#endif
+
+/* The permission bits, this host's to the HAL's.  POSIX names them and
+   leaves the numbers to the implementation, so each is read by name; where
+   the two agree, as they do here, the compiler folds this to a mask. */
+static mrb_int
+perm_to_hal(mode_t m)
+{
+  return ((m & S_ISUID) ? MRB_IO_S_ISUID : 0) |
+         ((m & S_ISGID) ? MRB_IO_S_ISGID : 0) |
+         ((m & S_ISVTX) ? MRB_IO_S_ISVTX : 0) |
+         ((m & S_IRUSR) ? MRB_IO_S_IRUSR : 0) |
+         ((m & S_IWUSR) ? MRB_IO_S_IWUSR : 0) |
+         ((m & S_IXUSR) ? MRB_IO_S_IXUSR : 0) |
+         ((m & S_IRGRP) ? MRB_IO_S_IRGRP : 0) |
+         ((m & S_IWGRP) ? MRB_IO_S_IWGRP : 0) |
+         ((m & S_IXGRP) ? MRB_IO_S_IXGRP : 0) |
+         ((m & S_IROTH) ? MRB_IO_S_IROTH : 0) |
+         ((m & S_IWOTH) ? MRB_IO_S_IWOTH : 0) |
+         ((m & S_IXOTH) ? MRB_IO_S_IXOTH : 0);
+}
+
+/* The same the other way, for a mode handed down from Ruby */
+static mode_t
+perm_from_hal(mrb_int m)
+{
+  return (mode_t)
+         (((m & MRB_IO_S_ISUID) ? S_ISUID : 0) |
+          ((m & MRB_IO_S_ISGID) ? S_ISGID : 0) |
+          ((m & MRB_IO_S_ISVTX) ? S_ISVTX : 0) |
+          ((m & MRB_IO_S_IRUSR) ? S_IRUSR : 0) |
+          ((m & MRB_IO_S_IWUSR) ? S_IWUSR : 0) |
+          ((m & MRB_IO_S_IXUSR) ? S_IXUSR : 0) |
+          ((m & MRB_IO_S_IRGRP) ? S_IRGRP : 0) |
+          ((m & MRB_IO_S_IWGRP) ? S_IWGRP : 0) |
+          ((m & MRB_IO_S_IXGRP) ? S_IXGRP : 0) |
+          ((m & MRB_IO_S_IROTH) ? S_IROTH : 0) |
+          ((m & MRB_IO_S_IWOTH) ? S_IWOTH : 0) |
+          ((m & MRB_IO_S_IXOTH) ? S_IXOTH : 0));
+}
+
 /* Convert POSIX struct stat to mrb_io_stat */
 static void
 convert_stat(const struct stat *src, mrb_io_stat *dst)
@@ -69,7 +124,34 @@ convert_stat(const struct stat *src, mrb_io_stat *dst)
 
   dst->st_dev = (mrb_int)src->st_dev;
   dst->st_ino = (mrb_int)src->st_ino;
-  dst->st_mode = (mrb_int)src->st_mode;
+  /* The kind is written in the HAL's terms; a kind this host cannot name
+     leaves the type empty, which every MRB_IO_S_IS* reads as false. */
+  dst->st_mode = perm_to_hal(src->st_mode);
+#ifdef MRB_IO_TYPE_IS_HAL_TYPE
+  dst->st_mode |= (mrb_int)(src->st_mode & S_IFMT);
+#else
+  if (S_ISREG(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFREG;
+  }
+  else if (S_ISDIR(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFDIR;
+  }
+  else if (S_ISCHR(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFCHR;
+  }
+  else if (S_ISBLK(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFBLK;
+  }
+  else if (S_ISFIFO(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFIFO;
+  }
+  else if (S_ISLNK(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFLNK;
+  }
+  else if (S_ISSOCK(src->st_mode)) {
+    dst->st_mode |= MRB_IO_S_IFSOCK;
+  }
+#endif /* MRB_IO_TYPE_IS_HAL_TYPE */
   dst->st_nlink = (mrb_int)src->st_nlink;
   dst->st_uid = (mrb_int)src->st_uid;
   dst->st_gid = (mrb_int)src->st_gid;
@@ -138,7 +220,7 @@ int
 mrb_hal_io_chmod(mrb_state *mrb, const char *path, mrb_int mode)
 {
   (void)mrb;
-  return chmod(path, (mode_t)mode);
+  return chmod(path, perm_from_hal(mode));
 }
 
 mrb_int
@@ -153,9 +235,9 @@ mrb_hal_io_umask(mrb_state *mrb, mrb_int mask)
     umask(old);
   }
   else {
-    old = umask((mode_t)mask);
+    old = umask(perm_from_hal(mask));
   }
-  return (mrb_int)old;
+  return perm_to_hal(old);
 }
 
 int
@@ -268,7 +350,7 @@ mrb_hal_io_open(mrb_state *mrb, const char *path, int flags, mrb_int mode)
   int fd;
   (void)mrb;
 
-  fd = open(path, flags, (mode_t)mode);
+  fd = open(path, flags, perm_from_hal(mode));
   if (fd == -1) {
     return -1;
   }

--- a/mrbgems/mruby-io/ports/posix/io_hal.c
+++ b/mrbgems/mruby-io/ports/posix/io_hal.c
@@ -124,8 +124,9 @@ convert_stat(const struct stat *src, mrb_io_stat *dst)
 
   dst->st_dev = (mrb_int)src->st_dev;
   dst->st_ino = (mrb_int)src->st_ino;
-  /* The kind is written in the HAL's terms; a kind this host cannot name
-     leaves the type empty, which every MRB_IO_S_IS* reads as false. */
+  /* The kind is written in the HAL's terms.  What the gem may read of it
+     is the port's declaration; where the kinds are mapped one by one, a
+     kind the port does not declare is not written either. */
   dst->st_mode = perm_to_hal(src->st_mode);
 #ifdef MRB_IO_TYPE_IS_HAL_TYPE
   dst->st_mode |= (mrb_int)(src->st_mode & S_IFMT);
@@ -142,15 +143,21 @@ convert_stat(const struct stat *src, mrb_io_stat *dst)
   else if (S_ISBLK(src->st_mode)) {
     dst->st_mode |= MRB_IO_S_IFBLK;
   }
+#ifdef MRB_HAL_IO_HAS_STAT_FIFO
   else if (S_ISFIFO(src->st_mode)) {
     dst->st_mode |= MRB_IO_S_IFIFO;
   }
+#endif
+#ifdef MRB_HAL_IO_HAS_STAT_SYMLINK
   else if (S_ISLNK(src->st_mode)) {
     dst->st_mode |= MRB_IO_S_IFLNK;
   }
+#endif
+#ifdef MRB_HAL_IO_HAS_STAT_SOCKET
   else if (S_ISSOCK(src->st_mode)) {
     dst->st_mode |= MRB_IO_S_IFSOCK;
   }
+#endif
 #endif /* MRB_IO_TYPE_IS_HAL_TYPE */
   dst->st_nlink = (mrb_int)src->st_nlink;
   dst->st_uid = (mrb_int)src->st_uid;

--- a/mrbgems/mruby-io/ports/posix/io_hal.c
+++ b/mrbgems/mruby-io/ports/posix/io_hal.c
@@ -193,6 +193,7 @@ mrb_hal_io_rename(mrb_state *mrb, const char *oldpath, const char *newpath)
   return rename(oldpath, newpath);
 }
 
+#ifdef MRB_HAL_IO_HAS_SYMLINK
 int
 mrb_hal_io_symlink(mrb_state *mrb, const char *target, const char *linkpath)
 {
@@ -206,6 +207,7 @@ mrb_hal_io_readlink(mrb_state *mrb, const char *path, char *buf, size_t bufsize)
   (void)mrb;
   return (mrb_int)readlink(path, buf, bufsize);
 }
+#endif /* MRB_HAL_IO_HAS_SYMLINK */
 
 char*
 mrb_hal_io_realpath(mrb_state *mrb, const char *path, char *resolved)

--- a/mrbgems/mruby-io/ports/posix/io_hal.c
+++ b/mrbgems/mruby-io/ports/posix/io_hal.c
@@ -481,6 +481,7 @@ mrb_hal_io_pipe(mrb_state *mrb, int fds[2])
  * Process Operations
  */
 
+#ifdef MRB_HAL_IO_HAS_SPAWN_PROCESS
 int
 mrb_hal_io_spawn_process(mrb_state *mrb, const char *cmd,
                           int stdin_fd, int stdout_fd, int stderr_fd,
@@ -563,6 +564,7 @@ mrb_hal_io_waitpid(mrb_state *mrb, int pid, int *status, int options)
 
   return (int)result;
 }
+#endif /* MRB_HAL_IO_HAS_SPAWN_PROCESS */
 
 /*
  * I/O Multiplexing

--- a/mrbgems/mruby-io/ports/posix/io_hal.c
+++ b/mrbgems/mruby-io/ports/posix/io_hal.c
@@ -165,6 +165,7 @@ mrb_hal_io_ftruncate(mrb_state *mrb, int fd, mrb_int length)
   return ftruncate(fd, (off_t)length);
 }
 
+#ifdef MRB_HAL_IO_HAS_FLOCK
 int
 mrb_hal_io_flock(mrb_state *mrb, int fd, int operation)
 {
@@ -178,6 +179,7 @@ mrb_hal_io_flock(mrb_state *mrb, int fd, int operation)
   }
   return 0;
 }
+#endif /* MRB_HAL_IO_HAS_FLOCK */
 
 int
 mrb_hal_io_unlink(mrb_state *mrb, const char *path)

--- a/mrbgems/mruby-io/ports/win/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/win/include/io_hal_features.h
@@ -1,0 +1,20 @@
+/*
+** io_hal_features.h - what the Windows port of mruby-io implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/io_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in io_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_IO_HAL_FEATURES_H
+#define MRUBY_IO_HAL_FEATURES_H
+
+/* No symbolic links: creating one needs a privilege a process cannot count
+   on, so `File.symlink` and `File.readlink` are left undefined rather than
+   defined to fail. */
+
+#endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/win/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/win/include/io_hal_features.h
@@ -25,4 +25,7 @@
    one), no symbolic link, no socket.  `FileTest.pipe?`, `.symlink?` and
    `.socket?` are left undefined rather than defined to answer wrongly. */
 
+/* CreateProcess(), and WaitForSingleObject() for the child: `IO.popen`. */
+#define MRB_HAL_IO_HAS_SPAWN_PROCESS
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/win/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/win/include/io_hal_features.h
@@ -20,4 +20,9 @@
 /* LockFileEx() stands in for flock(2): `File#flock`. */
 #define MRB_HAL_IO_HAS_FLOCK
 
+/* The st_mode _stat64() fills names a regular file, a directory or a
+   character device and nothing else: no FIFO (an anonymous pipe is not
+   one), no symbolic link, no socket.  `FileTest.pipe?`, `.symlink?` and
+   `.socket?` are left undefined rather than defined to answer wrongly. */
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/win/include/io_hal_features.h
+++ b/mrbgems/mruby-io/ports/win/include/io_hal_features.h
@@ -17,4 +17,7 @@
    on, so `File.symlink` and `File.readlink` are left undefined rather than
    defined to fail. */
 
+/* LockFileEx() stands in for flock(2): `File#flock`. */
+#define MRB_HAL_IO_HAS_FLOCK
+
 #endif /* MRUBY_IO_HAL_FEATURES_H */

--- a/mrbgems/mruby-io/ports/win/io_hal.c
+++ b/mrbgems/mruby-io/ports/win/io_hal.c
@@ -30,13 +30,54 @@
  * Helper Functions
  */
 
+/* The permission bits, this host's to the HAL's.  The C runtime names
+   three, _S_IREAD, _S_IWRITE and _S_IEXEC, and they are the owner's.
+   _stat() reports all three, _S_IEXEC from the file's extension, while
+   _chmod(), _umask() and _open() read _S_IREAD and _S_IWRITE and no others,
+   so a mode handed down is read for its owner read and write bits alone.
+   `File.umask(0022)` must leave the owner writing; collapsing any write bit
+   into _S_IWRITE would hand _umask() the one bit that takes writing away.
+   What _stat() reports for group and other is a mirror of the owner's,
+   which convert_stat() makes for itself. */
+static mrb_int
+perm_to_hal(unsigned short m)
+{
+  return ((m & _S_IREAD)  ? MRB_IO_S_IRUSR : 0) |
+         ((m & _S_IWRITE) ? MRB_IO_S_IWUSR : 0) |
+         ((m & _S_IEXEC)  ? MRB_IO_S_IXUSR : 0);
+}
+
+/* The same the other way, for a mode handed down from Ruby.  No _S_IEXEC:
+   none of the three that take a mode reads it, and _open() is documented
+   to refuse a mode with anything beyond the two. */
+static int
+perm_from_hal(mrb_int m)
+{
+  return ((m & MRB_IO_S_IRUSR) ? _S_IREAD  : 0) |
+         ((m & MRB_IO_S_IWUSR) ? _S_IWRITE : 0);
+}
+
 /* Convert Windows struct _stat64 to mrb_io_stat */
 static void
 convert_stat(const struct _stat64 *src, mrb_io_stat *dst)
 {
   dst->st_dev = (mrb_int)src->st_dev;
   dst->st_ino = (mrb_int)src->st_ino;
-  dst->st_mode = (mrb_int)src->st_mode;
+  /* The kind is tested with the runtime's own names and written in the
+     HAL's terms; _stat64() names a regular file, a directory and a
+     character device and nothing else, and a kind it cannot name leaves
+     the type empty, which every MRB_IO_S_IS* reads as false. */
+  dst->st_mode = perm_to_hal(src->st_mode);
+  dst->st_mode |= (dst->st_mode >> 3) | (dst->st_mode >> 6);
+  if ((src->st_mode & _S_IFMT) == _S_IFREG) {
+    dst->st_mode |= MRB_IO_S_IFREG;
+  }
+  else if ((src->st_mode & _S_IFMT) == _S_IFDIR) {
+    dst->st_mode |= MRB_IO_S_IFDIR;
+  }
+  else if ((src->st_mode & _S_IFMT) == _S_IFCHR) {
+    dst->st_mode |= MRB_IO_S_IFCHR;
+  }
   dst->st_nlink = (mrb_int)src->st_nlink;
   dst->st_uid = 0;  /* Windows doesn't have Unix-style UIDs */
   dst->st_gid = 0;  /* Windows doesn't have Unix-style GIDs */
@@ -117,7 +158,7 @@ int
 mrb_hal_io_chmod(mrb_state *mrb, const char *path, mrb_int mode)
 {
   (void)mrb;
-  return _chmod(path, (int)mode);
+  return _chmod(path, perm_from_hal(mode));
 }
 
 mrb_int
@@ -132,9 +173,9 @@ mrb_hal_io_umask(mrb_state *mrb, mrb_int mask)
     _umask(old);
   }
   else {
-    old = _umask((int)mask);
+    old = _umask(perm_from_hal(mask));
   }
-  return (mrb_int)old;
+  return perm_to_hal((unsigned short)old);
 }
 
 int
@@ -270,7 +311,7 @@ mrb_hal_io_open(mrb_state *mrb, const char *path, int flags, mrb_int mode)
      mode itself (it adds O_BINARY only for a "b" mode), so forcing
      _O_BINARY here would override that and break the text-mode CRLF
      handling that IO#gets and friends rely on. */
-  fd = _open(path, flags, (int)mode);
+  fd = _open(path, flags, perm_from_hal(mode));
   if (fd == -1) {
     return -1;
   }

--- a/mrbgems/mruby-io/ports/win/io_hal.c
+++ b/mrbgems/mruby-io/ports/win/io_hal.c
@@ -520,6 +520,7 @@ mrb_hal_io_pipe(mrb_state *mrb, int fds[2])
  * Process Operations
  */
 
+#ifdef MRB_HAL_IO_HAS_SPAWN_PROCESS
 int
 mrb_hal_io_spawn_process(mrb_state *mrb, const char *cmd,
                           int stdin_fd, int stdout_fd, int stderr_fd,
@@ -616,27 +617,32 @@ mrb_hal_io_waitpid(mrb_state *mrb, int pid, int *status, int options)
     return 0;  /* Non-blocking wait, no change */
   }
 
+  /* A -1 is final to the caller, which drops the pid, so the handle goes
+     with it either way. */
   if (wait_result != WAIT_OBJECT_0) {
     set_errno_from_win_error(GetLastError());
+    CloseHandle(h);
     return -1;
   }
 
-  /* Get exit code */
   if (!GetExitCodeProcess(h, &exit_code)) {
     set_errno_from_win_error(GetLastError());
+    CloseHandle(h);
     return -1;
   }
 
   if (status != NULL) {
-    /* Store exit code in status (shifted to match Unix convention) */
-    *status = (int)(exit_code << 8);
+    /* The raw status on this host is the exit code itself: io.c reads it
+       through a WEXITSTATUS() that is the identity here, and the Windows
+       port of mruby-process decodes it the same way. */
+    *status = (int)exit_code;
   }
 
-  /* Close process handle */
   CloseHandle(h);
 
   return pid;
 }
+#endif /* MRB_HAL_IO_HAS_SPAWN_PROCESS */
 
 /*
  * I/O Multiplexing

--- a/mrbgems/mruby-io/ports/win/io_hal.c
+++ b/mrbgems/mruby-io/ports/win/io_hal.c
@@ -197,27 +197,6 @@ mrb_hal_io_rename(mrb_state *mrb, const char *oldpath, const char *newpath)
   return rename(oldpath, newpath);
 }
 
-int
-mrb_hal_io_symlink(mrb_state *mrb, const char *target, const char *linkpath)
-{
-  (void)target;
-  (void)linkpath;
-  /* Symlinks require special privileges on Windows */
-  mrb_raise(mrb, E_NOTIMP_ERROR, "symlink is not supported on Windows");
-  return -1;  /* not reached */
-}
-
-mrb_int
-mrb_hal_io_readlink(mrb_state *mrb, const char *path, char *buf, size_t bufsize)
-{
-  (void)path;
-  (void)buf;
-  (void)bufsize;
-  /* Symlinks require special handling on Windows */
-  mrb_raise(mrb, E_NOTIMP_ERROR, "readlink is not supported on Windows");
-  return -1;  /* not reached */
-}
-
 char*
 mrb_hal_io_realpath(mrb_state *mrb, const char *path, char *resolved)
 {

--- a/mrbgems/mruby-io/ports/win/io_hal.c
+++ b/mrbgems/mruby-io/ports/win/io_hal.c
@@ -144,6 +144,7 @@ mrb_hal_io_ftruncate(mrb_state *mrb, int fd, mrb_int length)
   return _chsize_s(fd, (__int64)length);
 }
 
+#ifdef MRB_HAL_IO_HAS_FLOCK
 int
 mrb_hal_io_flock(mrb_state *mrb, int fd, int operation)
 {
@@ -182,6 +183,7 @@ mrb_hal_io_flock(mrb_state *mrb, int fd, int operation)
 
   return 0;
 }
+#endif /* MRB_HAL_IO_HAS_FLOCK */
 
 int
 mrb_hal_io_unlink(mrb_state *mrb, const char *path)

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -666,8 +666,8 @@ mrb_file_mtime(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, st.st_mtime);
 }
 
-#if defined(sun)
-/* Solaris and Illumos have no flock(2): unimplemented, and named as such so
+#ifndef MRB_HAL_IO_HAS_FLOCK
+/* this port has no file locking: unimplemented, and named as such so
    `respond_to?` can answer false */
 # define mrb_file_flock mrb_notimplement_m
 #else

--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -761,6 +761,7 @@ mrb_file_truncate(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(0);
 }
 
+#ifdef MRB_HAL_IO_HAS_SYMLINK
 /*
  * call-seq:
  *   File.symlink(old_name, new_name) -> 0
@@ -786,6 +787,11 @@ mrb_file_s_symlink(mrb_state *mrb, mrb_value klass)
   mrb_locale_free(dst);
   return mrb_fixnum_value(0);
 }
+#else
+/* this port has no symbolic links: unimplemented, and named as such so
+   `respond_to?` can answer false */
+# define mrb_file_s_symlink mrb_notimplement_m
+#endif
 
 /*
  * call-seq:
@@ -820,6 +826,11 @@ mrb_file_s_chmod(mrb_state *mrb, mrb_value klass)
   return mrb_fixnum_value(argc);
 }
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#ifdef MRB_HAL_IO_HAS_SYMLINK
 /*
  * call-seq:
  *   File.readlink(link_name) -> string
@@ -829,10 +840,6 @@ mrb_file_s_chmod(mrb_state *mrb, mrb_value klass)
  *   File.symlink("testfile", "link-to-test") #=> 0
  *   File.readlink("link-to-test")          #=> "testfile"
  */
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-
 static mrb_value
 mrb_file_s_readlink(mrb_state *mrb, mrb_value klass)
 {
@@ -856,6 +863,9 @@ mrb_file_s_readlink(mrb_state *mrb, mrb_value klass)
 
   return ret;
 }
+#else
+# define mrb_file_s_readlink mrb_notimplement_m
+#endif
 
 /*
  * call-seq:

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -12,7 +12,6 @@
 #include "io_hal.h"
 
 #include <sys/types.h>
-#include <sys/stat.h>
 
 #include <errno.h>
 #include <stdlib.h>
@@ -54,13 +53,11 @@ mrb_stat(mrb_state *mrb, mrb_value obj, mrb_io_stat *st)
   return mrb_stat0(mrb, obj, st, 0);
 }
 
-#if defined(S_ISLNK) || defined(_S_ISLNK) || defined(S_IFLNK) || defined(_S_IFLNK)
 static int
 mrb_lstat(mrb_state *mrb, mrb_value obj, mrb_io_stat *st)
 {
   return mrb_stat0(mrb, obj, st, 1);
 }
-#endif
 
 /*
  * call-seq:
@@ -77,16 +74,12 @@ mrb_lstat(mrb_state *mrb, mrb_value obj, mrb_io_stat *st)
 static mrb_value
 mrb_filetest_s_directory_p(mrb_state *mrb, mrb_value klass)
 {
-#ifndef S_ISDIR
-#   define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
-#endif
-
   mrb_io_stat st;
   mrb_value obj = mrb_get_arg1(mrb);
 
   if (mrb_stat(mrb, obj, &st) < 0)
     return mrb_false_value();
-  if (S_ISDIR(st.st_mode))
+  if (MRB_IO_S_ISDIR(st.st_mode))
     return mrb_true_value();
 
   return mrb_false_value();
@@ -111,20 +104,14 @@ mrb_filetest_s_directory_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 {
-#ifdef S_IFIFO
-#  ifndef S_ISFIFO
-#    define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
-#  endif
-
   mrb_io_stat st;
   mrb_value obj = mrb_get_arg1(mrb);
 
   if (mrb_stat(mrb, obj, &st) < 0)
     return mrb_false_value();
-  if (S_ISFIFO(st.st_mode))
+  if (MRB_IO_S_ISFIFO(st.st_mode))
     return mrb_true_value();
 
-#endif
   return mrb_false_value();
 }
 #endif
@@ -148,29 +135,13 @@ mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 {
-#ifndef S_ISLNK
-#  ifdef _S_ISLNK
-#    define S_ISLNK(m) _S_ISLNK(m)
-#  else
-#    ifdef _S_IFLNK
-#      define S_ISLNK(m) (((m) & S_IFMT) == _S_IFLNK)
-#    else
-#      ifdef S_IFLNK
-#        define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
-#      endif
-#    endif
-#  endif
-#endif
-
-#ifdef S_ISLNK
   mrb_io_stat st;
   mrb_value obj = mrb_get_arg1(mrb);
 
   if (mrb_lstat(mrb, obj, &st) == -1)
     return mrb_false_value();
-  if (S_ISLNK(st.st_mode))
+  if (MRB_IO_S_ISLNK(st.st_mode))
     return mrb_true_value();
-#endif
 
   return mrb_false_value();
 }
@@ -195,29 +166,13 @@ mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_socket_p(mrb_state *mrb, mrb_value klass)
 {
-#ifndef S_ISSOCK
-#  ifdef _S_ISSOCK
-#    define S_ISSOCK(m) _S_ISSOCK(m)
-#  else
-#    ifdef _S_IFSOCK
-#      define S_ISSOCK(m) (((m) & S_IFMT) == _S_IFSOCK)
-#    else
-#      ifdef S_IFSOCK
-#        define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)
-#      endif
-#    endif
-#  endif
-#endif
-
-#ifdef S_ISSOCK
   mrb_io_stat st;
   mrb_value obj = mrb_get_arg1(mrb);
 
   if (mrb_stat(mrb, obj, &st) < 0)
     return mrb_false_value();
-  if (S_ISSOCK(st.st_mode))
+  if (MRB_IO_S_ISSOCK(st.st_mode))
     return mrb_true_value();
-#endif
 
   return mrb_false_value();
 }
@@ -264,16 +219,12 @@ mrb_filetest_s_exist_p(mrb_state *mrb, mrb_value klass)
 static mrb_value
 mrb_filetest_s_file_p(mrb_state *mrb, mrb_value klass)
 {
-#ifndef S_ISREG
-#   define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
-#endif
-
   mrb_io_stat st;
   mrb_value obj = mrb_get_arg1(mrb);
 
   if (mrb_stat(mrb, obj, &st) < 0)
     return mrb_false_value();
-  if (S_ISREG(st.st_mode))
+  if (MRB_IO_S_ISREG(st.st_mode))
     return mrb_true_value();
 
   return mrb_false_value();

--- a/mrbgems/mruby-io/src/file_test.c
+++ b/mrbgems/mruby-io/src/file_test.c
@@ -53,11 +53,13 @@ mrb_stat(mrb_state *mrb, mrb_value obj, mrb_io_stat *st)
   return mrb_stat0(mrb, obj, st, 0);
 }
 
+#ifdef MRB_HAL_IO_HAS_STAT_SYMLINK
 static int
 mrb_lstat(mrb_state *mrb, mrb_value obj, mrb_io_stat *st)
 {
   return mrb_stat0(mrb, obj, st, 1);
 }
+#endif
 
 /*
  * call-seq:
@@ -85,11 +87,11 @@ mrb_filetest_s_directory_p(mrb_state *mrb, mrb_value klass)
   return mrb_false_value();
 }
 
-#ifdef _WIN32
-/* Windows anonymous pipes are not Unix FIFOs: unimplemented, and named as such
-   so `respond_to?` can answer false */
-# define mrb_filetest_s_pipe_p mrb_notimplement_m
-#else
+/* Whether a stat can name a FIFO, a symbolic link or a socket is the port's
+   to say, in its io_hal_features.h; a predicate the port cannot answer is
+   unimplemented, and named as such so `respond_to?` can answer false */
+
+#ifdef MRB_HAL_IO_HAS_STAT_FIFO
 /*
  * call-seq:
  *   File.pipe?(file_name)   ->  true or false
@@ -114,13 +116,11 @@ mrb_filetest_s_pipe_p(mrb_state *mrb, mrb_value klass)
 
   return mrb_false_value();
 }
+#else
+# define mrb_filetest_s_pipe_p mrb_notimplement_m
 #endif
 
-#ifdef _WIN32
-/* Symlinks are not reliably supported on Windows: unimplemented, and named as
-   such so `respond_to?` can answer false */
-# define mrb_filetest_s_symlink_p mrb_notimplement_m
-#else
+#ifdef MRB_HAL_IO_HAS_STAT_SYMLINK
 /*
  * call-seq:
  *   File.symlink?(file_name)   ->  true or false
@@ -145,13 +145,11 @@ mrb_filetest_s_symlink_p(mrb_state *mrb, mrb_value klass)
 
   return mrb_false_value();
 }
+#else
+# define mrb_filetest_s_symlink_p mrb_notimplement_m
 #endif
 
-#ifdef _WIN32
-/* Unix domain sockets are not supported on Windows: unimplemented, and named
-   as such so `respond_to?` can answer false */
-# define mrb_filetest_s_socket_p mrb_notimplement_m
-#else
+#ifdef MRB_HAL_IO_HAS_STAT_SOCKET
 /*
  * call-seq:
  *   File.socket?(file_name)   ->  true or false
@@ -176,6 +174,8 @@ mrb_filetest_s_socket_p(mrb_state *mrb, mrb_value klass)
 
   return mrb_false_value();
 }
+#else
+# define mrb_filetest_s_socket_p mrb_notimplement_m
 #endif
 
 /*

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -102,11 +102,7 @@ io_get_open_fptr(mrb_state *mrb, mrb_value io)
   return fptr;
 }
 
-#if !defined(MRB_NO_IO_POPEN) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-# define MRB_NO_IO_POPEN 1
-#endif
-
-#ifndef MRB_NO_IO_POPEN
+#ifdef MRB_HAL_IO_HAS_SPAWN_PROCESS
 static void
 io_set_process_status(mrb_state *mrb, pid_t pid, int status)
 {
@@ -323,7 +319,9 @@ io_alloc(mrb_state *mrb)
 #define NOFILE 64
 #endif
 
-#ifdef MRB_NO_IO_POPEN
+#ifndef MRB_HAL_IO_HAS_SPAWN_PROCESS
+/* this port runs no command: unimplemented, and named as such so
+   `respond_to?` can answer false */
 # define io_s_popen mrb_notimplement_m
 #else
 struct popen_params {
@@ -469,7 +467,7 @@ io_s_popen(mrb_state *mrb, mrb_value klass)
   DATA_PTR(io)  = fptr;
   return io;
 }
-#endif /* MRB_NO_IO_POPEN */
+#endif /* MRB_HAL_IO_HAS_SPAWN_PROCESS */
 
 static int
 symdup(mrb_state *mrb, int fd, mrb_bool *failed)
@@ -680,27 +678,19 @@ fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet)
     fptr->fd2 = -1;
   }
 
-#ifndef MRB_NO_IO_POPEN
+#ifdef MRB_HAL_IO_HAS_SPAWN_PROCESS
   if (fptr->pid != 0) {
-#if !defined(_WIN32)
-    pid_t pid;
-    int status;
+    /* The pid is whatever mrb_hal_io_spawn_process() handed out, and only
+       the port that made it knows what it names and how to wait on it. */
+    int pid, status;
     do {
-      pid = waitpid(fptr->pid, &status, 0);
+      pid = mrb_hal_io_waitpid(mrb, fptr->pid, &status, 0);
     } while (pid == -1 && errno == EINTR);
     if (!quiet && pid == fptr->pid) {
       io_set_process_status(mrb, pid, status);
     }
-#else
-    HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, fptr->pid);
-    DWORD status;
-    if (WaitForSingleObject(h, INFINITE) && GetExitCodeProcess(h, &status))
-      if (!quiet)
-        io_set_process_status(mrb, fptr->pid, (int)status);
-    CloseHandle(h);
-#endif
     fptr->pid = 0;
-    /* Note: we don't raise an exception when waitpid(3) fails */
+    /* Note: we don't raise an exception when the wait fails */
   }
 #endif
 
@@ -1412,7 +1402,6 @@ time2timeval(mrb_state *mrb, mrb_value time)
  *   f.puts "hello"
  */
 
-#if !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
 static mrb_value
 io_s_pipe(mrb_state *mrb, mrb_value klass)
 {
@@ -1440,7 +1429,6 @@ io_s_pipe(mrb_state *mrb, mrb_value klass)
 
   return mrb_assoc_new(mrb, r, w);
 }
-#endif
 
 static int
 mrb_io_read_data_pending(mrb_state *mrb, struct mrb_io *fptr)
@@ -2439,9 +2427,7 @@ mrb_init_io(mrb_state *mrb)
   mrb_define_class_method_id(mrb, io, MRB_SYM(for_fd),  io_s_for_fd,   MRB_ARGS_ARG(1,2));
   mrb_define_class_method_id(mrb, io, MRB_SYM(select),  io_s_select,  MRB_ARGS_ARG(1,3));
   mrb_define_class_method_id(mrb, io, MRB_SYM(sysopen), io_s_sysopen, MRB_ARGS_ARG(1,2));
-#if !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
   mrb_define_class_method_id(mrb, io, MRB_SYM(_pipe), io_s_pipe, MRB_ARGS_NONE());
-#endif
 
   MRB_MT_INIT_ROM(mrb, io, io_rom_entries);
 

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -401,13 +401,67 @@ assert('File.symlink') do
 end
 
 assert('File.chmod') do
-  File.open("#{$mrbtest_io_wfname}.chmod-test", 'w') {}
+  path = "#{$mrbtest_io_wfname}.chmod-test"
+  File.open(path, 'w') {}
   begin
-    assert_equal 1, File.chmod(0400, "#{$mrbtest_io_wfname}.chmod-test")
+    assert_equal 1, File.chmod(0400, path)
+    # An execute bit is nothing a Windows mode carries; the call takes it
+    # and leaves the file writable rather than refusing the mode.
+    assert_equal 1, File.chmod(0755, path)
+    File.open(path, 'w') {}
   ensure
     # On Windows, must restore write permission before deletion
-    File.chmod(0600, "#{$mrbtest_io_wfname}.chmod-test") rescue nil
-    File.delete("#{$mrbtest_io_wfname}.chmod-test")
+    File.chmod(0600, path) rescue nil
+    File.delete(path)
+  end
+end
+
+assert('File.open - a mode with an execute bit') do
+  path = "#{$mrbtest_io_wfname}.exec-test"
+  begin
+    File.open(path, 'w', 0755) { |f| f.write 'x' }
+    assert_equal 'x', File.open(path) { |f| f.read }
+  ensure
+    File.chmod(0600, path) rescue nil
+    File.delete(path) rescue nil
+  end
+end
+
+assert('File.umask') do
+  path = "#{$mrbtest_io_wfname}.umask-test"
+  probe = "#{$mrbtest_io_wfname}.umask-probe"
+  old = File.umask
+  begin
+    # A caller that overrides permissions, root on POSIX, writes to a file
+    # whatever its bits say, so a read-only file is asked first whether it
+    # refuses this one; the second half means nothing where it does not.
+    File.open(probe, 'w') {}
+    File.chmod(0400, probe)
+    enforced = begin
+      File.open(probe, 'w') {}
+      false
+    rescue Errno::EACCES
+      true
+    end
+
+    # 0022 keeps the owner's write bit, so the file it made opens for writing
+    File.umask(0022)
+    File.open(path, 'w') {}
+    assert_nothing_raised { File.open(path, 'w') {} }
+    File.delete(path)
+
+    if enforced
+      # 0222 takes it from everyone, so the file it made refuses to
+      File.umask(0222)
+      File.open(path, 'w') {}
+      assert_raise(Errno::EACCES) { File.open(path, 'w') {} }
+    end
+  ensure
+    File.umask(old)
+    [probe, path].each do |f|
+      File.chmod(0600, f) rescue nil
+      File.delete(f) rescue nil
+    end
   end
 end
 

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -526,7 +526,9 @@ assert('IO.popen') do
   begin
     $? = nil
     io = IO.popen("#{$cmd}echo mruby-io")
-    assert_true io.close_on_exec?
+    # A port without close-on-exec still runs the command and reports the
+    # child, so the rest of the test is for it too.
+    assert_true io.close_on_exec? if io.respond_to?(:close_on_exec?)
     assert_equal Integer, io.pid.class
 
     out = io.read


### PR DESCRIPTION
## Summary

Whether a method exists is the port's to decide, since the port is what a build names and a cross build has no host to detect the platform from. Since #7472 a port can say so: its `include/` is on the include path of the gem it serves, and `mruby-dir` reads its `dir_hal_features.h` there. `mruby-io` still decided in `src/`, from `_WIN32`, `sun`, `TARGET_OS_IPHONE`, and whichever `S_IS*` macros the host's `<sys/stat.h>` happened to spell.

The gem now uses the mechanism the way `mruby-dir` does. Each port declares in its `include/io_hal_features.h` what it implements, one macro guards the prototype, the port's implementation and the method definition, and the two functions whose only job was to refuse are deleted along with the platform tests in `src/` that stood in for the port's answer. On the way, the HAL's `stat` gets a mode encoding of its own, so `file_test.c` stops asking the host's macros about a number the port produced. `mruby-socket` follows in its own PR.

## Changes

| File | What |
| --- | --- |
| `mruby-io/ports/{posix,win}/include/io_hal_features.h` | new; `MRB_HAL_IO_HAS_SYMLINK`, `_FLOCK`, `_STAT_FIFO`, `_STAT_SYMLINK`, `_STAT_SOCKET`, `_SPAWN_PROCESS` |
| `mruby-io/include/io_hal.h` | includes the feature header; the file mode section states that `st_mode` is the HAL's own encoding and names the permission bits; guards the prototypes of `mrb_hal_io_symlink()`, `_readlink()`, `_flock()`, `_spawn_process()`, `_waitpid()`; says what `mrb_hal_io_waitpid()` owes, the pid being the spawn's and the status the host's raw one; `MRB_NO_IO_POPEN` becomes an `#undef` |
| `mruby-io/ports/{posix,win}/io_hal.c` | `convert_stat()` writes `st_mode` in the HAL's encoding, and `mrb_hal_io_chmod()`, `_umask()` and the creation mode of `_open()` map one handed down, the Windows port for the owner's read and write bits alone; `mrb_hal_io_waitpid()` takes over the wait `fptr_finalize()` did itself, the Windows one answering with the exit code itself and closing the handle on failure too; the POSIX implementations are guarded by the feature macros; the Windows `mrb_hal_io_symlink()` and `mrb_hal_io_readlink()` are deleted |
| `mruby-io/test/file.rb` | `File.umask`: a file made under 0022 opens for writing again, one made under 0222 does not; `File.chmod` and `File.open` each take a 0755 |
| `mruby-io/test/io.rb` | `IO.popen`: asks `respond_to?` before `close_on_exec?`, so the rest of the test runs where that one method is not implemented |
| `mruby-io/src/file.c` | `File.symlink`, `File.readlink`, `File#flock` follow the macros; the `sun` test goes |
| `mruby-io/src/file_test.c` | every predicate reads the kind through `MRB_IO_S_IS*`; `FileTest.pipe?`, `.symlink?`, `.socket?` follow the macros; the `_WIN32` and `S_IS*` cascades go, and with them the include of `<sys/stat.h>` |
| `mruby-io/src/io.c` | `IO.popen` follows the macro; `fptr_finalize()` waits for the child through `mrb_hal_io_waitpid()`; `IO._pipe` is unconditional; the `TARGET_OS_IPHONE` and `_WIN32` tests go |
| `mruby-io/README.md` | a "What the port declares" section with the table of macros |
| `doc/guides/mrbgems.md` | the port feature header section stops naming `mruby-dir` as the one gem that carries one, and names `MRB_NO_IO_POPEN` as the veto define |

### One macro, three places

Each bundled port ships an `io_hal_features.h`. A macro defined there guards the prototype in `io_hal.h`, the implementation in the port, and the method definition in `src/`, so a port that declares a capability without implementing it fails to link, and a port that declares nothing owes nothing: the method is defined as `mrb_notimplement_m`, so `respond_to?` answers false and a call raises `NotImplementedError`. The platform test, where there is one, is written once, in the port's header: `sun` and `__sun` for flock(2), `TARGET_OS_IPHONE` for fork(2).

Three of the macros name what the port's data is rather than a function it exports, so they guard only the code that reads it: `MRB_HAL_IO_HAS_STAT_FIFO`, `_STAT_SYMLINK` and `_STAT_SOCKET` say which kinds beyond a regular file and a directory the port's `stat` can name in `st_mode`.

`MRB_NO_IO_POPEN` stays as a build's veto: `io_hal.h` undefines `MRB_HAL_IO_HAS_SPAWN_PROCESS` after the port has spoken. It is the one veto define the tree has, so the guide names it where it describes the veto. The guide also stops naming `mruby-dir` as the gem that carries a feature header, since a list there goes stale with every gem that gets one; it says where the header lives and that the gem's README lists what each port declares.

### The HAL's stat gets its own mode encoding

`io_hal.h` spelled a file kind as `MRB_IO_S_ISLNK` and the rest, over numbers of its own, and nothing read them. `file_test.c` tested the host's `st_mode` with the host's `S_ISLNK`, under a cascade of fallbacks for a `<sys/stat.h>` that spells it `_S_IFLNK`, or `_S_ISLNK`, or not at all, and both ports copied `st_mode` across verbatim. POSIX fixes the names `S_IFMT`, `S_IFLNK` and `S_IRUSR`, and the `S_IS*()` macros that read them; it fixes none of the numbers behind them. A verbatim copy is therefore a guess about the host, and asking `FileTest.symlink?` to answer through the host's macros put that guess in a file that never sees the stat.

A port now writes the kind in the HAL's terms, so `file_test.c` reads every kind through `MRB_IO_S_IS*` and stops including `<sys/stat.h>`. The permission bits go with it, and `io_hal.h` names them: they already crossed this boundary, in both directions and unmapped, since `File.chmod(0644, path)`, `File.umask(0022)` and the creation mode of `IO.sysopen` hand the number a Ruby program wrote straight to the port. That number is the language's rather than the host's, so the port owes it the same mapping, and `io_hal.h` says so for all three.

The Windows runtime names three permission bits, and they are the owner's. `_stat()` reports all three, `_S_IEXEC` from the file's extension; `_chmod()`, `_open()` and `_umask()` read `_S_IREAD` and `_S_IWRITE` and no others, `_open()` refusing a mode that carries anything else, and `_umask()` reads them as the bits to take away. The port therefore reads a mode handed down for its owner read and write bits alone, which is what CRuby's Windows port does; the raw cast before this PR handed `_open()` every bit of the number, an execute bit among them. Read any wider, `File.umask(0022)` hands `_umask()` the write bit and every file made after it comes out read-only; the first draft of this PR did that, and the `File.umask` test was written to catch it: a file made under 0022 opens for writing again, one made under 0222 does not, the second half asked only where a read-only file refuses the caller at all, since root on POSIX writes whatever the bits say.

Neither kind of host pays for the other. POSIX requires the type constants to be usable in `#if`, so whether a host numbers the type as the HAL does is settled at compile time: one that does carries the field across as it is, one that does not tests the kind with the `S_IS*()` macros. The permission bits fold to a mask on their own. On this host the whole of it costs 80 bytes of `.text` in the POSIX port, four in each of the three stat entry points, six in `chmod`, thirteen in `umask` and eight in `open`, and every mode the two bundled ports read round-trips unaltered.

### The wait goes to the port with the spawn

`fptr_finalize()` waited for the child itself, with waitpid(2) on POSIX and `OpenProcess()` on Windows, though both ports carried a `mrb_hal_io_waitpid()` nothing called. The pid is whatever the port's spawn handed out, and the Windows port hands out the process handle, so `OpenProcess()` was given a handle where it wanted a process ID, `WaitForSingleObject()` was read as having failed when it succeeded, and the handle the spawn opened was never closed: `IO#close` on Windows left `$?` unset. Nothing noticed because `IO#close_on_exec?` is not implemented there and the test raised past the check.

The close now asks the port, and `io_hal.h` says what the port owes: the wait on whatever its spawn handed out and whatever release it needs afterwards, and a status that is the host's raw wait status, the value `WEXITSTATUS()` reads on that host and the one `Process::Status` is built from. The Windows port answers with the exit code itself, which is what `io.c`'s `WEXITSTATUS()` reads there and what the Windows port of mruby-process decodes. The retry on `EINTR` stays in `io.c`, where reads and writes already have theirs, and `io.c` is left with no process call of the host's.

### What was written with the wrong macro

- `File#flock` was undefined under `#if defined(sun)` in `file.c`, while the POSIX port called flock(2) unconditionally, so a Solaris build failed compiling the port before reaching the guard.
- `FileTest.pipe?`, `.symlink?` and `.socket?` answered the same question twice: `mrb_notimplement_m` under `_WIN32`, and a silent `false` wherever `<sys/stat.h>` lacked the `S_IS*` macro. Both are replaced by the port's declaration and the HAL's own `MRB_IO_S_IS*`.
- `IO.popen` was decided in `io.c` from `TARGET_OS_IPHONE`, which the port's `mrb_hal_io_spawn_process()` never looked at. `IO._pipe` was excluded on iOS under the same macro; that came in with 82053dd94 where it guarded a helper that existed for popen, and pipe(2) itself is not restricted there.

## Behaviour

On Linux, macOS and the BSDs, nothing observable changes.

On Windows, `File.symlink` and `File.readlink` still raise `NotImplementedError`, but `respond_to?` now answers false for each. Closing a stream `IO.popen` opened sets `$?`, which it left alone. A mode with an execute bit, `File.chmod(0755, path)` or `File.open(path, "w", 0755)`, reaches the runtime as `_S_IREAD | _S_IWRITE`, where the raw cast handed `_open()` the bit it is documented to refuse. On Solaris the POSIX port compiles. On iOS `IO.pipe` is defined.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory at the same path with `rake`; base is master c85303be2.

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,382,998 | 1,383,078 | +80 |
| ascii-ctype | 1,367,462 | 1,367,542 | +80 |
| byte-string | 1,344,822 | 1,344,902 | +80 |
| cxx_abi | 1,415,673 | 1,415,769 | +96 |
| no-float | 1,308,766 | 1,308,846 | +80 |
| no-bigint | 1,267,622 | 1,267,702 | +80 |
| full-debug (-O0) | 1,975,382 | 1,975,494 | +112 |

On a POSIX host one object moves: `mruby-io/ports/posix/io_hal.o` goes from 2,437 to 2,517, the mode mapping. `file.o`, `file_test.o` and `io.o` are byte for byte the same size in the C builds, since on this port every macro is declared and the guards select the code that was there, and `fptr_finalize()` calling the port instead of waitpid(2) compiles to the same length; in the C++ build it is 16 bytes longer, the cxx_abi row's extra 16. The Windows binary loses the two stubs; it was not measured here.

## Testing

Every commit was built from an empty directory and run with `rake -m test` on the host (mrbtest 2,616 to 2,618 / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0 at each of the six), and `prek run --from-ref <sha>^ --to-ref <sha>` passed at each, with `prettier --check` on every Markdown file a commit touches. The numbers below are the branch head.

- host (`build_config/default.rb`): mrbtest 2,618 (OK 2,550 / Skip 68) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`): mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1)
- `build_config/cross-mingw-winetest.rb` under wine: mrbtest 2,844 (OK 2,799 / Skip 45), bintest 100 (OK 92 / Skip 8), KO 0 / Crash 0; the `IO.popen` test runs there now, where it skipped; the skips for `File.symlink`, `File.readlink`, `IO.pipe` (through `FileTest.pipe?`), `Dir#seek` and `Dir#tell` read "unimplemented on this machine", which is the mark speaking
- the mode encoding, on the host build: `File.chmod` of 0644, 0600, 0755, 0444, 04755, 02755 and 01777 each read back from `stat(1)` unchanged, `File.umask` of 0022, 0077 and 0002 each read back unchanged, and a FIFO answers `FileTest.pipe?` alone, a Unix domain socket `FileTest.socket?` alone, a character device neither
- the `File.umask` test under wine against the Windows port as first written, which read any write bit as `_S_IWRITE`: Crash 1, `Errno::EACCES` on the second open of the file made under 0022; against the port as it is now: OK, and the host is OK with either
- the `IO.popen` test under wine against the Windows port with `fptr_finalize()` waiting by itself, as first submitted: KO 1, `$?` read back 259 (`STILL_ACTIVE`) where 0 was expected; with the port's wait: OK
- `File.chmod(0755, path)` and `File.open(path, "w", 0755)` on the host and under wine: OK; the runtime documented to refuse the bit is MSVC's, which wine's does not imitate, so the Windows-VC job is where those two tests say something
- `gcc -fsyntax-only -DMRB_NO_IO_POPEN` over `io.c` and the POSIX `io_hal.c`: the veto compiles

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

| | |
| --- | --- |
| OS | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| mingw | x86_64-w64-mingw32-gcc (GCC) 13-win32, wine-11.0 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-io/src/file.c` from each build's `compile_commands.json`, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/file.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-aware support for file locking, symbolic links, process spawning, and file-type detection.
  - Added comprehensive permission-bit handling for `chmod`, `umask`, file opening, and metadata across supported platforms.
  - Unsupported capabilities now correctly report as unavailable rather than exposing nonfunctional methods.

- **Bug Fixes**
  - Improved Windows file-mode conversion and process-handle cleanup.
  - Corrected child-process exit-code reporting.

- **Documentation**
  - Documented platform capability declarations and `IO.popen` configuration behavior.

- **Tests**
  - Expanded coverage for permissions, executable modes, umask behavior, and portable process handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->