### PR TITLE
array.c: sort an array holding an Integer too wide to store inline

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -2136,12 +2136,17 @@ mrb_ary_delete(mrb_state *mrb, mrb_value self)
 
 #define SMALL_ARRAY_SORT_THRESHOLD 16
 
-/* Check if all elements in the array are integers (fast path candidate) */
+/* Whether every element is an Integer the value itself carries, which is what
+   the three routines below sort: each of them reads an element with
+   mrb_integer() and writes the result back with SET_FIXNUM_VALUE(), and that
+   pair only holds for an Integer inside the inline range. Word boxing keeps a
+   wider one in an object, and writing its value back inline reinterprets the
+   bits as an address, so an array holding one is left to the general sort. */
 static mrb_bool
 ary_all_fixnum_p(const mrb_value *a, mrb_int n)
 {
   for (mrb_int i = 0; i < n; i++) {
-    if (!mrb_integer_p(a[i])) return FALSE;
+    if (!mrb_fixnum_p(a[i])) return FALSE;
   }
   return TRUE;
 }
@@ -2329,8 +2334,14 @@ sort_cmp(mrb_state *mrb, mrb_value ary, mrb_value a_val, mrb_value b_val, mrb_va
 
     if (type_a == type_b) {
       switch (type_a) {
-      case MRB_TT_FIXNUM:
-        cmp = (mrb_fixnum(a_val) > mrb_fixnum(b_val)) ? 1 : (mrb_fixnum(a_val) < mrb_fixnum(b_val)) ? -1 : 0;
+      case MRB_TT_INTEGER:
+        {
+          /* Read with mrb_integer(): an Integer too wide to sit in the value
+             is an object here, and reading that one as an inline value reads
+             its address. */
+          mrb_int a_i = mrb_integer(a_val), b_i = mrb_integer(b_val);
+          cmp = (a_i > b_i) ? 1 : (a_i < b_i) ? -1 : 0;
+        }
         break;
 #ifndef MRB_NO_FLOAT
       case MRB_TT_FLOAT:

--- a/test/t/array.rb
+++ b/test/t/array.rb
@@ -686,6 +686,31 @@ assert('Array#sort with a block that answers with a big integer') do
                Array.new(40) { |i| 40 - i }.sort { |a, b| a > b ? big : -big }
 end
 
+assert('Array#sort of Integers too wide to store inline') do
+  # The sort has a route of its own for an array of Integers, which reads each
+  # element as a number and writes the sorted order back the same way. Word
+  # boxing keeps an Integer past the inline range in an object instead, so that
+  # route is not one it can be written back through, and an array holding one
+  # is sorted like any other. 2**30 is past what a 32-bit word carries inline
+  # and 2**62 past a 64-bit one, so one base or the other is outside it
+  # wherever this runs, and a build too narrow for the wider one raises at the
+  # shift. A short array and a long one take different routes through the
+  # sort, so both are pinned. The shift count is a variable for the reason the
+  # big integer test above gives.
+  bases = [1 << 30]
+  begin
+    k = 62
+    bases << (1 << k)
+  rescue RangeError
+  end
+
+  bases.each do |base|
+    assert_equal [base, base + 1, base + 2], [base + 2, base, base + 1].sort
+    assert_equal Array.new(40) { |i| base + i },
+                 Array.new(40) { |i| base + 39 - i }.sort
+  end
+end
+
 assert('Array#freeze') do
   a = [].freeze
   assert_raise(FrozenError) do


### PR DESCRIPTION
## Summary

`Array#sort` has a route of its own for an array of Integers, which reads each element with `mrb_integer()` and writes the order back with `SET_FIXNUM_VALUE()`. That macro encodes an inline value whatever it is given, and the gate in front of the route admitted every Integer, the objects word boxing allocates for the wider ones included. Their bits came back reinterpreted as inline values. The route is now gated on the elements it can write back, and the general sort it leaves the rest to reads its Integer arm with `mrb_integer()` rather than `mrb_fixnum()`.

## Changes

| File | What |
|---|---|
| `src/array.c` | `ary_all_fixnum_p()` asks `mrb_fixnum_p()` of each element, which is what the three routines behind it can write back; `sort_cmp()` reads its Integer arm with `mrb_integer()` under `MRB_TT_INTEGER` |
| `test/t/array.rb` | a sort of Integers past the inline range, at `2**30` and at `2**62`, a short array and a long one |

### The gate

`ary_all_fixnum_p()` asked `mrb_integer_p()`, and its three callers read each element with `mrb_integer()` and write the result back with `SET_FIXNUM_VALUE()`. Reading is fine for any Integer, since `mrb_integer()` follows the object; writing back is only right for an Integer the value itself carries. Under word boxing an Integer past the inline range is an object, and writing its value back inline reinterprets the bits as an address. On the default 64-bit build, with `a = 1 << 62`:

    [a + 1, a].sort   #=> [-4611686018427387904, 4611686018427387905]

The gate now asks `mrb_fixnum_p()`, so an array holding a wider Integer takes the general sort like any other mixed array.

### The general sort

`sort_cmp()` compared a pair of the same type under `MRB_TT_FIXNUM` with `mrb_fixnum()`. With the gate fixed, a pair of wider Integers reaches this arm, and `mrb_fixnum()` on an object Integer is its address rather than its value. The arm is now `MRB_TT_INTEGER` and reads both sides with `mrb_integer()`. `MRB_TT_FIXNUM` is an alias of `MRB_TT_INTEGER`, so the case label is the same value under another name.

### The test

One base at `2**30` and one at `2**62`, so that one or the other is past the inline range wherever the test runs. Where an `mrb_int` is too narrow for the wider one, the shift raises and the test rescues and leaves that base out. A three-element array and a forty-element one, since an array under the small-sort threshold and one over it take different routes through the sort. The shift count is a variable so that a build too narrow for the literal still compiles the file.

## Behaviour

On the default 64-bit build, with `a = 1 << 62`:

```ruby
[a + 1, a].sort   # master: [-4611686018427387904, 4611686018427387905]
                  # this PR: [4611686018427387904, 4611686018427387905]
```

On a 32-bit word the same holds at `a = 1 << 30`.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test:build && rake test:run` at the commit: all seven builds and bintest green, 0 KO, 0 crash.
- The same under `i686-linux-gnu-gcc`: all seven builds and bintest green.
- The sort above, short and long, on master and on the branch, from the `bintest`, `no-float` and `no-bigint` builds of each of the two compilers, at the base past the inline range of each word: master answers the reinterpreted order on every build of both, the branch the numeric one. The base past the other word's range is inline there, or a Bigint under i686, and sorts the same on both sides.

## Environment

<details>

- Linux x86_64, kernel 7.0.0, AMD Ryzen 9 5950X, Ubuntu 24.04.4
- gcc 13.3.0, i686-linux-gnu-gcc 13.3.0
- GNU binutils 2.47
- CRuby 4.0.6
- compile line, `bintest` (`src/array.c`):

```
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/array.c
```

- compile line, `no-bigint` (`src/array.c`):

```
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/array.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integer array sorting for values too large to fit in the inline integer range.
  * Sorting now correctly handles both narrow and wide integer values.

* **Tests**
  * Added coverage for sorting oversized integers across supported build configurations.
  * Added checks for both small arrays and larger descending arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->