### PR TITLE
build: have check_func ask the linker as well

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -252,8 +252,10 @@ spec.build_settings do |spec|
 end
 ```
 
-`check_func` asks whether a name is declared once a header is included, or is
-a macro spelled that way:
+`check_func` asks whether a name is there to be called once a header is
+included: declared there, or a macro spelled that way, and defined by
+something the build links every binary with, which is the question on a host
+whose headers declare a function its C library does not define:
 
 ```ruby
 spec.build_settings do |spec|
@@ -261,13 +263,28 @@ spec.build_settings do |spec|
 end
 ```
 
+A name that a library of the gem's own defines is asked for with the gem's
+linker, `link: spec.linker`, and that linker's libraries and flags are linked
+as they are into the gem's binary; a gem adds them in its `build_settings`
+block, which is where a gem that has one writes them. `link: false` asks
+about the declaration alone, which is the question for a name C++ overloads,
+since an overload set has no one address to hand a link. A macro answers yes
+on its declaration alone either way, there being no one symbol to ask after.
+
+A build that cannot link a program, one that makes libmruby for another
+program to link and has no startup files or C library on its own link line,
+is answered about declarations alone throughout, since a link that fails
+there says nothing about the name. Whether it can is asked once, with a
+program that names `strlen`.
+
 A gem asks from a `spec.build_settings` block, as both of those do. It runs
 after every gem's `mrbgem.rake` body and before the rules are defined, which
 is what lets the defines an answer is turned into reach the compile.
 
 `try_compile` takes the source itself, for a question neither of the two
-spells. A build configuration asks its own compiler where it stands, having no
-gem lifecycle to wait on:
+spells, and `try_link` takes it and links it into a program as well. A build
+configuration asks its own compiler where it stands, having no gem lifecycle
+to wait on:
 
 ```ruby
 conf.cc.defines << 'HAVE_BUILTIN_CLZ' if conf.cc.try_compile(<<~SOURCE)
@@ -276,13 +293,13 @@ conf.cc.defines << 'HAVE_BUILTIN_CLZ' if conf.cc.try_compile(<<~SOURCE)
 SOURCE
 ```
 
-The three compile and never link, so a target with no library to link against
-still answers, and a `check_func` answer is about the declaration a compile
-can see rather than a symbol a link would resolve.
+`check_header` and `try_compile` compile and never link, so a target with no
+library to link against answers them as any other does.
 
 Each answer is kept for the life of the `rake` process, keyed by everything
 that goes into the compile: the command, the option string and the source
-extension it is spelled with, the flags, and the source. The extension is what
+extension it is spelled with, the flags, and the source, and for a link the
+link line's parts besides the object and the output. The extension is what
 tells a compiler whether it is reading C or C++, and can be all that separates
 two of a build's compilers, a toolchain being free to give them one command
 and one set of flags.

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -52,6 +52,9 @@ module MRuby
     # The answers `try_compile` has had, keyed by the command line and the
     # source it asked with.
     COMPILE_PROBES = {}
+    # The answers `try_link` has had, keyed the same way and by the link
+    # line as well.
+    LINK_PROBES = {}
 
     attr_accessor :label, :flags, :include_paths, :source_exts
     attr_reader :defines
@@ -211,9 +214,26 @@ module MRuby
     # `visualcpp` does exactly that, naming `cl` for both and handing the C++
     # one the C flags when `CFLAGS` is set and `CXXFLAGS` is not.
     def try_compile(source)
-      key = [build.filename(command), compile_options, source_exts.first,
-             all_flags, source]
-      COMPILE_PROBES.fetch(key) { COMPILE_PROBES[key] = run_compile_probe(source) }
+      COMPILE_PROBES.fetch(probe_key(source)) do |key|
+        COMPILE_PROBES[key] = run_compile_probe(source)
+      end
+    end
+
+    # Compile +source+, link the object into a program, and answer whether
+    # both happened.  The link is the build's linker's, with the libraries
+    # and flags it links every binary with; a gem's own linker for +linker+
+    # adds that gem's, as its binary is linked with them.  The answer is kept
+    # as `try_compile`'s is, and keyed by the link line as well.
+    def try_link(source, linker=nil)
+      base = build.linker
+      extra = linker.is_a?(Command::Linker) && !linker.equal?(base) ? linker.run_attrs : []
+      params = base.link_params(*extra)
+      key = probe_key(source) + [build.filename(base.command), base.link_options, params]
+      LINK_PROBES.fetch(key) do
+        LINK_PROBES[key] = run_compile_probe(source) do |dir, objfile, opts|
+          base.run_probe("#{dir}/probe#{build.exts.executable}", objfile, params, **opts)
+        end
+      end
     end
 
     # Whether the header +name+ is there, as `#include <name>` asks for it.
@@ -229,14 +249,38 @@ module MRuby
       try_compile("#include <#{name}>\nextern int mrb_probe;\n")
     end
 
-    # Whether +name+ is declared once +header+ is included, or is a macro
-    # spelled that way.  A macro answers yes because a call written as
-    # `name(...)` compiles either way, which is what a caller is asking.
+    # Whether +name+ is there to be called once +header+ is included: it is
+    # declared there, or is a macro spelled that way, and, wherever this
+    # build can link a program at all, a link resolves it.  A macro answers
+    # yes on its declaration alone, there being no one symbol to ask after.
     #
-    # The answer is about the declaration a compile can see, not about a
-    # symbol a link would resolve: this never links.  A host whose headers
-    # declare what its library does not define is not told apart here.
-    def check_func(name, header: nil)
+    # The link is against what the build's linker links every binary with;
+    # a linker for +link+, a gem's own, links that gem's libraries and flags
+    # as well, as its binary is linked with them.  `link: false` asks about
+    # the declaration alone, which is the question for a C++ overload set,
+    # since that has no one address to hand a link.
+    #
+    # A build that cannot link a program, one that makes libmruby for
+    # another program to link and has no startup files or C library on its
+    # own link line, is answered about the declaration alone throughout: a
+    # link that fails there says nothing about the name.
+    def check_func(name, header: nil, link: nil)
+      if link != false && can_link?
+        try_link(func_link_source(name, header), link)
+      else
+        try_compile(func_decl_source(name, header))
+      end
+    end
+
+    # Whether this build's linker can link a program against the C library,
+    # asked once and kept: a program that names `strlen`.
+    def can_link?
+      try_link(func_link_source('strlen', 'string.h'))
+    end
+
+    # A source that compiles when +name+ is declared once +header+ is
+    # included, or is a macro spelled that way.
+    def func_decl_source(name, header)
       source = header ? "#include <#{header}>\n" : ""
       # The name is mentioned and never called, so an undeclared one is the
       # error that answers no while a declared one asks nothing of a library.
@@ -249,7 +293,7 @@ module MRuby
       # type, which that cast does not give, so the mention that answers for
       # every other name would answer no for those.  A using-declaration asks
       # for no target and so names them all.
-      source += <<~SOURCE
+      source + <<~SOURCE
         int mrb_probe(void);
         int mrb_probe(void) {
         #ifdef #{name}
@@ -263,7 +307,32 @@ module MRuby
         #endif
         }
       SOURCE
-      try_compile(source)
+    end
+
+    # A program that links when +name+, declared once +header+ is included,
+    # is defined by something on the link line; a macro is a program that
+    # asks nothing.
+    def func_link_source(name, header)
+      source = header ? "#include <#{header}>\n" : ""
+      # The name is handed to a variadic function through a pointer the
+      # compiler cannot see through: the reference then outlives
+      # optimisation and reaches the linker, and nothing is cast, a cast
+      # between function types being what -Wcast-function-type reports.
+      # The helper sits in the arm that uses it, or the macro arm would have
+      # an unused static function to report.
+      source + <<~SOURCE
+        #ifdef #{name}
+        int main(void) { return 0; }
+        #else
+        static void mrb_probe_use(int n, ...);
+        static void mrb_probe_use(int n, ...) { (void)n; }
+        int main(void) {
+          void (*volatile mrb_probe)(int, ...) = mrb_probe_use;
+          mrb_probe(0, #{name});
+          return 0;
+        }
+        #endif
+      SOURCE
     end
 
     def search_header_path(name)
@@ -457,10 +526,19 @@ module MRuby
       end
     end
 
+    # What an answer about +source+ is kept under: everything that goes into
+    # the compile, the extension included.
+    def probe_key(source)
+      [build.filename(command), compile_options, source_exts.first, all_flags, source]
+    end
+
     # Compile +source+ and answer whether it compiled.  The source and the
     # object are named inside a directory that is removed on the way out; the
     # compiler is run from the directory a compile runs from, which is what a
-    # relative path in the flags is written against.
+    # relative path in the flags is written against.  A block is given the
+    # directory, the object and the options the compiler ran with, while the
+    # directory is still there, and its answer stands for an object that
+    # compiled.
     def run_compile_probe(source)
       Dir.mktmpdir("mruby-probe") do |dir|
         infile = "#{dir}/probe#{source_exts.first || '.c'}"
@@ -473,7 +551,8 @@ module MRuby
         opts[:chdir] = MRUBY_ROOT if build.compile_relative?
         # `system` answers nil where the command is not there to run at all,
         # which is an answer of no like any other failure to compile.
-        !!system("#{build.filename(command)} #{options}", **opts)
+        compiled = !!system("#{build.filename(command)} #{options}", **opts)
+        compiled && block_given? ? yield(dir, outfile, opts) : compiled
       end
     end
 
@@ -579,16 +658,30 @@ module MRuby
       [@libraries, @library_paths, @flags, @flags_before_libraries, @flags_after_libraries]
     end
 
-    def run(outfile, objfiles, _libraries=[], _library_paths=[], _flags=[], _flags_before_libraries=[], _flags_after_libraries=[])
+    # The link line's parts other than the objects and the output, from this
+    # linker's settings and the per-gem five `run` takes after its files, in
+    # the order `run_attrs` has them.
+    def link_params(_libraries=[], _library_paths=[], _flags=[], _flags_before_libraries=[], _flags_after_libraries=[])
+      { :flags => all_flags(_library_paths, _flags),
+        :flags_before_libraries => [flags_before_libraries, _flags_before_libraries].flatten.join(' '),
+        :flags_after_libraries => [flags_after_libraries, _flags_after_libraries].flatten.join(' '),
+        :libs => library_flags(_libraries) }
+    end
+
+    def run(outfile, objfiles, *attrs)
       mkdir_p File.dirname(outfile)
-      library_flags = [libraries, _libraries].flatten.map { |d| option_library % d }
 
       _pp "LD", outfile.relative_path
-      _run link_options, { :flags => all_flags(_library_paths, _flags),
-                            :outfile => filename(outfile) , :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' '),
-                            :flags_before_libraries => [flags_before_libraries, _flags_before_libraries].flatten.join(' '),
-                            :flags_after_libraries => [flags_after_libraries, _flags_after_libraries].flatten.join(' '),
-                            :libs => library_flags.join(' ') }
+      _run link_options, link_params(*attrs).merge(
+        :outfile => filename(outfile), :objs => filename(objfiles).map{|f| %Q["#{f}"]}.join(' '))
+    end
+
+    # Link the one +objfile+ into +outfile+, with +params+ from `link_params`,
+    # and answer whether it linked, saying nothing either way.  +opts+ are
+    # `system`'s, as the compile probe ran with them.
+    def run_probe(outfile, objfile, params, **opts)
+      options = link_options % params.merge(:outfile => filename(outfile), :objs => %Q["#{filename(objfile)}"])
+      !!system("#{build.filename(command)} #{options}", **opts)
     end
   end
 


### PR DESCRIPTION
## Summary

`check_func` compiled and never linked, so it answered about the declaration a
header gives and not about the symbol a link would resolve, and a host whose
headers declare a function its C library does not define was not told apart
from one that has it. It now links a name it found declared, wherever the
build can link a program at all, and answers yes only when the link resolved
it. A gem hands its own linker to `link:` to add its libraries, `link: false`
asks about the declaration alone, and `try_link` stands beside `try_compile`.

## Changes

| File | What |
|---|---|
| `lib/mruby/build/command.rb` | `check_func(name, header:, link:)` links by default where `can_link?` holds and asks about the declaration alone otherwise or with `link: false`; `can_link?`, asked once per compiler; `func_decl_source` and `func_link_source`, the two probe sources; `try_link(source, linker = nil)`; `LINK_PROBES` beside `COMPILE_PROBES`; `probe_key`; `run_compile_probe` hands a block the object while its directory is still there; `Linker#link_params` and `Linker#run_probe`, with `Linker#run` writing its line through `link_params` so the probe and the build write the same one |
| `doc/guides/compile.md` | What `check_func` asks now, `link:` and `try_link`, under the probes |

### What is linked against

The link is the build's linker's, with the libraries and flags it links every
binary with, so `cos` answers yes through the `-lm` the gcc toolchain
carries. A gem asking after a symbol a library of its own defines hands its
own linker to `link:`, `link: spec.linker`, and that linker's libraries and
flags are linked as they are into the gem's binary. The libraries are added in
the gem's `build_settings` block, which is where a gem that has one writes
them anyway, since `reset_commands` runs just before it.

### A build that cannot link

Several configurations under `build_config` make libmruby for another program
to link: `build_mrbtest_lib_only`, a linker that is `rx-elf-ld`, `kos-ld` or
the bare `ld` a `Command::Linker` starts with, and no startup files or C
library on the line. A link fails there whatever the name, so linking by
default would have answered no to every question on them. `can_link?` asks
once whether a program that names `strlen` links, and where it does not,
`check_func` answers about declarations alone throughout, as it did. An empty
`main` is not the question: a bare `ld` links that, with a warning about the
entry point, and fails only on the first name from the C library.

### The mention

The linked probe hands the name to a variadic function through a `volatile`
function pointer:

```c
#include <unistd.h>
#ifdef setresuid
int main(void) { return 0; }
#else
static void mrb_probe_use(int n, ...);
static void mrb_probe_use(int n, ...) { (void)n; }
int main(void) {
  void (*volatile mrb_probe)(int, ...) = mrb_probe_use;
  mrb_probe(0, setresuid);
  return 0;
}
#endif
```

The pointer is what keeps the reference alive: without `volatile`, clang at
`-O3` drops it and `nm` shows no `setresuid` in the object. Nothing is cast,
because a cast between function types is what `-Wcast-function-type` reports,
and clang's `-Wcast-function-type-strict` reports even the `void (*)(void)`
gcc documents as matching everything. A macro is caught by the `#ifdef` and
answers yes without linking, there being no one symbol to ask after; the
helper sits in the `#else` arm so that arm alone defines it, or `-Wall
-Werror` would refuse the macro arm for an unused static function. In C++ an
overloaded name has no one address to hand over, `pow` from `<math.h>` among
them, and `link: false` is the question for it: the declaration probe names
an overload set with a using-declaration, as before.

### What the answer is kept under

`try_compile`'s key, the command, the option string, the source extension,
the flags and the source, plus the linker's command, its `link_options` and
the parts of the link line other than the object and the output. A hundred
repeats of one question add no entry.

## Behaviour

On this host, and on `i686-linux-gnu-gcc` and `x86_64-w64-mingw32-gcc-posix`
where the row says so:

| question | `link: false` | default |
| --- | --- | --- |
| `setresuid`, `<unistd.h>`, `_GNU_SOURCE` | true | true; false either way on mingw, which does not declare it |
| a name a header declares and nothing defines | true | false |
| a function-like macro | true | true |
| an undeclared name | false | false |
| `cos`, `<math.h>` | true | true, through the build's `-lm` |
| `SSL_new`, `<openssl/ssl.h>` | true | false against the build's linker, true with one carrying `-lssl -lcrypto` |
| `Sleep`, `<windows.h>`, on mingw | true | true |
| `pow`, `<math.h>`, from `cxx` | true | false |
| any of the above on a build whose linker is the bare `ld` | as `link: false` | as `link: false`; `can_link?` is false there |

## Speed

A probe that links runs the compiler and then the linker once, and its answer
is then a hash lookup: a hundred repeats of the `setresuid` question take 4 to
8 ms in all, adding no entry. `can_link?` is one more link per compiler that
asks.

## Size

No object changes: `Linker#run` writes the same line as before, through
`link_params`.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc 13.3 and again with clang
  23.1: all builds green, 0 KO, 0 crash, 0 warnings from the test runner, no
  compiler warnings. The same with `i686-linux-gnu-gcc`, and
  `cross-mingw-winetest` under wine 11.0: green. Every binary is linked
  through the reworked `Linker#run`.
- A configuration with five builds, host gcc and clang, `i686-linux-gnu-gcc`,
  `x86_64-w64-mingw32-gcc-posix` and a `CrossBuild` whose linker is the bare
  `ld` with `build_mrbtest_lib_only`, asking the questions in the Behaviour
  table from the configuration block and, on the gcc build, from a gem's
  `build_settings` through `link: spec.linker`: the answers above on all
  five, and `rake defines` listing the `HAVE_SSL_NEW` the gem wrote from the
  linked answer.
- The probe source compiled by hand with gcc, clang, g++ and clang++ under
  `-Wall -Wextra -Wpedantic -Wcast-function-type -Werror`, and with clang and
  clang++ under `-Weverything -Werror`: clean, `nm` showing `U setresuid` in
  every object. Linked at `-O3` with `-flto`, and at `-Os` with
  `-ffunction-sections -fdata-sections` and the linker discarding unreferenced
  sections: the reference reaches the linker in each, and a declared name
  nothing defines fails the link in each.
- The `Process::Sys` work for `mrbgems/mruby-process`, rebased onto this,
  asks for `setresuid`, `setresgid` and `issetugid` as before and gets the
  linked answers; its `rake defines` lists the first two on glibc and all
  three on musl, and its builds are green under every toolchain above and
  under musl.

## Environment

<details>

- Ubuntu 24.04, Linux 7.0.0-30-generic, x86_64
- gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, Homebrew clang version 23.1.0,
  GNU ld (GNU Binutils) 2.47
- i686-linux-gnu-gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0,
  x86_64-w64-mingw32-gcc-posix (GCC) 13-posix, wine-11.0
- ruby 4.0.6, rake 13.3.1
- base `c85303be2`

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Build capability checks can now verify whether functions are linkable, including libraries and gem-specific linkers.
  - Added support for explicitly checking declarations without linking, useful for C++ overloads.

- **Bug Fixes**
  - Improved fallback behavior when linking is unavailable.
  - Link checks now account for linker parameters when caching results.

- **Documentation**
  - Expanded the Compile guide with clearer explanations of function, header, compile, and link checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->