### PR TITLE
mruby-io: drop the compat layer the HAL replaced

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -13,15 +13,29 @@
 #include "io_hal.h"
 
 #include <sys/types.h>
-#include <sys/stat.h>
-
-#include <fcntl.h>
 
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
-/* Undefine system macros that conflict with mrb_io_stat field names */
+/* Every file operation goes through the HAL, so what a platform is asked for
+   here is the spelling of a path and the numbers File::Constants publishes. */
+#if defined(_WIN32)
+  #define NULL_FILE "NUL"
+  #define MAXPATHLEN 1024
+ #if !defined(PATH_MAX)
+  #define PATH_MAX _MAX_PATH
+ #endif
+#else
+  #define NULL_FILE "/dev/null"
+  #include <sys/file.h>   /* LOCK_* */
+  #include <sys/param.h>  /* MAXPATHLEN */
+#endif
+
+/* A host that names struct stat's time fields with macros (st_atime for
+   st_atim.tv_sec, as glibc does) would rewrite the same field names on
+   mrb_io_stat, whose own are plain members.  Undone after the last system
+   header, so that a header included above is free to define them. */
 #ifdef st_atime
 #undef st_atime
 #endif
@@ -32,39 +46,11 @@
 #undef st_ctime
 #endif
 
-#if defined(_WIN32)
-  #include <windows.h>
-  #include <io.h>
-  #define NULL_FILE "NUL"
-  #define UNLINK _unlink
-  #define GETCWD _getcwd
-  #define CHMOD(a, b) 0
-  #define MAXPATHLEN 1024
- #if !defined(PATH_MAX)
-  #define PATH_MAX _MAX_PATH
- #endif
-  #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
-  #include <direct.h>
-#else
-  #define NULL_FILE "/dev/null"
-  #include <unistd.h>
-  #define UNLINK unlink
-  #define GETCWD getcwd
-  #define CHMOD(a, b) chmod(a,b)
-  #include <sys/file.h>
-#ifndef __DJGPP__
-  #include <libgen.h>
-#endif
-  #include <sys/param.h>
-  #include <pwd.h>
-#endif
-
 #define FILE_SEPARATOR "/"
 
 #if defined(_WIN32)
   #define PATH_SEPARATOR ";"
   #define FILE_ALT_SEPARATOR "\\"
-  #define VOLUME_SEPARATOR ":"
   #define DIRSEP_P(ch) (((ch) == '/') | ((ch) == '\\'))
   #define VOLSEP_P(ch) ((ch) == ':')
   #define UNC_PATH_P(path) (DIRSEP_P((path)[0]) && DIRSEP_P((path)[1]))
@@ -87,17 +73,6 @@
 #endif
 #ifndef LOCK_UN
 #define LOCK_UN MRB_IO_LOCK_UN
-#endif
-
-#if !defined(_WIN32) || defined(MRB_MINGW32_LEGACY)
-# define mrb_stat(path, sb) stat(path, sb)
-# define mrb_fstat(fd, sb)  fstat(fd, sb)
-#elif defined MRB_INT32
-# define mrb_stat(path, sb) _stat32(path, sb)
-# define mrb_fstat(fd, sb)  _fstat32(fd, sb)
-#else
-# define mrb_stat(path, sb) _stat64(path, sb)
-# define mrb_fstat(fd, sb)  _fstat64(fd, sb)
 #endif
 
 /*
@@ -731,12 +706,6 @@ mrb_file_size(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, st.st_size);
 }
 
-static int
-mrb_ftruncate(mrb_state *mrb, int fd, mrb_int length)
-{
-  return mrb_hal_io_ftruncate(mrb, fd, length);
-}
-
 /*
  * call-seq:
  *   file.truncate(integer) -> 0
@@ -754,7 +723,7 @@ mrb_file_truncate(mrb_state *mrb, mrb_value self)
   mrb_value lenv = mrb_get_arg1(mrb);
   int fd = mrb_io_fileno(mrb, self);
   mrb_int length = mrb_as_int(mrb, lenv);
-  if (mrb_ftruncate(mrb, fd, length) != 0) {
+  if (mrb_hal_io_ftruncate(mrb, fd, length) != 0) {
     mrb_sys_fail(mrb, "ftruncate");
   }
 

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -17,23 +17,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+/* A descriptor and the bytes moved through it go through the HAL, so what a
+   platform is asked for here is the width of a size and of a mode, the open
+   flags it names, and the way it reports a child's exit. */
 #if defined(_WIN32)
-  #include <winsock.h>
-  #include <io.h>
-  #include <basetsd.h>
+  #include <winsock.h>    /* getsockopt(), to tell a socket from a descriptor */
   #include <stdlib.h>
-  #define open  _open
-  #define close _close
-  #define dup _dup
-  #define dup2 _dup2
-  #define read  _read
-  #define write _write
-  #define lseek _lseek
-  #define isatty _isatty
   #define WEXITSTATUS(x) (x)
   typedef int fsize_t;
-  typedef long ftime_t;
-  typedef long fsuseconds_t;
   typedef int fmode_t;
   typedef int fssize_t;
 
@@ -42,16 +33,9 @@
   #endif
 
 #else
-  #include <sys/wait.h>
-  #include <sys/time.h>
+  #include <sys/wait.h>   /* WEXITSTATUS() */
   #include <unistd.h>
   typedef size_t fsize_t;
-  typedef time_t ftime_t;
-#ifdef __DJGPP__
-  typedef long fsuseconds_t;
-#else
-  typedef suseconds_t fsuseconds_t;
-#endif
   typedef mode_t fmode_t;
   typedef ssize_t fssize_t;
 #endif
@@ -314,10 +298,6 @@ io_alloc(mrb_state *mrb)
   fptr->close_fd2 = 1;
   return fptr;
 }
-
-#ifndef NOFILE
-#define NOFILE 64
-#endif
 
 #ifndef MRB_HAL_IO_HAS_SPAWN_PROCESS
 /* this port runs no command: unimplemented, and named as such so


### PR DESCRIPTION
## Summary

The IO HAL took over every call that `src/` used to make itself, but the macros and typedefs that stood in for those calls stayed behind. Reading `io.c` or `file.c` now means walking past a platform layer that nothing below it reads. This removes what has no callers left. No behaviour changes.

## Changes

| File | What |
|---|---|
| `mrbgems/mruby-io/src/file.c` | drop `UNLINK` / `GETCWD` / `CHMOD`, the `realpath()` spelled as `_fullpath()`, `mrb_stat()` / `mrb_fstat()`, `VOLUME_SEPARATOR`, `mrb_ftruncate()` and eight headers; move the `st_*time` `#undef` block after the last system header |
| `mrbgems/mruby-io/src/io.c` | drop the `open` to `isatty` underscore macros, `ftime_t` / `fsuseconds_t`, `NOFILE`, and `io.h` / `basetsd.h` / `sys/time.h` |

### file.c

- `UNLINK`, `GETCWD`, `CHMOD`, and `realpath()` spelled as `_fullpath()`: unlink, getcwd, chmod and realpath all go through the HAL.
- `mrb_stat()` / `mrb_fstat()`, which chose between `stat()`, `_stat32()` and `_stat64()`: `file.c` names no `struct stat`.
- `VOLUME_SEPARATOR`, which no path macro reads.
- The headers those needed: `windows.h`, `io.h`, `direct.h`, `unistd.h`, `libgen.h`, `pwd.h`, `sys/stat.h`, `fcntl.h`. `sys/file.h` and `sys/param.h` stay, for `LOCK_*` and `MAXPATHLEN`.
- `mrb_ftruncate()`, which only forwarded to the HAL.

Dropping `sys/stat.h` changes where the `st_atime` macros can arrive from, so the `#undef` block that keeps them off the fields of `mrb_io_stat` moves after the last system header rather than before it. Without that move the build fails on glibc, where `st_mtime` is `st_mtim.tv_sec`.

### io.c

- `open`, `close`, `dup`, `dup2`, `read`, `write`, `lseek`, `isatty` defined to the Windows CRT's underscore spellings: each is reached through the HAL, and none is called bare.
- `ftime_t` and `fsuseconds_t`, which named the types a `select()` timeout used to be built from; `IO.select` builds an `mrb_io_timeval`.
- `NOFILE`, unused since the descriptor loop that read it.
- `io.h`, `basetsd.h` and `sys/time.h`. `winsock.h` stays for the `getsockopt()` that tells a socket from a descriptor, `sys/wait.h` for `WEXITSTATUS()`, `sys/stat.h` for `check_file_descriptor()`.

What is left in both files is what the platform still answers for: the spelling of a path, the width of a size and of a mode, the open flags it names, the numbers `File::Constants` publishes, and how it reports a child's exit.

## Size

`.text` of `bin/mruby` for the seven `ci/gcc-clang` builds, gcc 13.3, base `64dead36c`.

| Build | master | this PR | delta |
|---|---:|---:|---:|
| bintest | 1,383,078 | 1,383,078 | 0 |
| ascii-ctype | 1,367,542 | 1,367,542 | 0 |
| byte-string | 1,344,902 | 1,344,902 | 0 |
| cxx_abi | 1,415,769 | 1,415,769 | 0 |
| no-float | 1,308,846 | 1,308,846 | 0 |
| no-bigint | 1,267,702 | 1,267,702 | 0 |
| full-debug (-O0) | 1,975,494 | 1,975,446 | -48 |

The 48 bytes in `full-debug` are the `mrb_ftruncate()` wrapper, which `-O0` emitted as a function and `-O3` had already inlined.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc 13.3: the seven library suites and bintest, 0 KO, 0 Crash.
- `MRUBY_CONFIG=cross-mingw-winetest rake -m test` with mingw-w64 gcc 13 under wine 11.0: 2844 library tests and 100 bintests, 0 KO, 0 Crash. This compiles both files with `_WIN32` defined and runs the result.
- The same tree ran the full workflow set on my fork; every job passes, including Windows-VC and both mingw jobs, so the MSVC side of the removals (`_stat64()`, the underscore CRT names) is compiled there.

## Environment

<details>
<summary>Host and compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic x86_64 |
| CPU | AMD Ryzen 9 5950X (32 threads) |
| C compiler | gcc 13.3.0 |
| binutils | GNU ld 2.47 |
| mingw | x86_64-w64-mingw32-gcc-posix 13, wine 11.0 |
| CRuby | ruby 4.0.6 |

Compile line of `file.c` per build, from `rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` options dropped:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/file.c
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined platform-specific file and I/O handling across supported environments.
  - Standardized file operations through the unified I/O layer, improving consistency across platforms.
  - Preserved existing file metadata and stream behavior while reducing platform-dependent implementation details.
  - No changes to the public API or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->