### PR TITLE
numeric.c: compare a pair of Integers as Integers however each is stored

### DIFF
--- a/src/numeric.c
+++ b/src/numeric.c
@@ -2190,7 +2190,14 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
     return mrb_bint_cmp(mrb, v1, v2);
   }
 #endif
-  if (!mrb_fixnum_p(v2)) {
+  /* Whether the value on the right is an Integer, which `mrb_fixnum_p()` does
+     not answer: word boxing keeps an Integer in the value itself only while it
+     fits a tagged machine word and allocates an object for a wider one, and
+     only the first of the two is a fixnum. Asking it here handed every Integer
+     past the inline range to the other side, and that hand-over asks this same
+     function again with the pair reversed, so two of them were passed back and
+     forth until the stack ran out. */
+  if (!mrb_integer_p(v2)) {
     if (!mrb_obj_is_kind_of(mrb, v2, mrb_class_get_id(mrb, MRB_SYM(Numeric)))) {
       return -2;
     }
@@ -2214,8 +2221,12 @@ cmpnum(mrb_state *mrb, mrb_value v1, mrb_value v2)
     return cmpnum_rev(cmpnum_int_float(mrb_integer(v2), mrb_float(v1)));
   }
 
-  if (mrb_fixnum_p(v1)) {
-    if (mrb_fixnum_p(v2)) {
+  /* A pair of Integers is compared as Integers however each of the two is
+     stored: `mrb_integer_p()` takes in the ones word boxing allocates an
+     object for, which are exactly the ones the cast below would round, and a
+     rounded pair reads as equal wherever the two sit inside one significand. */
+  if (mrb_integer_p(v1)) {
+    if (mrb_integer_p(v2)) {
       mrb_int x = mrb_integer(v1);
       mrb_int y = mrb_integer(v2);
 

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -200,6 +200,40 @@ assert('Integer comparison with a Float at the ends of the mrb_int range') do
   assert_true(imin > -inf)
 end
 
+assert('Integer comparison of two values too wide to store inline') do
+  # Word boxing keeps an Integer in the value itself only while it fits a
+  # tagged machine word and allocates an object for a wider one, which is a
+  # difference in where the number is kept and not in the number: a pair of
+  # them stands in the same order as any other pair. The comparisons are asked
+  # for by name so that each is the method's own, the operators being opcodes
+  # that read a pair of Integers themselves.
+  #
+  # 2**30 is past what a 32-bit word carries inline and 2**62 past a 64-bit
+  # one, so one pair or the other is outside it wherever this runs. Where an
+  # mrb_int is too narrow for the wider pair, mruby-bigint answers the
+  # comparison and a build without it raises at the shift, which is what the
+  # rescue leaves that pair out for; the shift count is a variable for the
+  # reason the big integer tests give, a constant one out of range failing the
+  # build rather than raising.
+  pairs = [[1 << 30, (1 << 30) + 1]]
+  begin
+    k = 62
+    pairs << [1 << k, (1 << k) + 1]
+  rescue RangeError
+  end
+
+  pairs.each do |small, large|
+    assert_equal(-1, small.__send__(:<=>, large))
+    assert_equal(1, large.__send__(:<=>, small))
+    assert_equal(0, large.__send__(:<=>, large))
+    assert_true(small.__send__(:<, large))
+    assert_true(small.__send__(:<=, large))
+    assert_false(small.__send__(:>, large))
+    assert_false(small.__send__(:>=, large))
+    assert_true(large.__send__(:>, small))
+  end
+end
+
 assert('Integer#~', '15.2.8.3.8') do
   # Complement
   assert_equal(-1, ~0)


### PR DESCRIPTION
## Summary

`cmpnum()` asked `mrb_fixnum_p()` whether an operand was an Integer, which is not the question that answers: word boxing keeps an Integer in the value itself only while it fits a tagged machine word and allocates an object for a wider one, and only the first of the two is a fixnum. A pair of Integers past the inline range therefore left the Integer arm, and what met it there depended on whether the build has a Float: without one the two sides were passed back and forth until the stack ran out, with one they were rounded and read as equal. Both places now ask `mrb_integer_p()`.

## Changes

| File | What |
|---|---|
| `src/numeric.c` | `cmpnum()` asks `mrb_integer_p()` of each side where it asked `mrb_fixnum_p()` |
| `test/t/integer.rb` | a comparison of two Integers past the inline range, at `2**30` and at `2**62` |

### Without a Float

The arm for a right-hand side that is not an Integer hands the pair to that side's own `<=>`, and the hand-over reaches this same function with the pair reversed. Two Integers past the inline range were passed back and forth until the stack ran out. That is the failure on the 32-bit `no-float` CI build: `Process.clock_gettime` in milliseconds times 1000 and in microseconds are both past `2**30` once the host has been up about eighteen minutes, which is why the same commit passed earlier in the day and failed later.

    SystemStackError: Process.clock_gettime in each unit => SystemStackError (mrbgems: mruby-process)

### With a Float

The same question sent such a pair down the Float path, which rounds each side to an `mrb_float` and reads a pair inside one significand as equal. On the default 64-bit build, `(1<<62)` and `(1<<62)+1` answered `0` to `<=>` and `false` to `<`. A 32-bit `mrb_int` is exact in a double, so with a double for the Float this arm needs a 64-bit `mrb_int` to reach. The crash above is the one a 32-bit word meets.

### Reaching it

The operators are opcodes that read a pair of Integers themselves, so either bug needs a send to reach: `__send__`, `Comparable`, `Array#sort` with a block and the rest. The test asks the comparisons through `__send__` for that reason.

### The test

One pair at `2**30` and one at `2**62`, so that one or the other is past the inline range wherever the test runs. Where an `mrb_int` is too narrow for the wider pair, mruby-bigint answers it and a build without the gem raises at the shift, which the test rescues and leaves that pair out for. The shift count is a variable so that a build too narrow for the literal still compiles the file.

## Behaviour

On the default 64-bit build, with `a = 1 << 62`:

```ruby
a.__send__(:<=>, a + 1)   # master: 0      this PR: -1
a.__send__(:<, a + 1)     # master: false  this PR: true
```

On a build without a Float, with `a = 1 << 30` on a 32-bit word or `1 << 62` on a 64-bit one, `a.__send__(:<=>, a + 1)` raised SystemStackError on master and answers `-1` here.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test:build && rake test:run` at the commit: all seven builds and bintest green, 0 KO, 0 crash.
- The same under `i686-linux-gnu-gcc`, the 32-bit word the CI failure came from: all seven builds and bintest green.
- The readings above, on master and on the branch, from the `bintest`, `no-float` and `no-bigint` builds of each of the two compilers, at the base past the inline range of each word: master raises SystemStackError on `no-float` under both, and answers `0` on the other two builds under x86-64, where the pair is rounded; under i686 the pair is exact in a double and master answers `-1` there. The branch answers `-1` on every build of both.

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X, Ubuntu 24.04.4
- gcc 13.3.0, i686-linux-gnu-gcc 13.3.0
- GNU binutils 2.47
- CRuby 4.0.6
- compile line, `no-float` (`src/numeric.c`):

```
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/numeric.c
```

- compile line, `bintest` (`src/numeric.c`):

```
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/numeric.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed comparisons involving large integers to return correct ordering results.
  * Prevented comparison failures caused by repeated fallback processing or loss of precision when large values were converted to floating-point numbers.

* **Tests**
  * Added coverage for comparison operators across integer sizes and operand orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->