### PR TITLE
mruby-process: let the port say what it implements

### DIFF
--- a/mrbgems/mruby-process/README.md
+++ b/mrbgems/mruby-process/README.md
@@ -22,8 +22,8 @@ from, the second the `Struct` `Process::Tms` is one of.
 | Process.pid                       | o             | also `$$`                                |
 | Process.ppid                      | o             |                                          |
 | Process.kill                      | o             | no negative-signal form yet, see below   |
-| Process.wait, .wait2              | o             | `.waitpid2` too; not `.waitall`          |
-| Process.waitpid                   | o             | sets `$?`; POSIX only, see below         |
+| Process.wait, .wait2              | o             | if the port waits; not `.waitall`        |
+| Process.waitpid, .waitpid2        | o             | sets `$?`; if the port waits, see below  |
 | Process.clock_gettime             | o             | seven units; symbolic clock ids          |
 | Process.clock_getres              | o             | takes `:hertz` too                       |
 | Process.times                     | o             | needs a build with Float, see below      |
@@ -55,6 +55,27 @@ from, the second the `Struct` `Process::Tms` is one of.
 | Process.exit, .exit!              |               | see mruby-exit                           |
 | Process.uid, .gid, ...            |               | separate change                          |
 | Process.getpgrp, ...              |               | separate change                          |
+
+## What the port declares
+
+Whether a method exists is the port's to say, since the port is what a build
+names and a `hal-process-<conf>` gem may stand in for the bundled ones. Each
+port publishes a `process_hal_features.h` in its `include/`, which
+`include/process_hal.h` reads before it declares anything. One macro there
+guards the prototype, the port's implementation and the method definition, so
+a capability the port does not declare is marked not implemented, as mruby-dir
+and mruby-io mark theirs: `respond_to?` answers false for it and a call raises
+`NotImplementedError`. A port that declares a capability it does not implement
+fails to link.
+
+| macro                      | methods                                           | posix | win |
+| -------------------------- | ------------------------------------------------- | ----- | --- |
+| `MRB_HAL_PROCESS_HAS_WAIT` | `Process.wait`, `.waitpid`, `.wait2`, `.waitpid2` | o     |     |
+
+`Process::WNOHANG` and `Process::WUNTRACED` are the shape of the call and are
+defined whether or not the port waits. What a port has but cannot do for the
+arguments it was given, a signal Windows cannot deliver or a pid selector it
+does not read, fails at the call site through `errno` instead.
 
 ## Architecture
 
@@ -131,9 +152,10 @@ constrains; this list is a map.
   from `mruby-io` decodes through the same path (`src/status.c`).
 - `raw_status` is permanent, not a compatibility detail: it is what `#to_i`
   returns and the only thing a status needs to store.
-- Unsupported operations fail through `errno` (`ENOSYS`) rather than by the
-  method being absent, so a program is told at the call site what this
-  platform will not do.
+- A port says in its `process_hal_features.h` what it does not implement at
+  all, and the method is marked not implemented; an operation it has but
+  cannot do for these arguments fails through `errno` (`ENOSYS`), so a program
+  is told at the call site what this platform will not do.
 - `Process::Status.new` is undefined, as in CRuby; the allocator is left
   alone so `mrb_obj_new()` keeps working (`src/status.c`).
 - A `Process::Status` is frozen once built; a subclass instance is not
@@ -184,20 +206,23 @@ constrains; this list is a map.
   port sources detail the calls.
 - On Windows only `KILL` and `TERM` can be delivered (as
   `TerminateProcess()`), signal 0 asks whether the process can be opened, and
-  any other signal fails with `ENOSYS`. A wait status is the child's exit code
-  and nothing more, so a status always reads as exited, and `Process.waitpid`
-  fails for every process (`ENOSYS` for -1, `ECHILD` for a specific pid) until
-  `Process.spawn` exists to make children; `ports/win/process_hal.c` says why.
+  any other signal fails with `ENOSYS`. A raw status is the child's exit code
+  and nothing more, so a status always reads as exited. The port declares no
+  wait until `Process.spawn` exists to make children;
+  `ports/win/include/process_hal_features.h` says why.
 - On Windows `Process::Tms#cutime` and `#cstime` always read `0.0`: Win32
   reports no reaped child's CPU time, and CRuby's Windows build answers the
   same way.
 
 ## Adding a port
 
-Create `ports/<name>/` with sources implementing every function in
-`include/process_hal.h`, then build with `conf.ports :<name>, :posix` so gems
-without a `<name>` port fall back. Every `.c` under the directory is compiled;
-the bundled ports keep the clocks apart in `clock_hal.c` and the rest in
-`process_hal.c`, which is a convenience rather than a rule. A port that cannot do something should set
-`errno` to `ENOSYS` and return the documented failure value rather than
-pretending to succeed.
+Create `ports/<name>/` with an `include/process_hal_features.h` declaring what
+the port implements and sources implementing every function
+`include/process_hal.h` declares under it, then build with
+`conf.ports :<name>, :posix` so gems without a `<name>` port fall back. Every
+`.c` under the directory is compiled; the bundled ports keep the clocks apart
+in `clock_hal.c` and the rest in `process_hal.c`, which is a convenience rather
+than a rule. A port that cannot do something for the arguments it was given
+should set `errno` to `ENOSYS` and return the documented failure value rather
+than pretending to succeed; something it cannot do at all it leaves
+undeclared.

--- a/mrbgems/mruby-process/include/process_hal.h
+++ b/mrbgems/mruby-process/include/process_hal.h
@@ -32,6 +32,19 @@
 #include <mruby.h>
 #include <stdint.h>
 
+/*
+ * What the port implements
+ *
+ * The port publishes it in a header under its include/, and the build puts
+ * that directory on the include path of this gem and of every gem that
+ * depends on it.  Whether a method exists is the port's to say, because the
+ * port is what a build names: a cross build has no host to detect one from,
+ * and a `hal-process-<conf>` gem may stand in for the bundled ports
+ * altogether.  What each macro says, and what it guards, is written where it
+ * is defined.
+ */
+#include "process_hal_features.h"
+
 MRB_BEGIN_DECL
 
 /*
@@ -164,8 +177,14 @@ mrb_int mrb_hal_process_pid(mrb_state *mrb);
    cannot name a parent (errno ENOSYS when it has no such notion at all). */
 mrb_int mrb_hal_process_ppid(mrb_state *mrb);
 
+#ifdef MRB_HAL_PROCESS_HAS_WAIT
 /*
  * Wait for a child process to change state.
+ *
+ * Declared in the port's process_hal_features.h.  A port without it has no
+ * children to wait for, and the gem defines no wait rather than one that
+ * fails; the status decoder below is asked for all the same, since a status
+ * can arrive from elsewhere, mruby-io's `IO.popen` being one source.
  *
  * @param pid         child to wait for, or MRB_PROCESS_WAIT_ANY
  * @param flags       zero or more MRB_PROCESS_WAIT_* bits
@@ -177,6 +196,7 @@ mrb_int mrb_hal_process_ppid(mrb_state *mrb);
  */
 int mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
                             mrb_int *result_pid, mrb_int *raw_status);
+#endif
 
 /*
  * Send a signal to a process.

--- a/mrbgems/mruby-process/ports/posix/include/process_hal_features.h
+++ b/mrbgems/mruby-process/ports/posix/include/process_hal_features.h
@@ -1,0 +1,20 @@
+/*
+** process_hal_features.h - what the POSIX port of mruby-process implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/process_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in process_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_PROCESS_HAL_FEATURES_H
+#define MRUBY_PROCESS_HAL_FEATURES_H
+
+/* waitpid(2): `Process.wait`, `Process.waitpid`, `Process.wait2` and
+   `Process.waitpid2`. */
+#define MRB_HAL_PROCESS_HAS_WAIT
+
+#endif /* MRUBY_PROCESS_HAL_FEATURES_H */

--- a/mrbgems/mruby-process/ports/posix/process_hal.c
+++ b/mrbgems/mruby-process/ports/posix/process_hal.c
@@ -63,6 +63,7 @@ mrb_hal_process_ppid(mrb_state *mrb)
  * Waiting
  */
 
+#ifdef MRB_HAL_PROCESS_HAS_WAIT
 int
 mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
                         mrb_int *result_pid, mrb_int *raw_status)
@@ -90,6 +91,7 @@ mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
   *raw_status = (result == 0) ? 0 : (mrb_int)status;
   return 0;
 }
+#endif
 
 /*
  * Signalling

--- a/mrbgems/mruby-process/ports/win/include/process_hal_features.h
+++ b/mrbgems/mruby-process/ports/win/include/process_hal_features.h
@@ -1,0 +1,23 @@
+/*
+** process_hal_features.h - what the Windows port of mruby-process implements
+**
+** See Copyright Notice in mruby.h
+**
+** The gem's include/process_hal.h reads this before it declares anything.  A macro defined
+** here guards three things at once: the prototype there, the implementation
+** in process_hal.c, and the method definition under src/.  A port that declared a
+** capability and did not implement it would fail to link, and one that
+** declares nothing owes nothing.
+*/
+
+#ifndef MRUBY_PROCESS_HAL_FEATURES_H
+#define MRUBY_PROCESS_HAL_FEATURES_H
+
+/* No wait.  Win32 waits on a handle, and a handle is got by opening a
+   process ID, which succeeds for any process this one may open and says
+   nothing about parentage: waiting on one would report a stranger's exit
+   code as a child's.  A port learns of its children when it creates them,
+   so `Process.wait` and its three other spellings are answerable once
+   spawn exists and not before. */
+
+#endif /* MRUBY_PROCESS_HAL_FEATURES_H */

--- a/mrbgems/mruby-process/ports/win/process_hal.c
+++ b/mrbgems/mruby-process/ports/win/process_hal.c
@@ -8,15 +8,8 @@
 ** part of the interface Win32 can answer honestly and fails, rather than
 ** guesses, at the rest:
 **
-**   - a wait cannot be answered at all.  Win32 identifies a process to wait
-**     on by handle, and a handle is obtained by opening a process ID, which
-**     succeeds for any process this one may open rather than only for its
-**     own children.  Waiting on it would report a stranger's exit code as a
-**     child's, so every wait fails instead: ECHILD for a specific process,
-**     since this port can name no child, and ENOSYS for MRB_PROCESS_WAIT_ANY,
-**     which has no handle standing for it.  A port learns of its children
-**     when it creates them, so this is answerable once spawn exists and not
-**     before.  No process is ever reported as stopped either;
+**   - a wait is not declared at all; include/process_hal_features.h says
+**     why.  No process is ever reported as stopped either;
 **   - a raw status is the child's exit code, which is what mruby-io's
 **     `IO.popen` already gives the `Process::Status` it builds on this
 **     platform, so a decoded status always reads as exited;
@@ -127,37 +120,6 @@ mrb_hal_process_ppid(mrb_state *mrb)
 
   if (ppid < 0) errno = ESRCH;
   return ppid;
-}
-
-/*
- * Waiting
- */
-
-int
-mrb_hal_process_waitpid(mrb_state *mrb, mrb_int pid, unsigned int flags,
-                        mrb_int *result_pid, mrb_int *raw_status)
-{
-  (void)mrb;
-  (void)flags;
-  (void)result_pid;
-  (void)raw_status;
-
-  /* A wait needs a handle, and there is no handle standing for "any child". */
-  if (pid <= 0) {
-    errno = ENOSYS;
-    return -1;
-  }
-
-  /* OpenProcess() opens any process this one is allowed to open, and asks
-     nothing about parentage, so a handle got that way is no evidence that
-     the process is a child.  Waiting on it would answer Process.waitpid with
-     an unrelated process's exit code and publish it as `$?`.  ECHILD is both
-     the honest answer and the same one a real child gets from a wait that
-     has already reaped it: this port knows of no children, because a port
-     learns of its children by creating them, and creating them is spawn's
-     to add. */
-  errno = ECHILD;
-  return -1;
 }
 
 /*

--- a/mrbgems/mruby-process/src/process.c
+++ b/mrbgems/mruby-process/src/process.c
@@ -30,14 +30,6 @@
 #include <stdint.h>
 #include <string.h>
 
-/* `$?` and `$$` are not word names, so MRB_GVSYM() cannot spell them and
-   they are interned where they are used. */
-static void
-set_last_status(mrb_state *mrb, mrb_value status)
-{
-  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$?"), status);
-}
-
 /*
  * Refuse a value that would not survive the narrowing a port has to do with
  * it.
@@ -225,6 +217,15 @@ process_kill(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, argc);
 }
 
+#ifdef MRB_HAL_PROCESS_HAS_WAIT
+/* `$?` and `$$` are not word names, so MRB_GVSYM() cannot spell them and
+   they are interned where they are used. */
+static void
+set_last_status(mrb_state *mrb, mrb_value status)
+{
+  mrb_gv_set(mrb, mrb_intern_lit(mrb, "$?"), status);
+}
+
 /* The wait itself.  Two module functions differ only in whether the status
    is handed back beside the pid, so the wait is done here and both of them
    publish it through `$?`. */
@@ -311,6 +312,14 @@ process_waitpid2(mrb_state *mrb, mrb_value self)
   if (mrb_nil_p(pid)) return mrb_nil_value();
   return mrb_assoc_new(mrb, pid, status);
 }
+#else
+/* A port that declares no wait has no children to wait for.  The four
+   spellings are defined as `mrb_notimplement_m`, the mark of a body this
+   build does not supply: `respond_to?` answers false for them and a call
+   raises NotImplementedError, as mruby-dir and mruby-io mark theirs. */
+# define process_waitpid  mrb_notimplement_m
+# define process_waitpid2 mrb_notimplement_m
+#endif
 
 void
 mrb_mruby_process_gem_init(mrb_state *mrb)

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -18,13 +18,20 @@ module ProcessTestUtil
   # there is nothing there to give Process.waitpid or Process.kill, and its
   # IO.popen sets $? through a path that never fires; both are mruby-io's to
   # fix, and neither is what this gem is being tested for.  The Windows port
-  # would refuse the wait in any case: it cannot tell a child from any other
-  # process it may open, so it reports ECHILD rather than a stranger's exit
-  # code.  See the README.
+  # declares no wait in any case: it cannot tell a child from any other
+  # process it may open, so it does not wait at all rather than report a
+  # stranger's exit code.  See the README.
   def self.child_reason
     return "IO.popen is not available" unless popen?
     return "IO#pid is a process handle, not a pid, on this platform" if windows?
     nil
+  end
+
+  # Whether this port declares a wait.  The four spellings and the wait
+  # behind them come and go together, which the test below pins, so one of
+  # them is asked for all.
+  def self.wait?
+    Process.respond_to?(:waitpid)
   end
 
   # Whether Process.kill turned +pid+ down rather than passing it on.  What a
@@ -128,7 +135,28 @@ assert('Process::WNOHANG, Process::WUNTRACED') do
   assert_equal 0, Process::WNOHANG & Process::WUNTRACED
 end
 
+assert('the wait is what the port declares') do
+  # Whether there is a wait is the port's to say, through its
+  # process_hal_features.h, and it says it once for all four spellings: a
+  # port that declares none leaves all four marked as not implemented, which
+  # `respond_to?` answers false for and a call raises NotImplementedError
+  # from.  The two option constants are the shape of the call and stay
+  # defined either way.
+  spellings = [:wait, :waitpid, :wait2, :waitpid2]
+  spellings.each do |name|
+    assert_equal ProcessTestUtil.wait?, Process.respond_to?(name), name.to_s
+  end
+  unless ProcessTestUtil.wait?
+    spellings.each do |name|
+      assert_raise(NotImplementedError, name.to_s) { Process.__send__(name) }
+    end
+  end
+  assert_true Process.const_defined?(:WNOHANG)
+  assert_true Process.const_defined?(:WUNTRACED)
+end
+
 assert('Process.waitpid with a flag it does not define') do
+  skip "this port declares no wait" unless ProcessTestUtil.wait?
   # A port answers for the bits it is given and says nothing about the rest,
   # so a bit that stands for nothing is refused before it reaches one.  A
   # negative value is refused for the same reason: read as the unsigned value
@@ -139,6 +167,7 @@ assert('Process.waitpid with a flag it does not define') do
 end
 
 assert('Process.waitpid reports the error by itself') do
+  skip "this port declares no wait" unless ProcessTestUtil.wait?
   # What a SystemCallError message carries after the error is the object the
   # call was working on, the way `File.open` names the path it could not open.
   # A wait has no such object and CRuby names nothing here.  Compared against
@@ -289,7 +318,7 @@ assert('a pid or a signal number too large for the platform') do
   skip "this build cannot name a number wider than a pid" unless big
 
   assert_raise(RangeError) { Process.kill(0, big) }
-  assert_raise(RangeError) { Process.waitpid(big) }
+  assert_raise(RangeError) { Process.waitpid(big) } if ProcessTestUtil.wait?
 
   # As a signal, its size is only what is wrong with it where the build's own
   # Integer carries it: a build that promoted it to a big integer refuses it


### PR DESCRIPTION
## Summary

Whether a method exists is the port's to decide, since the port is what a build names and a cross build has no host to detect the platform from. Since #7472 a port can say so: its `include/` is on the include path of the gem it serves, and `mruby-dir` reads its `dir_hal_features.h` there. `mruby-process` had no such header. Its Windows port implemented `mrb_hal_process_waitpid()` as a function whose whole body was a refusal, so that `Process.waitpid` existed on every port and told a program at the call site that this one would never wait.

The gem now uses the mechanism the way `mruby-dir` does. Each bundled port declares in its `include/process_hal_features.h` what it implements, one macro guards the prototype, the POSIX implementation and the method definitions, and the refusing stub is deleted. The Windows port declares nothing, because it has nothing to wait for: Win32 waits on a handle, a handle is got by opening a process ID, and that succeeds for any process this one may open, so a wait on one could report a stranger's exit code as a child's. A port learns of its children when it creates them, so the declaration belongs with spawn.

## Changes

| File | What |
| --- | --- |
| `mruby-process/ports/{posix,win}/include/process_hal_features.h` | new; `MRB_HAL_PROCESS_HAS_WAIT`, declared by the POSIX port and not by the Windows one |
| `mruby-process/include/process_hal.h` | includes the feature header; guards the prototype of `mrb_hal_process_waitpid()` |
| `mruby-process/ports/posix/process_hal.c` | the implementation is guarded by the feature macro |
| `mruby-process/ports/win/process_hal.c` | the refusing `mrb_hal_process_waitpid()` is deleted; the reasoning moves to the feature header |
| `mruby-process/src/process.c` | `Process.wait`, `.waitpid`, `.wait2` and `.waitpid2` follow the macro, and are `mrb_notimplement_m` where it is not defined |
| `mruby-process/test/process.rb` | new test: the four spellings answer `respond_to?` together and the two constants exist either way; the three wait tests that ran on every port skip where the port declares no wait |
| `mruby-process/README.md` | a "What the port declares" section with the table of macros |

### One macro, three places

Each bundled port ships a `process_hal_features.h`. A macro defined there guards the prototype in `process_hal.h`, the implementation in the port, and the method definition in `src/`, so a port that declares a capability without implementing it fails to link, and a port that declares nothing owes nothing: the method is defined as `mrb_notimplement_m`, so `respond_to?` answers false and a call raises `NotImplementedError`, as `mruby-dir` and `mruby-io` mark theirs.

`Process::WNOHANG` and `Process::WUNTRACED` stay defined on every port: they are the shape of the call, not a capability. What a port has but cannot do for the arguments it was given, a signal Windows cannot deliver or a pid selector it does not read, still fails through `errno` at the call site, and the README now draws that line.

## Behaviour

On POSIX, nothing observable changes. On Windows:

```ruby
Process.respond_to?(:waitpid)   # was true, now false
Process.waitpid(pid)            # was Errno::ECHILD, now NotImplementedError
Process.waitpid                 # was Errno::ENOSYS, now NotImplementedError
```

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory with `rake`; base is master b9ec0fa1a.

| build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| bintest | 1,383,078 | 1,383,078 | 0 |
| ascii-ctype | 1,367,542 | 1,367,542 | 0 |
| byte-string | 1,344,902 | 1,344,902 | 0 |
| cxx_abi | 1,415,769 | 1,415,769 | 0 |
| no-float | 1,308,846 | 1,308,846 | 0 |
| no-bigint | 1,267,702 | 1,267,702 | 0 |
| full-debug (-O0) | 1,975,494 | 1,975,494 | 0 |

On a POSIX host no object moves: `process.o` and the POSIX `process_hal.o` are the same size in every build, and `nm -S` of `process.o` lists the same symbols at the same sizes, since on this port the macro is declared and the guards select the code that was there. The Windows binary loses the stub; it was not measured here.

## Testing

The commit was built from an empty directory and run with `rake -m test`, and `SKIP=markdownlint,actionlint prek run --from-ref HEAD^ --to-ref HEAD` passed, with `prettier --check` on the README.

- host (`build_config/default.rb`): mrbtest 2,620 (OK 2,552 / Skip 68), KO 0 / Crash 0 / Warning 0
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`): mrbtest KO 0 / Crash 0 / Warning 0 in every build (bintest 2,863, ascii-ctype 2,852, byte-string 2,780, cxx_abi 2,863, no-float 2,598, no-bigint 2,817, full-debug 2,863), bintest 147 (OK 146 / Skip 1)
- `build_config/cross-mingw-winetest.rb` under wine: mrbtest 2,845 (OK 2,798 / Skip 47), bintest 100 (OK 92 / Skip 8), KO 0 / Crash 0 / Warning 0. The new test takes its Windows branch here: all four spellings answer `respond_to?` false and raise `NotImplementedError`
- `rake amalgam`: the port's `process_hal_features.h` is inlined before `process_hal.h` in the generated `mruby.h`, and `gcc -std=gnu99 -fsyntax-only -Wall -Wundef mruby.c` reports nothing

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

| | |
| --- | --- |
| OS | Linux 7.0.0-30-generic x86_64 |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| mingw | x86_64-w64-mingw32-gcc (GCC) 13-win32, wine-11.0 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-process/src/process.c` from each build's `compile_commands.json`, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-process/src/process.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DHAVE_SYS_RESOURCE_H -DMRBGEM_MRUBY_PROCESS_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-process/src/process.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process-wait methods now consistently reflect platform support.
  * Unsupported wait methods report unavailable through `respond_to?` and raise `NotImplementedError` when called.

* **Bug Fixes**
  * Windows no longer exposes unsupported process-wait operations.
  * Wait-related status handling now aligns with each platform’s declared capabilities.

* **Documentation**
  * Updated guidance explains platform-specific process-wait availability, unsupported operations, and port capability declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->