### PR TITLE
mruby-socket: let the port say what it implements

### DIFF
--- a/mrbgems/mruby-socket/README.md
+++ b/mrbgems/mruby-socket/README.md
@@ -47,6 +47,17 @@ it does not implement fails to link.
 | -------------------------------- | ------------------------------------------ | ----- | --- |
 | `MRB_HAL_SOCKET_HAS_SOCKADDR_UN` | `Socket.sockaddr_un`, `Addrinfo#unix_path` | o     |     |
 | `MRB_HAL_SOCKET_HAS_SOCKETPAIR`  | `Socket.socketpair`                        | o     |     |
+| `MRB_HAL_SOCKET_HAS_FD_IO`       | `BasicSocket#sysseek`                      | o     |     |
+
+`MRB_HAL_SOCKET_HAS_FD_IO` guards no port function. It says a socket is a
+file descriptor that read(2), write(2) and lseek(2) take, so `BasicSocket`
+inherits every method of `IO`; a port that leaves it out gets `sysread`,
+`syswrite`, `read` and `write` through recv(2) and send(2) instead, and no
+`sysseek`. That is all it changes. A socket that is not a descriptor still
+has to be one `IO.new` accepts and `IO#close` closes as a socket, and both
+of those are mruby-io's, which today knows a Winsock handle and no other;
+a port for another such host brings that knowledge to mruby-io before it
+leaves this macro out.
 
 The Ruby layer is not gated. `UNIXSocket.new`, `UNIXServer.new`,
 `UNIXSocket.socketpair` and `Socket.unpack_sockaddr_un` keep their bodies on

--- a/mrbgems/mruby-socket/README.md
+++ b/mrbgems/mruby-socket/README.md
@@ -46,10 +46,12 @@ it does not implement fails to link.
 | macro                            | methods                                    | posix | win |
 | -------------------------------- | ------------------------------------------ | ----- | --- |
 | `MRB_HAL_SOCKET_HAS_SOCKADDR_UN` | `Socket.sockaddr_un`, `Addrinfo#unix_path` | o     |     |
+| `MRB_HAL_SOCKET_HAS_SOCKETPAIR`  | `Socket.socketpair`                        | o     |     |
 
-The Ruby layer is not gated. `UNIXSocket.new`, `UNIXServer.new` and
-`Socket.unpack_sockaddr_un` keep their bodies on every port and reach the
-C method they build on, whose refusal is what a caller sees.
+The Ruby layer is not gated. `UNIXSocket.new`, `UNIXServer.new`,
+`UNIXSocket.socketpair` and `Socket.unpack_sockaddr_un` keep their bodies on
+every port and reach the C method they build on, whose refusal is what a
+caller sees.
 
 ## License
 

--- a/mrbgems/mruby-socket/README.md
+++ b/mrbgems/mruby-socket/README.md
@@ -32,6 +32,25 @@ Date: Tue, 21 May 2013 04:31:30 GMT
 - fix possible descriptor leakage (see XXX comments)
 - `UNIXSocket#recv_io` `UNIXSocket#send_io`
 
+## What the port declares
+
+Whether a method exists is the port's to say, since the port is what a build
+names and a `hal-socket-<conf>` gem may stand in for the bundled ones. Each
+port publishes a `socket_hal_features.h` in its `include/`, which
+`include/socket_hal.h` reads before it declares anything. One macro there
+guards the prototype, the port's implementation and the method definition, so
+a capability the port does not declare has no method at all rather than one
+that fails, and `respond_to?` answers false. A port that declares a capability
+it does not implement fails to link.
+
+| macro                            | methods                                    | posix | win |
+| -------------------------------- | ------------------------------------------ | ----- | --- |
+| `MRB_HAL_SOCKET_HAS_SOCKADDR_UN` | `Socket.sockaddr_un`, `Addrinfo#unix_path` | o     |     |
+
+The Ruby layer is not gated. `UNIXSocket.new`, `UNIXServer.new` and
+`Socket.unpack_sockaddr_un` keep their bodies on every port and reach the
+C method they build on, whose refusal is what a caller sees.
+
 ## License
 
 Copyright (c) 2013 Internet Initiative Japan Inc.

--- a/mrbgems/mruby-socket/README.md
+++ b/mrbgems/mruby-socket/README.md
@@ -43,11 +43,12 @@ a capability the port does not declare has no method at all rather than one
 that fails, and `respond_to?` answers false. A port that declares a capability
 it does not implement fails to link.
 
-| macro                            | methods                                    | posix | win |
-| -------------------------------- | ------------------------------------------ | ----- | --- |
-| `MRB_HAL_SOCKET_HAS_SOCKADDR_UN` | `Socket.sockaddr_un`, `Addrinfo#unix_path` | o     |     |
-| `MRB_HAL_SOCKET_HAS_SOCKETPAIR`  | `Socket.socketpair`                        | o     |     |
-| `MRB_HAL_SOCKET_HAS_FD_IO`       | `BasicSocket#sysseek`                      | o     |     |
+| macro                            | methods                                    | posix                    | win |
+| -------------------------------- | ------------------------------------------ | ------------------------ | --- |
+| `MRB_HAL_SOCKET_HAS_SOCKADDR_UN` | `Socket.sockaddr_un`, `Addrinfo#unix_path` | o                        |     |
+| `MRB_HAL_SOCKET_HAS_SOCKETPAIR`  | `Socket.socketpair`                        | o                        |     |
+| `MRB_HAL_SOCKET_HAS_FD_IO`       | `BasicSocket#sysseek`                      | o                        |     |
+| `MRB_HAL_SOCKET_HAS_GETPEEREID`  | `BasicSocket#getpeereid`                   | o, on macOS and the BSDs |     |
 
 `MRB_HAL_SOCKET_HAS_FD_IO` guards no port function. It says a socket is a
 file descriptor that read(2), write(2) and lseek(2) take, so `BasicSocket`

--- a/mrbgems/mruby-socket/include/socket_hal.h
+++ b/mrbgems/mruby-socket/include/socket_hal.h
@@ -91,6 +91,12 @@ mrb_value mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pa
 mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen);
 #endif
 
+#ifdef MRB_HAL_SOCKET_HAS_GETPEEREID
+/* Effective user and group id of the peer of a connected Unix domain socket
+ * Returns: 0 on success, -1 on error (sets errno) */
+int mrb_hal_socket_getpeereid(mrb_state *mrb, int fd, mrb_int *euid, mrb_int *egid);
+#endif
+
 #ifdef MRB_HAL_SOCKET_HAS_SOCKETPAIR
 /* Create a pair of connected sockets
  * domain: address family (e.g., AF_UNIX)

--- a/mrbgems/mruby-socket/include/socket_hal.h
+++ b/mrbgems/mruby-socket/include/socket_hal.h
@@ -91,6 +91,7 @@ mrb_value mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pa
 mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen);
 #endif
 
+#ifdef MRB_HAL_SOCKET_HAS_SOCKETPAIR
 /* Create a pair of connected sockets
  * domain: address family (e.g., AF_UNIX)
  * type: socket type (e.g., SOCK_STREAM)
@@ -98,6 +99,7 @@ mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t 
  * sv: array to receive the two socket descriptors
  * Returns: 0 on success, -1 on error (sets errno) */
 int mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2]);
+#endif
 
 /* Enumerate local IP addresses for all network interfaces.
  * Returns an Array of String values, each a binary sockaddr_in (AF_INET) or

--- a/mrbgems/mruby-socket/include/socket_hal.h
+++ b/mrbgems/mruby-socket/include/socket_hal.h
@@ -14,6 +14,19 @@
 
 #include <mruby.h>
 
+/*
+ * What the port implements
+ *
+ * The port publishes it in a header under its include/, and the build puts
+ * that directory on the include path of this gem and of every gem that
+ * depends on it.  Whether a method exists is the port's to say, because the
+ * port is what a build names: a cross build has no host to detect one from,
+ * and a `hal-socket-<conf>` gem may stand in for the bundled ports
+ * altogether.  What each macro says, and what it guards, is written where it
+ * is defined.
+ */
+#include "socket_hal_features.h"
+
 MRB_BEGIN_DECL
 
 /*
@@ -64,13 +77,19 @@ const char* mrb_hal_socket_inet_ntop(int af, const void *src, char *dst, size_t 
 int mrb_hal_socket_inet_pton(int af, const char *src, void *dst);
 
 /*
- * Platform-Specific Socket Features
+ * Operations a port declares in its socket_hal_features.h
  */
 
+#ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 /* Create Unix domain socket address structure
  * path: Unix socket path
- * Returns: packed sockaddr string, or raises exception if not supported */
+ * Returns: packed sockaddr string; raises ArgumentError for a path too long */
 mrb_value mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen);
+
+/* Get Unix socket path from sockaddr
+ * Returns: Unix socket path string; raises SocketError for another family */
+mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen);
+#endif
 
 /* Create a pair of connected sockets
  * domain: address family (e.g., AF_UNIX)
@@ -79,10 +98,6 @@ mrb_value mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pa
  * sv: array to receive the two socket descriptors
  * Returns: 0 on success, -1 on error (sets errno) */
 int mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2]);
-
-/* Get Unix socket path from sockaddr
- * Returns: Unix socket path string, or raises exception if not supported */
-mrb_value mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen);
 
 /* Enumerate local IP addresses for all network interfaces.
  * Returns an Array of String values, each a binary sockaddr_in (AF_INET) or

--- a/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
@@ -28,4 +28,12 @@
    know the socket for one; of the bundled io ports only Windows does. */
 #define MRB_HAL_SOCKET_HAS_FD_IO
 
+/* getpeereid(2): `BasicSocket#getpeereid`.  A BSD interface, which macOS
+   and the BSDs have and Linux does not; a build on another libc that has
+   one may say so with HAVE_GETPEEREID. */
+#if defined(HAVE_GETPEEREID) || defined(__APPLE__) || defined(__FreeBSD__) || \
+    defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+# define MRB_HAL_SOCKET_HAS_GETPEEREID
+#endif
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
@@ -17,4 +17,7 @@
    through them every `UNIXSocket` and `UNIXServer` address. */
 #define MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 
+/* socketpair(2): `Socket.socketpair`. */
+#define MRB_HAL_SOCKET_HAS_SOCKETPAIR
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
@@ -20,4 +20,12 @@
 /* socketpair(2): `Socket.socketpair`. */
 #define MRB_HAL_SOCKET_HAS_SOCKETPAIR
 
+/* A socket is a file descriptor: read(2), write(2), lseek(2) and close(2)
+   take it, so `BasicSocket` inherits every method of `IO` unchanged.  This
+   guards no port function; without it `src/` reads and writes a socket
+   through recv(2) and send(2), and leaves `BasicSocket#sysseek` undefined.
+   It changes nothing in mruby-io, whose `IO.new` and `IO#close` must still
+   know the socket for one; of the bundled io ports only Windows does. */
+#define MRB_HAL_SOCKET_HAS_FD_IO
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/posix/include/socket_hal_features.h
@@ -1,0 +1,20 @@
+/*
+** socket_hal_features.h - what the POSIX port of mruby-socket implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/socket_hal.h reads this before it declares anything.  A macro
+** defined here guards three things at once: the prototype there, the
+** implementation in socket_hal.c, and the method definition under src/.  A
+** port that declared a capability and did not implement it would fail to
+** link, and one that declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_SOCKET_HAL_FEATURES_H
+#define MRUBY_SOCKET_HAL_FEATURES_H
+
+/* struct sockaddr_un: `Socket.sockaddr_un` and `Addrinfo#unix_path`, and
+   through them every `UNIXSocket` and `UNIXServer` address. */
+#define MRB_HAL_SOCKET_HAS_SOCKADDR_UN
+
+#endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/posix/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/posix/socket_hal.c
@@ -129,12 +129,14 @@ mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen)
 }
 #endif /* MRB_HAL_SOCKET_HAS_SOCKADDR_UN */
 
+#ifdef MRB_HAL_SOCKET_HAS_SOCKETPAIR
 int
 mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2])
 {
   (void)mrb;
   return socketpair(domain, type, protocol, sv);
 }
+#endif
 
 #ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 mrb_value

--- a/mrbgems/mruby-socket/ports/posix/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/posix/socket_hal.c
@@ -129,6 +129,21 @@ mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen)
 }
 #endif /* MRB_HAL_SOCKET_HAS_SOCKADDR_UN */
 
+#ifdef MRB_HAL_SOCKET_HAS_GETPEEREID
+int
+mrb_hal_socket_getpeereid(mrb_state *mrb, int fd, mrb_int *euid, mrb_int *egid)
+{
+  uid_t uid;
+  gid_t gid;
+  (void)mrb;
+
+  if (getpeereid(fd, &uid, &gid) != 0) return -1;
+  *euid = (mrb_int)uid;
+  *egid = (mrb_int)gid;
+  return 0;
+}
+#endif
+
 #ifdef MRB_HAL_SOCKET_HAS_SOCKETPAIR
 int
 mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2])

--- a/mrbgems/mruby-socket/ports/posix/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/posix/socket_hal.c
@@ -101,6 +101,7 @@ mrb_hal_socket_inet_pton(int af, const char *src, void *dst)
  * Platform-Specific Socket Features
  */
 
+#ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 mrb_value
 mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen)
 {
@@ -126,6 +127,7 @@ mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen)
 
   return s;
 }
+#endif /* MRB_HAL_SOCKET_HAS_SOCKADDR_UN */
 
 int
 mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2])
@@ -134,6 +136,7 @@ mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, in
   return socketpair(domain, type, protocol, sv);
 }
 
+#ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 mrb_value
 mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen)
 {
@@ -149,6 +152,7 @@ mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen)
 
   return mrb_str_new_cstr(mrb, ((const struct sockaddr_un*)sockaddr)->sun_path);
 }
+#endif /* MRB_HAL_SOCKET_HAS_SOCKADDR_UN */
 
 mrb_value
 mrb_hal_socket_ip_address_list(mrb_state *mrb)

--- a/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
@@ -1,0 +1,19 @@
+/*
+** socket_hal_features.h - what the Windows port of mruby-socket implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/socket_hal.h reads this before it declares anything.  A macro
+** defined here guards three things at once: the prototype there, the
+** implementation in socket_hal.c, and the method definition under src/.  A
+** port that declared a capability and did not implement it would fail to
+** link, and one that declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_SOCKET_HAL_FEATURES_H
+#define MRUBY_SOCKET_HAL_FEATURES_H
+
+/* No Unix domain addresses: `Socket.sockaddr_un` and `Addrinfo#unix_path`
+   are left undefined rather than defined to fail. */
+
+#endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
@@ -24,4 +24,6 @@
    `IO.new` accepts the handle and `IO#close` closes it with closesocket()
    is mruby-io's own doing for Winsock, not this header's. */
 
+/* No getpeereid(2): `BasicSocket#getpeereid` is undefined. */
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
@@ -18,4 +18,10 @@
 
 /* No socketpair(2): `Socket.socketpair` is likewise undefined. */
 
+/* A SOCKET is not a C runtime descriptor: read(), write() and lseek() do
+   not take it, so MRB_HAL_SOCKET_HAS_FD_IO is not declared and `src/` reads
+   and writes a socket through recv() and send() instead.  That mruby-io's
+   `IO.new` accepts the handle and `IO#close` closes it with closesocket()
+   is mruby-io's own doing for Winsock, not this header's. */
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
+++ b/mrbgems/mruby-socket/ports/win/include/socket_hal_features.h
@@ -16,4 +16,6 @@
 /* No Unix domain addresses: `Socket.sockaddr_un` and `Addrinfo#unix_path`
    are left undefined rather than defined to fail. */
 
+/* No socketpair(2): `Socket.socketpair` is likewise undefined. */
+
 #endif /* MRUBY_SOCKET_HAL_FEATURES_H */

--- a/mrbgems/mruby-socket/ports/win/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/win/socket_hal.c
@@ -247,19 +247,6 @@ mrb_hal_socket_inet_pton(int af, const char *src, void *dst)
  * Platform-Specific Socket Features
  */
 
-int
-mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2])
-{
-  (void)mrb;
-  (void)domain;
-  (void)type;
-  (void)protocol;
-  (void)sv;
-  /* socketpair is not supported on Windows */
-  errno = ENOSYS;
-  return -1;
-}
-
 mrb_value
 mrb_hal_socket_ip_address_list(mrb_state *mrb)
 {

--- a/mrbgems/mruby-socket/ports/win/socket_hal.c
+++ b/mrbgems/mruby-socket/ports/win/socket_hal.c
@@ -247,16 +247,6 @@ mrb_hal_socket_inet_pton(int af, const char *src, void *dst)
  * Platform-Specific Socket Features
  */
 
-mrb_value
-mrb_hal_socket_sockaddr_un(mrb_state *mrb, const char *path, size_t pathlen)
-{
-  (void)path;
-  (void)pathlen;
-  mrb_raise(mrb, mrb_class_get_id(mrb, MRB_SYM(NotImplementedError)),
-            "sockaddr_un unsupported on Windows");
-  return mrb_nil_value();
-}
-
 int
 mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, int sv[2])
 {
@@ -268,16 +258,6 @@ mrb_hal_socket_socketpair(mrb_state *mrb, int domain, int type, int protocol, in
   /* socketpair is not supported on Windows */
   errno = ENOSYS;
   return -1;
-}
-
-mrb_value
-mrb_hal_socket_unix_path(mrb_state *mrb, const char *sockaddr, size_t socklen)
-{
-  (void)sockaddr;
-  (void)socklen;
-  mrb_raise(mrb, mrb_class_get_id(mrb, MRB_SYM(NotImplementedError)),
-            "unix_path unsupported on Windows");
-  return mrb_nil_value();
 }
 
 mrb_value

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -1240,21 +1240,18 @@ mrb_tcpsocket_allocate(mrb_state *mrb, mrb_value klass)
   return mrb_obj_value((struct RObject*)mrb_obj_alloc(mrb, ttype, c));
 }
 
-/* Windows overrides for IO methods on BasicSocket objects.
- * This is because sockets on Windows are not the same as file
- * descriptors, and thus functions which operate on file descriptors
- * will break on socket descriptors.
+/* On a port whose socket is not a file descriptor, IO's read and write
+ * cannot take it; these stand in for them through recv() and send().
  */
-#ifdef _WIN32
+#ifndef MRB_HAL_SOCKET_HAS_FD_IO
 /*
  * call-seq:
  *   basicsocket.sysread(maxlen, outbuf=nil) -> string
  *
- * Windows-specific implementation to read from socket using recv().
- * Overrides IO#sysread for socket objects on Windows.
+ * Reads from the socket with recv(), in place of IO#sysread.
  */
 static mrb_value
-mrb_win32_basicsocket_sysread(mrb_state *mrb, mrb_value self)
+mrb_basicsocket_recv_sysread(mrb_state *mrb, mrb_value self)
 {
   mrb_value buf = mrb_nil_value();
   mrb_int maxlen;
@@ -1283,7 +1280,7 @@ mrb_win32_basicsocket_sysread(mrb_state *mrb, mrb_value self)
         mrb_raise(mrb, E_EOF_ERROR, "sysread failed: End of File");
       }
       break;
-    case SOCKET_ERROR: /* Error */
+    case -1: /* Error */
       sock_sys_fail(mrb, "recv");
       break;
     default:
@@ -1300,24 +1297,23 @@ mrb_win32_basicsocket_sysread(mrb_state *mrb, mrb_value self)
  * call-seq:
  *   basicsocket.syswrite(string) -> integer
  *
- * Windows-specific implementation to write to socket using send().
- * Overrides IO#syswrite for socket objects on Windows.
+ * Writes to the socket with send(), in place of IO#syswrite.
  */
 static mrb_value
-mrb_win32_basicsocket_syswrite(mrb_state *mrb, mrb_value self)
+mrb_basicsocket_send_syswrite(mrb_state *mrb, mrb_value self)
 {
   mrb_value str;
-  SOCKET sd = socket_fd(mrb, self);
+  int sd = socket_fd(mrb, self);
 
   mrb_get_args(mrb, "S", &str);
 
   int n = send(sd, RSTRING_PTR(str), (int)RSTRING_LEN(str), 0);
-  if (n == SOCKET_ERROR)
+  if (n == -1)
     sock_sys_fail(mrb, "send");
   return mrb_int_value(mrb, n);
 }
 
-#endif
+#endif /* MRB_HAL_SOCKET_HAS_FD_IO */
 
 /* ---------------------------*/
 static const mrb_mt_entry addrinfo_rom_entries[] = {
@@ -1337,17 +1333,21 @@ static const mrb_mt_entry basicsocket_rom_entries[] = {
   MRB_MT_ENTRY(mrb_basicsocket_setsockopt,    MRB_SYM(setsockopt), MRB_ARGS_REQ(1)|MRB_ARGS_OPT(2)),
   MRB_MT_ENTRY(mrb_basicsocket_shutdown,      MRB_SYM(shutdown), MRB_ARGS_OPT(1)),
   MRB_MT_ENTRY(mrb_basicsocket_set_is_socket, MRB_SYM_E(_is_socket), MRB_ARGS_REQ(1)),
-#ifdef _WIN32
-  /* `close` is IO's: fptr_finalize() calls closesocket() for a socket on
-     Windows and then clears the descriptor, which an override here did not,
-     leaving the object open to being closed a second time */
-  MRB_MT_ENTRY(mrb_win32_basicsocket_sysread,  MRB_SYM(sysread), MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1)),
-  /* a socket cannot seek: unimplemented, and named as such so `respond_to?`
-     can answer false */
-  MRB_MT_ENTRY(mrb_notimplement_m,             MRB_SYM(sysseek), MRB_ARGS_REQ(1)),
-  MRB_MT_ENTRY(mrb_win32_basicsocket_syswrite, MRB_SYM(syswrite), MRB_ARGS_REQ(1)),
-  MRB_MT_ENTRY(mrb_win32_basicsocket_sysread,  MRB_SYM(read), MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1)),
-  MRB_MT_ENTRY(mrb_win32_basicsocket_syswrite, MRB_SYM(write), MRB_ARGS_REQ(1)),
+#ifndef MRB_HAL_SOCKET_HAS_FD_IO
+  /* The port's socket is not a file descriptor, so IO's read and write are
+     replaced and there is nothing to seek. `close` stays IO's: on Windows
+     fptr_finalize() closes a socket with closesocket() and then clears the
+     descriptor, which an override here did not, leaving the object open to
+     being closed a second time. That is mruby-io's knowledge of Winsock,
+     not this macro's: a port for another host whose socket is not a
+     descriptor has to teach IO.new and IO#close the same before it leaves
+     MRB_HAL_SOCKET_HAS_FD_IO out. */
+  MRB_MT_ENTRY(mrb_basicsocket_recv_sysread,  MRB_SYM(sysread), MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1)),
+  /* unimplemented, and named as such so `respond_to?` can answer false */
+  MRB_MT_ENTRY(mrb_notimplement_m,            MRB_SYM(sysseek), MRB_ARGS_REQ(1)),
+  MRB_MT_ENTRY(mrb_basicsocket_send_syswrite, MRB_SYM(syswrite), MRB_ARGS_REQ(1)),
+  MRB_MT_ENTRY(mrb_basicsocket_recv_sysread,  MRB_SYM(read), MRB_ARGS_REQ(1)|MRB_ARGS_OPT(1)),
+  MRB_MT_ENTRY(mrb_basicsocket_send_syswrite, MRB_SYM(write), MRB_ARGS_REQ(1)),
 #endif
 };
 

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -296,6 +296,7 @@ mrb_addrinfo_getnameinfo(mrb_state *mrb, mrb_value self)
  *
  *   addr.unix_path  #=> "/tmp/socket"
  */
+#ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 static mrb_value
 mrb_addrinfo_unix_path(mrb_state *mrb, mrb_value self)
 {
@@ -307,6 +308,11 @@ mrb_addrinfo_unix_path(mrb_state *mrb, mrb_value self)
 
   return mrb_hal_socket_unix_path(mrb, RSTRING_PTR(sastr), (size_t)RSTRING_LEN(sastr));
 }
+#else
+/* this port has no Unix domain addresses: unimplemented, and named as such
+   so `respond_to?` can answer false */
+# define mrb_addrinfo_unix_path mrb_notimplement_m
+#endif
 
 /* Helper to convert sockaddr to address list array [family, port, host, host] */
 static mrb_value
@@ -1154,6 +1160,7 @@ mrb_socket_sockaddr_family(mrb_state *mrb, mrb_value klass)
  *   Socket.sockaddr_un("/tmp/socket")
  *   Socket.sockaddr_un("/var/run/daemon.sock")
  */
+#ifdef MRB_HAL_SOCKET_HAS_SOCKADDR_UN
 static mrb_value
 mrb_socket_sockaddr_un(mrb_state *mrb, mrb_value klass)
 {
@@ -1162,6 +1169,9 @@ mrb_socket_sockaddr_un(mrb_state *mrb, mrb_value klass)
   mrb_get_args(mrb, "S", &path);
   return mrb_hal_socket_sockaddr_un(mrb, RSTRING_PTR(path), (size_t)RSTRING_LEN(path));
 }
+#else
+# define mrb_socket_sockaddr_un mrb_notimplement_m
+#endif
 
 /*
  * call-seq:

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -1183,6 +1183,7 @@ mrb_socket_sockaddr_un(mrb_state *mrb, mrb_value klass)
  *   sock1, sock2 = Socket.socketpair(Socket::AF_UNIX, Socket::SOCK_STREAM)
  *   sock1, sock2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_DGRAM)
  */
+#ifdef MRB_HAL_SOCKET_HAS_SOCKETPAIR
 static mrb_value
 mrb_socket_socketpair(mrb_state *mrb, mrb_value klass)
 {
@@ -1200,6 +1201,11 @@ mrb_socket_socketpair(mrb_state *mrb, mrb_value klass)
   mrb_ary_push(mrb, ary, mrb_fixnum_value(sv[1]));
   return ary;
 }
+#else
+/* this port has no socketpair(2): unimplemented, and named as such so
+   `respond_to?` can answer false */
+# define mrb_socket_socketpair mrb_notimplement_m
+#endif
 
 /*
  * call-seq:

--- a/mrbgems/mruby-socket/src/socket.c
+++ b/mrbgems/mruby-socket/src/socket.c
@@ -365,32 +365,32 @@ socket_family(int s)
   return ss.ss_family;
 }
 
-#ifdef HAVE_GETPEEREID
+#ifdef MRB_HAL_SOCKET_HAS_GETPEEREID
 /*
  * call-seq:
  *   basicsocket.getpeereid -> [euid, egid]
  *
  * Returns the effective user ID and group ID of the peer process.
- * Only available on systems that support getpeereid().
+ * Only available on ports that declare getpeereid().
  *
  *   euid, egid = sock.getpeereid
  */
 static mrb_value
 mrb_basicsocket_getpeereid(mrb_state *mrb, mrb_value self)
 {
-  gid_t egid;
-  uid_t euid;
+  mrb_int euid, egid;
   int s = socket_fd(mrb, self);
-  if (getpeereid(s, &euid, &egid) != 0)
+  if (mrb_hal_socket_getpeereid(mrb, s, &euid, &egid) != 0)
     sock_sys_fail(mrb, "getpeereid");
 
   mrb_value ary = mrb_ary_new_capa(mrb, 2);
-  mrb_ary_push(mrb, ary, mrb_fixnum_value((mrb_int)euid));
-  mrb_ary_push(mrb, ary, mrb_fixnum_value((mrb_int)egid));
+  mrb_ary_push(mrb, ary, mrb_int_value(mrb, euid));
+  mrb_ary_push(mrb, ary, mrb_int_value(mrb, egid));
   return ary;
 }
 #else
-/* unimplemented, and named as such so `respond_to?` can answer false */
+/* this port has no getpeereid(2): unimplemented, and named as such so
+   `respond_to?` can answer false */
 # define mrb_basicsocket_getpeereid mrb_notimplement_m
 #endif
 

--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -56,12 +56,15 @@ end
 assert('BasicSocket#getpeereid') do
   s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
   begin
-    # getpeereid(2) is compiled in only where HAVE_GETPEEREID is defined.
-    # Where it is not, the method is here to refuse, and that is what
-    # respond_to? has to report rather than promise an answer.
-    unless s.respond_to?(:getpeereid)
-      assert_raise(NotImplementedError) { s.getpeereid }
-    end
+    # getpeereid(2) is compiled in only where the port declares
+    # MRB_HAL_SOCKET_HAS_GETPEEREID. Where it does not, the method is here
+    # to refuse, and that is what respond_to? has to report rather than
+    # promise an answer. Where it does, unix.rb runs it on a socket pair.
+    # getpeereid(2) is documented to refuse a socket that is not a Unix
+    # domain SOCK_STREAM with EINVAL, but macOS answers for this one, so
+    # what it does here is not asserted.
+    skip "the port has getpeereid(2); unix.rb runs it" if s.respond_to?(:getpeereid)
+    assert_raise(NotImplementedError) { s.getpeereid }
   ensure
     s.close rescue nil
   end

--- a/mrbgems/mruby-socket/test/socket.rb
+++ b/mrbgems/mruby-socket/test/socket.rb
@@ -67,8 +67,9 @@ assert('BasicSocket#getpeereid') do
   end
 end
 
-# SocketTest.win? reads the same _WIN32 that guards the sysseek entry, so this
-# test runs everywhere and asks each platform for the answer it compiled.
+# Whether a socket is an IO descriptor is the port's to declare, and of the
+# bundled ports only Windows says it is not, so SocketTest.win? picks the
+# answer each build compiled and the test runs everywhere.
 assert('BasicSocket#sysseek') do
   s = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
   begin

--- a/mrbgems/mruby-socket/test/unix.rb
+++ b/mrbgems/mruby-socket/test/unix.rb
@@ -140,4 +140,26 @@ assert('Socket#recv and #recvfrom reject a negative length') do
   end
 end
 
+# getpeereid(2) is compiled in only where the port declares
+# MRB_HAL_SOCKET_HAS_GETPEEREID, which the POSIX port does on macOS and the
+# BSDs. It answers for a connected Unix domain socket, and both ends of a
+# pair belong to this process, so each reports the same credentials.
+assert('BasicSocket#getpeereid on a socket pair') do
+  a, b = UNIXSocket.socketpair
+  begin
+    if a.respond_to?(:getpeereid)
+      ids = a.getpeereid
+      assert_equal 2, ids.length
+      assert_kind_of Integer, ids[0]
+      assert_kind_of Integer, ids[1]
+      assert_equal ids, b.getpeereid
+    else
+      assert_raise(NotImplementedError) { a.getpeereid }
+    end
+  ensure
+    a.close rescue nil
+    b.close rescue nil
+  end
+end
+
 end # SocketTest.win?


### PR DESCRIPTION
## Summary

Whether a method exists is the port's to decide, since the port is what a build names and a cross build has no host to detect the platform from. Since #7472 a port can say so: its `include/` is on the include path of the gem it serves, and `mruby-dir` reads its `dir_hal_features.h` there. `mruby-socket` still decided in `src/`, from `_WIN32` and from a `HAVE_GETPEEREID` nothing defines.

The gem now uses the mechanism the way `mruby-dir` does. Each port declares in its `include/socket_hal_features.h` what it implements, one macro guards the prototype, the port's implementation and the method definition, and the three functions whose only job was to refuse are deleted along with the platform tests in `src/` that stood in for the port's answer. `mruby-io` gets the same treatment in its own PR; the two are independent.

## Changes

| File | What |
| --- | --- |
| `mruby-socket/ports/{posix,win}/include/socket_hal_features.h` | new; `MRB_HAL_SOCKET_HAS_SOCKADDR_UN`, `_SOCKETPAIR`, `_FD_IO`, `_GETPEEREID` |
| `mruby-socket/include/socket_hal.h` | includes the feature header; guards the prototypes of `mrb_hal_socket_sockaddr_un()`, `_unix_path()` and `_socketpair()`; `mrb_hal_socket_getpeereid()` added |
| `mruby-socket/ports/{posix,win}/socket_hal.c` | the POSIX implementations are guarded by the feature macros, and `mrb_hal_socket_getpeereid()` is new; the three Windows stubs are deleted |
| `mruby-socket/src/socket.c` | `Socket.sockaddr_un`, `Addrinfo#unix_path`, `Socket.socketpair`, `BasicSocket#getpeereid` follow the macros; the `#ifdef _WIN32` around the `BasicSocket` overrides becomes `#ifndef MRB_HAL_SOCKET_HAS_FD_IO`, and the two overrides lose their `mrb_win32_` names |
| `mruby-socket/test/socket.rb` | the two comments that named `HAVE_GETPEEREID` and `_WIN32` now name the macros; the `getpeereid` test is skipped where the port has the method, since unix.rb runs it there |
| `mruby-socket/test/unix.rb` | new test: both ends of a `UNIXSocket.socketpair` report the same credentials where the port has getpeereid(2), and raise `NotImplementedError` where it does not |
| `mruby-socket/README.md` | a "What the port declares" section with the table of macros |

### One macro, three places

Each bundled port ships a `socket_hal_features.h`. A macro defined there guards the prototype in `socket_hal.h`, the implementation in the port, and the method definition in `src/`, so a port that declares a capability without implementing it fails to link, and a port that declares nothing owes nothing: the method is defined as `mrb_notimplement_m`, so `respond_to?` answers false and a call raises `NotImplementedError`. The platform test, where there is one, is written once, in the port's header: macOS and the BSDs for getpeereid(2).

One of the macros names what the port's data is rather than a function it exports, so it guards only the code that reads it: `MRB_HAL_SOCKET_HAS_FD_IO` says whether the port's socket is a C runtime descriptor. It settles what `src/socket.c` does and no more: that `IO.new` takes a Winsock handle and `IO#close` closes it with closesocket() is mruby-io's own knowledge of that host, under its own `_WIN32`, so a port for another host whose socket is not a descriptor brings the same to mruby-io before it leaves the macro out. The feature headers, the README and the comment in `socket.c` say so rather than let the name promise it.

### What was written with the wrong macro

- The `BasicSocket` overrides for `read`, `write`, `sysread`, `syswrite` and the `sysseek` mark sat under `#ifdef _WIN32`; one fact decides all six, whether the port's socket is a C runtime descriptor, and the port now states it.
- `BasicSocket#getpeereid` was compiled under `HAVE_GETPEEREID`, which nothing in the tree defines, so no build ever had it. The call moves into the HAL and the POSIX port declares it on macOS and the BSDs; `HAVE_GETPEEREID` still works, as a way for a build on another libc to tell the port it has one.

### What the stubs hid

`mrb_hal_socket_socketpair()` on Windows set `ENOSYS`, which `sock_sys_fail()` then overwrote with the last Winsock error of a call never made, `Unknown error: 0`. It goes with the stub.

## Behaviour

On Linux, nothing observable changes. On macOS and the BSDs, `BasicSocket#getpeereid` exists. It was the refusing entry on every build, so it had never run anywhere.

On Windows, `Socket.sockaddr_un`, `Addrinfo#unix_path` and `Socket.socketpair` still raise `NotImplementedError`, but `respond_to?` now answers false for each, and `Socket.socketpair` no longer reports `Unknown error: 0`.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory at the same path with `rake`; base is master c85303be2.

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,382,998 | 1,382,998 | 0 |
| ascii-ctype | 1,367,462 | 1,367,462 | 0 |
| byte-string | 1,344,822 | 1,344,822 | 0 |
| cxx_abi | 1,415,673 | 1,415,673 | 0 |
| no-float | 1,308,766 | 1,308,766 | 0 |
| no-bigint | 1,267,622 | 1,267,622 | 0 |
| full-debug (-O0) | 1,975,382 | 1,975,382 | 0 |

On a POSIX host no object moves: `socket.o` and the POSIX `socket_hal.o` are byte for byte the same size, since on this port every macro is declared and the guards select the code that was there. The Windows binary loses the three stubs; it was not measured here.

## Testing

Every commit was built from an empty directory and run with `rake -m test` on the host (mrbtest KO 0 / Crash 0 / Warning 0 at each of the four; the head adds one test), and `prek run --from-ref <sha>^ --to-ref <sha>` passed at each, with `prettier --check` on every Markdown file a commit touches. The numbers below are the branch head.

- host (`build_config/default.rb`): mrbtest 2,617 (OK 2,549 / Skip 68) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`): mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1)
- `build_config/cross-mingw-winetest.rb` under wine: mrbtest 2,842 (OK 2,796 / Skip 46), bintest 100 (OK 92 / Skip 8), KO 0 / Crash 0
- The getpeereid(2) path, which this host does not have: a build of `full-core` with `HAVE_GETPEEREID` and a `getpeereid()` stood in for it on Linux by `SO_PEERCRED`, refusing a socket that is not `AF_UNIX` with `EINVAL` as the BSDs do. mrbtest 2,860 (OK 2,840 / Skip 20), KO 0 / Crash 0 / Warning 0; the socket pair test reports this process's uid and gid at both ends. The real declaration and linkage are what the macOS jobs of this PR's CI run, and the socket pair test asserts there

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

| | |
| --- | --- |
| OS | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| mingw | x86_64-w64-mingw32-gcc (GCC) 13-win32, wine-11.0 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-socket/src/socket.c` from each build's `compile_commands.json`, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-socket/src/socket.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_SOCKET_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-socket/src/socket.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing platform-specific socket capabilities and how unsupported operations are reported.

* **New Features**
  * Added support for detecting Unix-domain sockets, socket pairs, file-descriptor I/O, and peer credentials by platform.
  * POSIX platforms now support peer-credential lookup where available.

* **Behavior Changes**
  * Unsupported socket operations now consistently appear unavailable and raise `NotImplementedError` when called.
  * Windows no longer exposes unsupported Unix-domain socket functionality.

* **Tests**
  * Expanded coverage for peer-credential support and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->