### PR TITLE
NEWS.md: quote the match globals so GitHub does not read them as math

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -362,7 +362,7 @@ any of those needs updating.
 - [#7022](https://github.com/mruby/mruby/pull/7022) vm.c: restore the GC arena in the allocating inline opcodes
 - [#7023](https://github.com/mruby/mruby/pull/7023) vm.c: refresh regs before storing the OP_GETIDX0 Hash result
 - [#7024](https://github.com/mruby/mruby/pull/7024) mruby-regexp: do not truncate a POSIX bracket class name length
-- [#7025](https://github.com/mruby/mruby/pull/7025) mruby-regexp: set $&, $`, $' and $+ after a match
+- [#7025](https://github.com/mruby/mruby/pull/7025) mruby-regexp: set `$&`, `` $` ``, `$'` and `$+` after a match
 - [#7026](https://github.com/mruby/mruby/pull/7026) mruby-regexp: return Arrays from `Regexp#named_captures`
 - [#7027](https://github.com/mruby/mruby/pull/7027) mruby-regexp: add `Regexp#names` and `MatchData#names`
 - [#7031](https://github.com/mruby/mruby/pull/7031) mruby-regexp: quote the pattern as written in `RegexpError` messages


### PR DESCRIPTION
## Summary

The `#7025` line under "Merged Pull Requests" in `NEWS.md` does not render on GitHub. The math renderer reads `$&, $` and `$' and $` as inline math and shows "Unable to render expression", and the bare backtick in `` $` `` opens a code span that runs into the next line.

## Changes

Each of the four globals on that line is now quoted the way the same globals are already written on the "match globals" line of the "Regular expressions" section and on the `#7281` line: `$&`, `` $` ``, `$'` and `$+`.

## Testing

Rendered the whole file through the GitHub markdown API before and after the change. Before, the `#7025` line produced two `math-renderer` elements. After, the file produces none, every code span is closed, and the line reads as four inline code spans.

`npx prettier@3.7.4 --check NEWS.md` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog formatting for match-related global variable names to improve consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->