### PR TITLE
mruby-regexp: keep the levels a pattern nests on a stack of the parser's own

### DIFF
--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -83,18 +83,6 @@ MRuby::Build.new('ascii-ctype') do |conf|
   conf.gembox 'full-core'
   conf.cc.defines << 'MRB_USE_ASCII_CTYPE'
 
-  # A second mruby-regexp refusal that needs a build of its own: the parse
-  # depth limit. Reaching a limit costs the C stack that limit stands for,
-  # about 600 bytes a level, so no build can be asked to reach the default
-  # 4096, whose 2.4 MiB is more than a Windows thread's whole stack, and the
-  # test skips above 512 for that reason. This build sets a limit a test may
-  # reach anywhere in the matrix, some 300 KiB, which is what gives
-  # `parse depth limit over` a home; the arithmetic that refuses is the same
-  # at any limit. It rides along here rather than in a build of its own so
-  # that the matrix runs no extra pass, and it costs this build nothing: the
-  # depth a pattern may nest is not what ASCII classification is about.
-  conf.cc.defines << 'MRB_REGEXP_PARSE_DEPTH_LIMIT=512'
-
   # mruby-process reads CPU time through getrusage(2) wherever the header
   # probe finds <sys/resource.h>, which is every host this matrix runs on, so
   # its times(2) fallback would otherwise compile nowhere in CI. Answering the

--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -334,7 +334,7 @@ Every entry is a place this engine answers a pattern differently from CRuby.
 #define MRB_REGEXP_STACK_LIMIT 2048
 #endif
 
-/* How deep a pattern may nest, the parser's own C stack (1 to 1,048,576) */
+/* How deep a pattern may nest (1 to 1,048,576) */
 #ifndef MRB_REGEXP_PARSE_DEPTH_LIMIT
 #define MRB_REGEXP_PARSE_DEPTH_LIMIT 4096
 #endif
@@ -359,27 +359,35 @@ assertions that reach the engine below it.
 
 ### The parse depth limit
 
-`MRB_REGEXP_PARSE_DEPTH_LIMIT` bounds the compiler and guards the C stack. A
-pattern past it raises `RegexpError`, `parse depth limit over`, CRuby's
-message. Every group, lookaround, atomic group and inline option toggle costs a
-level. The default is Onigmo's `ONIG_MAX_PARSE_DEPTH`, so the refusal point is
-CRuby's.
+`MRB_REGEXP_PARSE_DEPTH_LIMIT` bounds how deep a pattern may nest. A pattern
+past it raises `RegexpError`, `parse depth limit over`, CRuby's message. Every
+group, lookaround, atomic group, inline option toggle and nested character
+class costs a level. The default is Onigmo's `ONIG_MAX_PARSE_DEPTH`, so the
+refusal point is CRuby's.
 
-**A build on a stack smaller than about 3 MiB has to lower it.** A level costs
-about 600 bytes on a 64-bit build, so the default's deepest pattern spends 2.4
-MiB. Size the limit from a third of the stack:
+The parser keeps the levels it has open on a heap stack of its own, as the
+backtracking engine keeps its state, so a compile spends a constant amount of C
+stack however deep the pattern nests. The limit is a matter of agreement with
+CRuby rather than of stack, and one value holds for every build.
 
-| Stack   | A limit that fits           |
-| ------- | --------------------------- |
-| 8 MiB   | 4096 (default, CRuby-exact) |
-| 1 MiB   | 512                         |
-| 256 KiB | 128                         |
-| 64 KiB  | 32                          |
+What the limit costs is heap, and only while a pattern that deep compiles: a
+level is 32 bytes on any ABI, the first eight (the pattern itself is one) live
+in the compiler's own frame, and past them the levels move to a buffer that
+doubles as it grows. Raising the limit reserves nothing; it bounds what one
+pattern can be made to use, at the limit rounded up to a power of two times 32
+bytes, plus one String header:
 
-`-Os` and a 32-bit ABI make a level cheaper; `-fstack-usage` over
-`re_compile.c` gives the figure as `compile_alt` plus `compile_seq`. Written
-patterns do not nest this deep: 128 still takes every pattern anyone writes and
-gives up only the CRuby-exact refusal point.
+| Limit          | Heap a pattern can spend |
+| -------------- | ------------------------ |
+| 4096 (default) | 128 KiB                  |
+| 512            | 16 KiB                   |
+| 128            | 4 KiB                    |
+| 32             | 1 KiB                    |
+
+A build that cannot make the allocation raises `NoMemoryError`. A nested
+character class is the one construct still read by recursion, at about 500
+bytes of C stack a level, which the class table bounds at 256 levels whatever
+the limit.
 
 ### What the build decides
 

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -381,40 +381,23 @@ typedef struct mrb_regexp_pattern {
 #endif
 
 /* How deep a pattern may nest. Every construct that opens a level costs one:
-   a group of any kind, a lookaround, an atomic group, and an inline option
+   a group of any kind, a lookaround, an atomic group, an inline option
    toggle, which encloses the rest of the group it stands in and so is a level
-   of its own (see compile_alt() in re_compile.c). A pattern past this is
-   `parse depth limit over`, which is CRuby's message for the same refusal.
-
-   Unlike the two limits above, what this one guards is the C stack: the
-   parser recurses per level, so without it a deep enough pattern reaches the
-   end of the stack, which is a crash rather than an error.
+   of its own, and a character class nested in another (see open_level() and
+   parse_nested_class() in re_compile.c). A pattern past this is `parse depth
+   limit over`, which is CRuby's message for the same refusal.
 
    The default is Onigmo's ONIG_MAX_PARSE_DEPTH, so a pattern is refused
-   exactly where CRuby refuses it. What that costs is stack, and a build has
-   to know the price: a level takes about 600 bytes on a 64-bit build, so the
-   deepest pattern the default accepts spends around 2.4 MiB, and a pattern
-   deeper than that spends the same before being refused, the count being
-   reached at the bottom of the recursion. A build whose stack is smaller
-   than that -- the 1 MiB a Windows thread is given by default is, and an
-   RTOS task is by far -- has to set this to what it can pay for or keep the
-   crash the limit is here to prevent: a third of the stack is the share to
-   size it from, the compiler not being the only thing standing on that
-   stack, so about 512 for 1 MiB, 128 for 256 KiB, 32 for 64 KiB. The figure
-   to divide is the build's own: -Os and a 32-bit ABI both make a level
-   cheaper, and `-fstack-usage` over re_compile.c names it (the frames of
-   compile_alt and compile_seq, the rest inlining into them: 560 bytes on a
-   64-bit gcc -O2 build, 528 at -Os, 592 on a clang -O3 one).
-
-   Lowering it costs little in practice. Nesting this deep is not what a
-   written pattern does -- a handful of levels is ordinary and dozens are
-   unusual -- so a build that sets 128 still takes every pattern anyone
-   writes, and trades only the CRuby-exact refusal point for a crash it
-   cannot otherwise avoid.
+   exactly where CRuby refuses it, and that agreement is all this limit
+   guards: the parser keeps the levels it has open on the heap, 32 bytes
+   each, so a pattern nested past what the machine holds is refused by the
+   allocator, at whatever depth that is, and no build has a stack to size
+   this from. One value holds for every build. (A nested character class is
+   still read by recursion, at about 500 bytes of C stack a level, which the
+   class table bounds at 256 levels.)
 
    The floor is 1, a build that takes no nesting at all; the ceiling is where
-   the limit stops being one, every stack this engine runs on having ended
-   long before. */
+   the limit stops being one, a million levels being 32 MiB of them. */
 #ifndef MRB_REGEXP_PARSE_DEPTH_LIMIT
 #define MRB_REGEXP_PARSE_DEPTH_LIMIT 4096
 #endif

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2594,6 +2594,400 @@ parse_group_ref(re_compiler *c)
   return group;
 }
 
+/* Compile what a '(' opens, the '(' itself just consumed: a group of any
+   kind, a lookaround, an atomic group, an absent repeater, a conditional or
+   an inline option, through the ')' that closes it where the construct has
+   one. Answers as compile_atom() does for it: TRUE, an atom having been
+   read. */
+static mrb_bool
+open_group(re_compiler *c)
+{
+  mrb_bool capturing = TRUE;
+
+  /* Options in effect on entry. A group restores them on exit so an
+     inline toggle like (?i) inside it (which sets c->flags for the rest
+     of the group) does not leak past the closing ')'. */
+  uint32_t saved_flags = c->flags;
+
+  const char *cap_name = NULL;
+  uint32_t cap_name_len = 0;
+
+  /* `(?` and nothing more: the prefix that names which group this is
+     runs off the end of the pattern. It is reported here because what
+     the parser would otherwise be left with is a `?` standing where no
+     atom is, which compile_seq() reads as a quantifier with nothing to
+     repeat. */
+  if (peek(c) == '?' && c->p + 1 >= c->src_end) {
+    compile_error(c, "end pattern in group");
+  }
+
+  if (peek(c) == '?' && c->p + 1 < c->src_end) {
+    if (c->p[1] == ':') {
+      next_char(c); next_char(c);  /* skip ?: */
+      capturing = FALSE;
+    }
+    else if (c->p[1] == '=' || c->p[1] == '!') {
+      /* lookahead (?=...) or (?!...) */
+      mrb_bool negative = (c->p[1] == '!');
+      next_char(c); next_char(c);  /* skip ?= or ?! */
+      uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
+      compile_look_body(c, negative);
+      c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+      next_char(c);
+      c->needs_backtrack = TRUE;  /* needs backtracking engine */
+      c->flags = saved_flags;
+      return TRUE;  /* done with this atom */
+    }
+    else if (c->p[1] == '<' && c->p + 2 < c->src_end && (c->p[2] == '=' || c->p[2] == '!')) {
+      /* lookbehind (?<=...) or (?<!...) */
+      mrb_bool negative = (c->p[2] == '!');
+      next_char(c); next_char(c); next_char(c);  /* skip ?<= or ?<! */
+      uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
+      uint32_t sub_start = c->code_len;
+      c->alt_count = 0;  /* the record is this body's own; see there */
+      compile_look_body(c, negative);
+      uint32_t body_end = c->code_len;  /* the RE_LOOK_END is at body_end - 1 */
+
+      /* A sub-pattern holding a \g call cannot be measured yet: where
+         the call jumps is not decided until resolve_calls(), and the
+         body it runs may not be written yet. A width of its own per
+         branch is out of reach for one of those, the record above being
+         long gone by then, so it is left with the single carrier it can
+         be given here and measure_deferred_lookbehinds() fills that in
+         once the calls are wired. */
+      mrb_bool deferred = FALSE;
+      for (uint32_t i = sub_start; i < body_end; i++) {
+        if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
+      }
+      if (deferred) {
+        insert_inst(c, sub_start, RE_LB_WIDTH, 0, 0);
+      }
+      else {
+        add_lookbehind_widths(c, lb_pos, sub_start, body_end);
+      }
+      c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
+
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+      next_char(c);
+      c->needs_backtrack = TRUE;  /* needs backtracking engine */
+      c->flags = saved_flags;
+      return TRUE;
+    }
+    else if (c->p[1] == '>') {
+      /* atomic group (?>...): the body is a non-capturing group whose
+         first match is its only one. The two instructions bracketing it
+         carry a number of the group's own, which is how the executor
+         pairs the end of a body with the group it closes when a failure
+         after the body has to fail the group; see bt_match(). The number
+         is the count of groups numbered before it rather than the
+         nesting depth: a possessive repeat wraps a group around code
+         already emitted, and with depths that wrapper and a group inside
+         it, compiled with the same groups open around them, shared a
+         depth, so a cut of the wrapper was read as the inner group's.
+         Every numbered group emits two instructions, so the number fits
+         the field. */
+      next_char(c); next_char(c);  /* skip ?> */
+      uint16_t cut = (uint16_t)++c->num_cuts;
+      emit(c, RE_ATOMIC, 0, cut);
+      compile_alt(c);
+      emit(c, RE_ATOMIC_END, 0, cut);
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+      next_char(c);
+      c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
+      c->flags = saved_flags;
+      return TRUE;
+    }
+    else if (c->p[1] == '~') {
+      /* The absent repeater (?~e): the longest run of text from here
+         that holds no match of e. The body is no part of the match, it
+         is run at one position after another to say where the run has
+         to stop, so the three instructions are a scan rather than a
+         sub-pattern the search passes through, and RE_ABSENT is its
+         head. `offset` on that head is the text after the group, which
+         is patched in once the body is compiled, as a lookaround's is.
+
+         CRuby's syntax has no absent expression (?~|absent|exp) or
+         absent stopper (?~|absent): a `|` here opens an alternative of
+         the body like any other, so (?~|a|b) is this repeater over
+         `|a|b`, which matches empty everywhere and leaves the absent
+         with nothing it can reach. That is CRuby's answer too. */
+      next_char(c); next_char(c);  /* skip ?~ */
+      emit(c, RE_ABSENT_START, 0, 0);
+      uint32_t head = emit(c, RE_ABSENT, 0, 0);
+      compile_alt(c);
+      emit(c, RE_ABSENT_END, 0, 0);
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+      next_char(c);
+      c->pat->code[head].offset = (uint16_t)c->code_len;
+      c->needs_backtrack = TRUE;  /* the Pike VM has no scan of its own */
+      c->flags = saved_flags;
+      return TRUE;
+    }
+    else if (c->p[1] == '\'' ||
+             (c->p[1] == '<' && c->p + 2 < c->src_end &&
+              c->p[2] != '=' && c->p[2] != '!')) {
+      /* A named capture, in either spelling: (?<name>...) or (?'name'...).
+         The quoted one needs none of the ruling out the angled one does
+         above, since no lookbehind is spelled with a quote. The name runs
+         to its own terminator, so a '>' inside quotes and a quote inside
+         angles are both members of the name. */
+      int close = (c->p[1] == '<') ? '>' : '\'';
+      next_char(c); next_char(c);  /* skip ?< or ?' */
+      cap_name = c->p;
+      while (peek(c) != close && peek(c) >= 0) {
+        /* CRuby's fetch_name() ends the scan at a ')' instead of taking it
+           into the name, and a name no delimiter ended is `invalid group
+           name`. The first byte is exempt, the test starting one byte
+           in, so (?<)>x) names ")" in both engines. The message quotes
+           to the end of the pattern, as CRuby does when the scan never
+           reached a delimiter. */
+        if (peek(c) == ')' && c->p > cap_name) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          cap_name, (size_t)(c->src_end - cap_name)));
+        }
+        next_char(c);
+      }
+      /* A name the pattern ends before the delimiter of is the same
+         `invalid group name` as one a ')' ended, quoted the same way,
+         and an empty one is empty whether or not it was ever closed:
+         (?'  and (?<>x) answer alike, as they do in CRuby. */
+      if (c->p == cap_name) compile_error(c, "group name is empty");
+      if (peek(c) != close) {
+        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                        cap_name, (size_t)(c->p - cap_name)));
+      }
+      /* A definition names a group, it never numbers one: CRuby reads a
+         leading digit or '-' as the number spelling, which only a
+         reference may use, and refuses it here. Everything after the first
+         byte is a name to both engines, `-` and spaces included, so this
+         is not a restriction to word characters. Without it, (?<1>x)
+         defined a group that no \k could reach, the reference side
+         reading digits as a number. */
+      if (*cap_name == '-' || (*cap_name >= '0' && *cap_name <= '9')) {
+        compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                        cap_name, (size_t)(c->p - cap_name)));
+      }
+      if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
+      cap_name_len = (uint32_t)(c->p - cap_name);
+      next_char(c);  /* skip the closing > or ' */
+    }
+    else if (c->p[1] == 'i' || c->p[1] == 'm' || c->p[1] == 'x' || c->p[1] == '-') {
+      /* Inline options: the toggle form (?imx) / (?-imx) changes the
+         options for the rest of the enclosing group, and the scoped
+         form (?imx:...) is a non-capturing group whose options apply
+         only to its body. */
+      next_char(c);  /* skip '?' */
+      uint32_t new_flags = parse_inline_flags(c, c->flags);
+      if (peek(c) == ')') {
+        /* The rest of the enclosing group, alternatives and all, is the
+           toggle's scope: `a(?i)b|c` is `a(?i:b|c)`, as Onigmo builds it
+           (parse_exp() hands its "option only" remainder to
+           parse_subexp(), the alternation level). So compile that
+           remainder here rather than returning to the sequence the
+           toggle was read in, where the `|` would split at the level the
+           toggle was written at and `c` would match with no `a` before
+           it. compile_alt() consumes every `|` and stops at the group's
+           ')' or the end of the pattern, which is where the caller
+           expects the parse point, so what follows is unchanged: the
+           enclosing compile_seq() finds its terminator, a stray ')' at
+           top level is still refused by mrb_re_compile(), and a
+           quantifier with nothing before it is refused by the
+           compile_seq() called from here. */
+        next_char(c);
+        c->flags = new_flags;
+        compile_alt(c);
+        c->flags = saved_flags;
+        return TRUE;
+      }
+      else if (peek(c) == ':') {
+        next_char(c);
+        c->flags = new_flags;
+        compile_alt(c);
+        c->flags = saved_flags;
+        if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+        next_char(c);
+        return TRUE;
+      }
+      else {
+        if (peek(c) < 0) compile_error(c, "end pattern in group");
+        compile_error(c, "undefined group option");
+      }
+    }
+    else if (c->p[1] == '(') {
+      /* The conditional (?(cond)yes|no): `yes` where the group `cond`
+         names has matched, `no` where it has not, and `no` is empty
+         where it is left out. The condition is a group reference in the
+         spellings a backreference takes, `(1)`, `(<name>)` and
+         `('name')`, and a group has matched when its capture pair is
+         closed: one still open, the conditional standing inside it, has
+         not, and neither has one a repetition has just re-entered (see
+         RE_SAVE in bt_match()). That is Onigmo's reading too.
+
+         The number form is read here rather than by parse_group_ref():
+         the digits run to the ')' with no delimiter of their own, and
+         CRuby refuses the sign that gives the relative forms, so what is
+         read is digits or a malformed name. Every check the absolute
+         form makes there is made here in the same order, the count
+         check coming after the parse as it does for `\1(a)`, so
+         `(?(1)b|c)(a)` is as valid as that is. A named pattern refuses
+         the number as it refuses `\1`.
+
+         Two branches at most: a third `|` is `invalid conditional
+         pattern`, as in CRuby, so the bodies are read one sequence at a
+         time rather than through compile_alt(), which would take every
+         `|`. The bodies nest a level as a group's would, and the
+         count is kept the way compile_alt() keeps it.
+
+         One instruction carries the test and the layout is a fork's
+         with the choice made by the captures instead of pushed: RE_COND
+         goes on at pc + 1 where the group has matched and at `offset`
+         where it has not, `yes` ends with a jump past `no`, and with no
+         `no` the head's offset is the text after the group. */
+      next_char(c); next_char(c);  /* skip ?( */
+      int group = 0;
+      int cond = peek(c);
+      if (cond < 0) {
+        /* `(?(` and nothing more: CRuby answers for the prefix, not for
+           the condition it never began. */
+        compile_error(c, "undefined group option");
+      }
+      if (cond == '<' || cond == '\'') {
+        group = parse_group_ref(c);
+        /* A name closed by its delimiter and then something other than
+           the ')': CRuby's answer is the prefix's, as above. */
+        if (peek(c) != ')') compile_error(c, "undefined group option");
+      }
+      else if (cond >= '0' && cond <= '9') {
+        const char *digits = c->p;
+        while (peek(c) != ')' && peek(c) >= 0) next_char(c);
+        uint32_t dlen = (uint32_t)(c->p - digits);
+        mrb_bool numeric = TRUE;
+        for (uint32_t i = 0; numeric && i < dlen; i++) {
+          if (digits[i] < '0' || digits[i] > '9') numeric = FALSE;
+        }
+        /* A condition the pattern ends inside is quoted back the way a
+           name the pattern ends inside is, and so is one that is not
+           all digits, as in parse_group_ref(). */
+        if (!numeric || peek(c) < 0) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          digits, (size_t)dlen));
+        }
+        int n = 0;
+        for (uint32_t i = 0; i < dlen; i++) {
+          int digit = digits[i] - '0';
+          if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
+          n = n * 10 + digit;
+        }
+        /* Group 0 is the whole match, which is never closed while the
+           pattern runs, and CRuby refuses it as it refuses `\k<0>`. */
+        if (n == 0) {
+          compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
+                                          digits, (size_t)dlen));
+        }
+        if (c->dont_capture) {
+          compile_error(c, "numbered backref/call is not allowed. (use name)");
+        }
+        if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
+        if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
+        group = n;
+      }
+      else {
+        /* Anything else in the condition's place, a bare name, a signed
+           number, nothing at all: CRuby refuses the condition rather
+           than reading it as a name. */
+        compile_error(c, "invalid conditional pattern");
+      }
+      next_char(c);  /* skip the ')' closing the condition */
+
+      uint32_t head = emit(c, RE_COND, (uint8_t)group, 0);
+      if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
+        compile_error(c, "parse depth limit over");
+      }
+      compile_seq(c);
+      if (peek(c) == '|') {
+        next_char(c);
+        uint32_t skip = emit(c, RE_JMP, 0, 0);
+        c->pat->code[head].offset = (uint16_t)c->code_len;
+        compile_seq(c);
+        if (peek(c) == '|') compile_error(c, "invalid conditional pattern");
+        c->pat->code[skip].offset = (uint16_t)c->code_len;
+      }
+      else {
+        c->pat->code[head].offset = (uint16_t)c->code_len;
+      }
+      c->depth--;
+      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+      next_char(c);
+      c->needs_backtrack = TRUE;  /* the Pike VM's threads carry no test of their captures */
+      c->flags = saved_flags;
+      return TRUE;
+    }
+    else if (c->p[1] == '#') {
+      /* preprocess_pattern() removes a terminated comment group before
+         the parser runs, so one reaching here was never closed, which
+         is the pattern ending inside the prefix like any other. */
+      compile_error(c, "end pattern in group");
+    }
+    else {
+      /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
+         (?<= (?<! (?<name> (?'name' (?> (?~ (?( (?imx forms. Comment
+         groups (?#...) never get here either, having been removed by
+         preprocess_pattern(). Raise here rather than falling through to
+         the capturing-group path, which would leave the stray `?` for
+         compile_seq to spin on forever (A1). */
+      if (c->p[1] == '<') {
+        /* `(?<` and nothing more, the only way a '<' reaches here: the
+           pattern ends before the character that tells a lookbehind
+           from a named group. CRuby answers for the group that never
+           closes rather than for the prefix, which either reading
+           leaves open. */
+        compile_error(c, "end pattern with unmatched parenthesis");
+      }
+      compile_error(c, "undefined group option");
+    }
+  }
+
+  /* Onigmo's ONIG_OPTION_DONT_CAPTURE_GROUP, which CRuby turns on for a
+     pattern that declares a named group: a plain (...) then groups
+     without capturing, so the numbered side counts only the named
+     groups. The named group itself keeps its number. The count of groups
+     opened is taken before that demotion: CRuby demotes plain groups
+     only once the parse is done, so while it reads the pattern every one
+     of them is still a group that a `\NN` may refer to. */
+  if (capturing && c->num_groups < UINT16_MAX) c->num_groups++;
+  if (c->dont_capture && cap_name == NULL) capturing = FALSE;
+
+  uint16_t group = 0;
+  if (capturing) {
+    if (c->num_captures >= RE_MAX_CAPTURES) {
+      compile_error(c, "too many capture groups are specified");
+    }
+    group = c->num_captures++;
+    emit(c, RE_SAVE, 0, group * 2);
+    if (cap_name) {
+      /* register named capture */
+      c->pat->named_captures = (re_named_capture*)mrb_realloc(c->mrb, c->pat->named_captures,
+        sizeof(re_named_capture) * (c->num_named + 1));
+      c->pat->named_captures[c->num_named].name = cap_name;
+      c->pat->named_captures[c->num_named].name_len = cap_name_len;
+      c->pat->named_captures[c->num_named].group = group;
+      c->num_named++;
+    }
+  }
+
+  compile_alt(c);
+
+  if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+  next_char(c);
+
+  if (capturing) {
+    emit(c, RE_SAVE, 0, group * 2 + 1);
+  }
+  c->flags = saved_flags;  /* the options this group opened with */
+  return TRUE;
+}
+
 /* Compile a single atom (character, class, group, etc.). Returns whether one
    was read: FALSE when what stands at the parse point is not an atom, either a
    quantifier metacharacter or the end of the sequence, neither of them
@@ -2607,393 +3001,8 @@ compile_atom(re_compiler *c)
 
   switch (ch) {
   case '(':
-    {
-      next_char(c);
-      mrb_bool capturing = TRUE;
-
-      /* Options in effect on entry. A group restores them on exit so an
-         inline toggle like (?i) inside it (which sets c->flags for the rest
-         of the group) does not leak past the closing ')'. */
-      uint32_t saved_flags = c->flags;
-
-      const char *cap_name = NULL;
-      uint32_t cap_name_len = 0;
-
-      /* `(?` and nothing more: the prefix that names which group this is
-         runs off the end of the pattern. It is reported here because what
-         the parser would otherwise be left with is a `?` standing where no
-         atom is, which compile_seq() reads as a quantifier with nothing to
-         repeat. */
-      if (peek(c) == '?' && c->p + 1 >= c->src_end) {
-        compile_error(c, "end pattern in group");
-      }
-
-      if (peek(c) == '?' && c->p + 1 < c->src_end) {
-        if (c->p[1] == ':') {
-          next_char(c); next_char(c);  /* skip ?: */
-          capturing = FALSE;
-        }
-        else if (c->p[1] == '=' || c->p[1] == '!') {
-          /* lookahead (?=...) or (?!...) */
-          mrb_bool negative = (c->p[1] == '!');
-          next_char(c); next_char(c);  /* skip ?= or ?! */
-          uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
-          compile_look_body(c, negative);
-          c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
-          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-          next_char(c);
-          c->needs_backtrack = TRUE;  /* needs backtracking engine */
-          c->flags = saved_flags;
-          break;  /* done with this atom */
-        }
-        else if (c->p[1] == '<' && c->p + 2 < c->src_end && (c->p[2] == '=' || c->p[2] == '!')) {
-          /* lookbehind (?<=...) or (?<!...) */
-          mrb_bool negative = (c->p[2] == '!');
-          next_char(c); next_char(c); next_char(c);  /* skip ?<= or ?<! */
-          uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
-          uint32_t sub_start = c->code_len;
-          c->alt_count = 0;  /* the record is this body's own; see there */
-          compile_look_body(c, negative);
-          uint32_t body_end = c->code_len;  /* the RE_LOOK_END is at body_end - 1 */
-
-          /* A sub-pattern holding a \g call cannot be measured yet: where
-             the call jumps is not decided until resolve_calls(), and the
-             body it runs may not be written yet. A width of its own per
-             branch is out of reach for one of those, the record above being
-             long gone by then, so it is left with the single carrier it can
-             be given here and measure_deferred_lookbehinds() fills that in
-             once the calls are wired. */
-          mrb_bool deferred = FALSE;
-          for (uint32_t i = sub_start; i < body_end; i++) {
-            if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
-          }
-          if (deferred) {
-            insert_inst(c, sub_start, RE_LB_WIDTH, 0, 0);
-          }
-          else {
-            add_lookbehind_widths(c, lb_pos, sub_start, body_end);
-          }
-          c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
-
-          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-          next_char(c);
-          c->needs_backtrack = TRUE;  /* needs backtracking engine */
-          c->flags = saved_flags;
-          break;
-        }
-        else if (c->p[1] == '>') {
-          /* atomic group (?>...): the body is a non-capturing group whose
-             first match is its only one. The two instructions bracketing it
-             carry a number of the group's own, which is how the executor
-             pairs the end of a body with the group it closes when a failure
-             after the body has to fail the group; see bt_match(). The number
-             is the count of groups numbered before it rather than the
-             nesting depth: a possessive repeat wraps a group around code
-             already emitted, and with depths that wrapper and a group inside
-             it, compiled with the same groups open around them, shared a
-             depth, so a cut of the wrapper was read as the inner group's.
-             Every numbered group emits two instructions, so the number fits
-             the field. */
-          next_char(c); next_char(c);  /* skip ?> */
-          uint16_t cut = (uint16_t)++c->num_cuts;
-          emit(c, RE_ATOMIC, 0, cut);
-          compile_alt(c);
-          emit(c, RE_ATOMIC_END, 0, cut);
-          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-          next_char(c);
-          c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
-          c->flags = saved_flags;
-          break;
-        }
-        else if (c->p[1] == '~') {
-          /* The absent repeater (?~e): the longest run of text from here
-             that holds no match of e. The body is no part of the match, it
-             is run at one position after another to say where the run has
-             to stop, so the three instructions are a scan rather than a
-             sub-pattern the search passes through, and RE_ABSENT is its
-             head. `offset` on that head is the text after the group, which
-             is patched in once the body is compiled, as a lookaround's is.
-
-             CRuby's syntax has no absent expression (?~|absent|exp) or
-             absent stopper (?~|absent): a `|` here opens an alternative of
-             the body like any other, so (?~|a|b) is this repeater over
-             `|a|b`, which matches empty everywhere and leaves the absent
-             with nothing it can reach. That is CRuby's answer too. */
-          next_char(c); next_char(c);  /* skip ?~ */
-          emit(c, RE_ABSENT_START, 0, 0);
-          uint32_t head = emit(c, RE_ABSENT, 0, 0);
-          compile_alt(c);
-          emit(c, RE_ABSENT_END, 0, 0);
-          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-          next_char(c);
-          c->pat->code[head].offset = (uint16_t)c->code_len;
-          c->needs_backtrack = TRUE;  /* the Pike VM has no scan of its own */
-          c->flags = saved_flags;
-          break;
-        }
-        else if (c->p[1] == '\'' ||
-                 (c->p[1] == '<' && c->p + 2 < c->src_end &&
-                  c->p[2] != '=' && c->p[2] != '!')) {
-          /* A named capture, in either spelling: (?<name>...) or (?'name'...).
-             The quoted one needs none of the ruling out the angled one does
-             above, since no lookbehind is spelled with a quote. The name runs
-             to its own terminator, so a '>' inside quotes and a quote inside
-             angles are both members of the name. */
-          int close = (c->p[1] == '<') ? '>' : '\'';
-          next_char(c); next_char(c);  /* skip ?< or ?' */
-          cap_name = c->p;
-          while (peek(c) != close && peek(c) >= 0) {
-            /* CRuby's fetch_name() ends the scan at a ')' instead of taking it
-               into the name, and a name no delimiter ended is `invalid group
-               name`. The first byte is exempt, the test starting one byte
-               in, so (?<)>x) names ")" in both engines. The message quotes
-               to the end of the pattern, as CRuby does when the scan never
-               reached a delimiter. */
-            if (peek(c) == ')' && c->p > cap_name) {
-              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                              cap_name, (size_t)(c->src_end - cap_name)));
-            }
-            next_char(c);
-          }
-          /* A name the pattern ends before the delimiter of is the same
-             `invalid group name` as one a ')' ended, quoted the same way,
-             and an empty one is empty whether or not it was ever closed:
-             (?'  and (?<>x) answer alike, as they do in CRuby. */
-          if (c->p == cap_name) compile_error(c, "group name is empty");
-          if (peek(c) != close) {
-            compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                            cap_name, (size_t)(c->p - cap_name)));
-          }
-          /* A definition names a group, it never numbers one: CRuby reads a
-             leading digit or '-' as the number spelling, which only a
-             reference may use, and refuses it here. Everything after the first
-             byte is a name to both engines, `-` and spaces included, so this
-             is not a restriction to word characters. Without it, (?<1>x)
-             defined a group that no \k could reach, the reference side
-             reading digits as a number. */
-          if (*cap_name == '-' || (*cap_name >= '0' && *cap_name <= '9')) {
-            compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                            cap_name, (size_t)(c->p - cap_name)));
-          }
-          if (!RE_NAME_LEN_FITS(c->p - cap_name)) compile_error(c, "group name too long");
-          cap_name_len = (uint32_t)(c->p - cap_name);
-          next_char(c);  /* skip the closing > or ' */
-        }
-        else if (c->p[1] == 'i' || c->p[1] == 'm' || c->p[1] == 'x' || c->p[1] == '-') {
-          /* Inline options: the toggle form (?imx) / (?-imx) changes the
-             options for the rest of the enclosing group, and the scoped
-             form (?imx:...) is a non-capturing group whose options apply
-             only to its body. */
-          next_char(c);  /* skip '?' */
-          uint32_t new_flags = parse_inline_flags(c, c->flags);
-          if (peek(c) == ')') {
-            /* The rest of the enclosing group, alternatives and all, is the
-               toggle's scope: `a(?i)b|c` is `a(?i:b|c)`, as Onigmo builds it
-               (parse_exp() hands its "option only" remainder to
-               parse_subexp(), the alternation level). So compile that
-               remainder here rather than returning to the sequence the
-               toggle was read in, where the `|` would split at the level the
-               toggle was written at and `c` would match with no `a` before
-               it. compile_alt() consumes every `|` and stops at the group's
-               ')' or the end of the pattern, which is where the caller
-               expects the parse point, so what follows is unchanged: the
-               enclosing compile_seq() finds its terminator, a stray ')' at
-               top level is still refused by mrb_re_compile(), and a
-               quantifier with nothing before it is refused by the
-               compile_seq() called from here. */
-            next_char(c);
-            c->flags = new_flags;
-            compile_alt(c);
-            c->flags = saved_flags;
-            return TRUE;
-          }
-          else if (peek(c) == ':') {
-            next_char(c);
-            c->flags = new_flags;
-            compile_alt(c);
-            c->flags = saved_flags;
-            if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-            next_char(c);
-            return TRUE;
-          }
-          else {
-            if (peek(c) < 0) compile_error(c, "end pattern in group");
-            compile_error(c, "undefined group option");
-          }
-        }
-        else if (c->p[1] == '(') {
-          /* The conditional (?(cond)yes|no): `yes` where the group `cond`
-             names has matched, `no` where it has not, and `no` is empty
-             where it is left out. The condition is a group reference in the
-             spellings a backreference takes, `(1)`, `(<name>)` and
-             `('name')`, and a group has matched when its capture pair is
-             closed: one still open, the conditional standing inside it, has
-             not, and neither has one a repetition has just re-entered (see
-             RE_SAVE in bt_match()). That is Onigmo's reading too.
-
-             The number form is read here rather than by parse_group_ref():
-             the digits run to the ')' with no delimiter of their own, and
-             CRuby refuses the sign that gives the relative forms, so what is
-             read is digits or a malformed name. Every check the absolute
-             form makes there is made here in the same order, the count
-             check coming after the parse as it does for `\1(a)`, so
-             `(?(1)b|c)(a)` is as valid as that is. A named pattern refuses
-             the number as it refuses `\1`.
-
-             Two branches at most: a third `|` is `invalid conditional
-             pattern`, as in CRuby, so the bodies are read one sequence at a
-             time rather than through compile_alt(), which would take every
-             `|`. The bodies nest a level as a group's would, and the
-             count is kept the way compile_alt() keeps it.
-
-             One instruction carries the test and the layout is a fork's
-             with the choice made by the captures instead of pushed: RE_COND
-             goes on at pc + 1 where the group has matched and at `offset`
-             where it has not, `yes` ends with a jump past `no`, and with no
-             `no` the head's offset is the text after the group. */
-          next_char(c); next_char(c);  /* skip ?( */
-          int group = 0;
-          int cond = peek(c);
-          if (cond < 0) {
-            /* `(?(` and nothing more: CRuby answers for the prefix, not for
-               the condition it never began. */
-            compile_error(c, "undefined group option");
-          }
-          if (cond == '<' || cond == '\'') {
-            group = parse_group_ref(c);
-            /* A name closed by its delimiter and then something other than
-               the ')': CRuby's answer is the prefix's, as above. */
-            if (peek(c) != ')') compile_error(c, "undefined group option");
-          }
-          else if (cond >= '0' && cond <= '9') {
-            const char *digits = c->p;
-            while (peek(c) != ')' && peek(c) >= 0) next_char(c);
-            uint32_t dlen = (uint32_t)(c->p - digits);
-            mrb_bool numeric = TRUE;
-            for (uint32_t i = 0; numeric && i < dlen; i++) {
-              if (digits[i] < '0' || digits[i] > '9') numeric = FALSE;
-            }
-            /* A condition the pattern ends inside is quoted back the way a
-               name the pattern ends inside is, and so is one that is not
-               all digits, as in parse_group_ref(). */
-            if (!numeric || peek(c) < 0) {
-              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                              digits, (size_t)dlen));
-            }
-            int n = 0;
-            for (uint32_t i = 0; i < dlen; i++) {
-              int digit = digits[i] - '0';
-              if (n > (RE_MAX_BACKREF_NUM - digit) / 10) compile_error(c, "too big number");
-              n = n * 10 + digit;
-            }
-            /* Group 0 is the whole match, which is never closed while the
-               pattern runs, and CRuby refuses it as it refuses `\k<0>`. */
-            if (n == 0) {
-              compile_error_str(c, mrb_format(c->mrb, "invalid group name <%l>",
-                                              digits, (size_t)dlen));
-            }
-            if (c->dont_capture) {
-              compile_error(c, "numbered backref/call is not allowed. (use name)");
-            }
-            if (n > RE_MAX_CAPTURES) n = RE_MAX_CAPTURES;
-            if (n > (int)c->max_backref) c->max_backref = (uint16_t)n;
-            group = n;
-          }
-          else {
-            /* Anything else in the condition's place, a bare name, a signed
-               number, nothing at all: CRuby refuses the condition rather
-               than reading it as a name. */
-            compile_error(c, "invalid conditional pattern");
-          }
-          next_char(c);  /* skip the ')' closing the condition */
-
-          uint32_t head = emit(c, RE_COND, (uint8_t)group, 0);
-          if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
-            compile_error(c, "parse depth limit over");
-          }
-          compile_seq(c);
-          if (peek(c) == '|') {
-            next_char(c);
-            uint32_t skip = emit(c, RE_JMP, 0, 0);
-            c->pat->code[head].offset = (uint16_t)c->code_len;
-            compile_seq(c);
-            if (peek(c) == '|') compile_error(c, "invalid conditional pattern");
-            c->pat->code[skip].offset = (uint16_t)c->code_len;
-          }
-          else {
-            c->pat->code[head].offset = (uint16_t)c->code_len;
-          }
-          c->depth--;
-          if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-          next_char(c);
-          c->needs_backtrack = TRUE;  /* the Pike VM's threads carry no test of their captures */
-          c->flags = saved_flags;
-          break;
-        }
-        else if (c->p[1] == '#') {
-          /* preprocess_pattern() removes a terminated comment group before
-             the parser runs, so one reaching here was never closed, which
-             is the pattern ending inside the prefix like any other. */
-          compile_error(c, "end pattern in group");
-        }
-        else {
-          /* (?X) with an unsupported X: not one of the recognized (?: (?= (?!
-             (?<= (?<! (?<name> (?'name' (?> (?~ (?( (?imx forms. Comment
-             groups (?#...) never get here either, having been removed by
-             preprocess_pattern(). Raise here rather than falling through to
-             the capturing-group path, which would leave the stray `?` for
-             compile_seq to spin on forever (A1). */
-          if (c->p[1] == '<') {
-            /* `(?<` and nothing more, the only way a '<' reaches here: the
-               pattern ends before the character that tells a lookbehind
-               from a named group. CRuby answers for the group that never
-               closes rather than for the prefix, which either reading
-               leaves open. */
-            compile_error(c, "end pattern with unmatched parenthesis");
-          }
-          compile_error(c, "undefined group option");
-        }
-      }
-
-      /* Onigmo's ONIG_OPTION_DONT_CAPTURE_GROUP, which CRuby turns on for a
-         pattern that declares a named group: a plain (...) then groups
-         without capturing, so the numbered side counts only the named
-         groups. The named group itself keeps its number. The count of groups
-         opened is taken before that demotion: CRuby demotes plain groups
-         only once the parse is done, so while it reads the pattern every one
-         of them is still a group that a `\NN` may refer to. */
-      if (capturing && c->num_groups < UINT16_MAX) c->num_groups++;
-      if (c->dont_capture && cap_name == NULL) capturing = FALSE;
-
-      uint16_t group = 0;
-      if (capturing) {
-        if (c->num_captures >= RE_MAX_CAPTURES) {
-          compile_error(c, "too many capture groups are specified");
-        }
-        group = c->num_captures++;
-        emit(c, RE_SAVE, 0, group * 2);
-        if (cap_name) {
-          /* register named capture */
-          c->pat->named_captures = (re_named_capture*)mrb_realloc(c->mrb, c->pat->named_captures,
-            sizeof(re_named_capture) * (c->num_named + 1));
-          c->pat->named_captures[c->num_named].name = cap_name;
-          c->pat->named_captures[c->num_named].name_len = cap_name_len;
-          c->pat->named_captures[c->num_named].group = group;
-          c->num_named++;
-        }
-      }
-
-      compile_alt(c);
-
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-
-      if (capturing) {
-        emit(c, RE_SAVE, 0, group * 2 + 1);
-      }
-      c->flags = saved_flags;  /* the options this group opened with */
-    }
-    break;
+    next_char(c);
+    return open_group(c);
 
   case '[':
     next_char(c);

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -21,8 +21,51 @@
    silently alias different classes. */
 #define RE_MAX_CLASSES 256
 
-/* How many branches one alternation may hold. */
-#define RE_MAX_ALTS 64
+/* What opened a nesting level of the parse; see re_level. */
+enum {
+  RE_LEVEL_PATTERN,     /* the pattern itself, the level the parse begins in */
+  RE_LEVEL_GROUP,       /* (...), (?:...), (?<name>...) and (?'name'...) */
+  RE_LEVEL_LOOKAHEAD,   /* (?=...) and (?!...) */
+  RE_LEVEL_LOOKBEHIND,  /* (?<=...) and (?<!...) */
+  RE_LEVEL_ATOMIC,      /* (?>...) */
+  RE_LEVEL_ABSENT,      /* (?~...) */
+  RE_LEVEL_OPTION,      /* (?imx:...) */
+  RE_LEVEL_TOGGLE,      /* (?imx), whose scope is the rest of the group it stands in */
+  RE_LEVEL_COND         /* (?(cond)yes|no) */
+};
+
+/* One nesting level the parse has open: what the construct that opened it
+   needs at its close, and what the level it stands in needs back once the
+   close is done. The levels are a stack the parse keeps on the heap rather
+   than frames it keeps on the C stack, so what a deep pattern costs is an
+   allocation the code reads and answers, at any depth, on any stack; see
+   compile_levels(). */
+typedef struct {
+  uint8_t kind;         /* RE_LEVEL_* */
+  uint8_t state;        /* GROUP: it captures; LOOKAHEAD, LOOKBEHIND: it is
+                           negated; COND: the `no` body is being read */
+  uint16_t num;         /* GROUP: the capture index; LOOKAHEAD, LOOKBEHIND,
+                           ATOMIC: the cut number; see RE_ATOMIC */
+  uint32_t flags;       /* the options in effect when the level opened, which
+                           its close restores: an inline toggle inside a group
+                           does not leak past the group's ')' */
+  uint32_t head;        /* LOOKAHEAD, LOOKBEHIND, ABSENT, COND: the
+                           instruction that opened the level, whose offset the
+                           close patches to the code after it */
+  uint32_t aux;         /* LOOKBEHIND: where the body's code begins; COND:
+                           the RE_JMP that carries `yes` past `no` */
+  uint32_t begin;       /* code_len before the level's opener: what a
+                           quantifier after the close binds to */
+  uint32_t atom_start;  /* c->atom_start as the enclosing level had it */
+  uint32_t alt_start;   /* code_len where the level's first branch began */
+  uint32_t branches;    /* how many `|` the level has read so far */
+} re_level;
+
+/* Levels the compiler keeps inline before it spills to the heap. A written
+   pattern nests a handful deep, so this is every pattern anyone writes
+   compiling with no allocation for its levels; what the array costs is one
+   frame's worth of C stack once, not per level. */
+#define RE_LEVELS_INLINE 8
 
 /* Compiler state.
 
@@ -73,30 +116,40 @@ typedef struct {
                                the next number, so no two that nest share one;
                                see RE_ATOMIC and RE_LOOK_END */
   uint32_t atom_start;      /* where the atom a quantifier binds to begins;
-                               compile_quantified sets it to the position
+                               compile_levels() sets it to the position
                                before the atom, and a `\u{...}` list moves it
                                forward so the quantifier repeats the last
                                codepoint alone */
   uint32_t literal_cp[RE_MAX_CLASSES];  /* by class id: the codepoint whose
                                /i literal the class stands for, 0 for a class
                                made by anything else; see literal_class() */
-  uint32_t depth;           /* nesting levels open at the parse point, one per
-                               compile_alt() frame on the C stack; bounded by
+  uint32_t depth;           /* nesting levels open at the parse point: the
+                               levels on the stack below and the character
+                               classes open inside one another; bounded by
                                MRB_REGEXP_PARSE_DEPTH_LIMIT */
-  /* The alternation that finished last, as the code index each of its
-     branches begins at, the span it covers, and how many branches it has.
-     The lookbehind arm reads it to tell a body that *is* an alternation
-     from one that merely holds one: only the first may give each branch a
-     rewind of its own, which is CRuby's line too. The record is cleared
-     when a lookbehind body begins, so what it holds is that body's own; the
-     alternation spanning the whole body is the last inside it to finish.
+  /* The levels the parse has open, innermost last; see re_level. They
+     start in `levels_inline` and move to a String the GC arena keeps for
+     the compile once they outgrow it, as pending_calls is kept: a raise
+     unwinds nothing here, and the arena drops the String with the frame. */
+  re_level *levels;
+  uint32_t level_count;
+  uint32_t level_capa;
+  mrb_value level_store;    /* nil while the levels are inline */
+  re_level levels_inline[RE_LEVELS_INLINE];
+  /* The alternation that finished last, as the span it covers and how many
+     branches it has. The lookbehind arm reads it to tell a body that *is*
+     an alternation from one that merely holds one: only the first may give
+     each branch a rewind of its own, which is CRuby's line too. The record
+     is cleared when a lookbehind body begins, so what it holds is that
+     body's own; the alternation spanning the whole body is the last inside
+     it to finish. Where each branch begins is read off the SPLIT chain the
+     span starts with; see close_alternation() for its layout.
 
      These are positions, so anything that moves or drops code ends the
-     record rather than adjusting it: insert_inst() clears it, and so does
-     every rollback in compile_quantified(). Without that, `(?:a|b){0}` would
-     leave the branch heads of an alternation whose code is gone, pointing at
-     whatever was emitted in its place. */
-  uint32_t alt_starts[RE_MAX_ALTS];
+     record rather than adjusting it: insert_insts() clears it, and so does
+     every rollback in compile_quantifiers(). Without that, `(?:a|b){0}`
+     would leave the record of an alternation whose code is gone, pointing
+     at whatever was emitted in its place. */
   uint32_t alt_count;       /* 0 when no alternation has been compiled */
   uint32_t alt_from;        /* code index of the alternation's first SPLIT */
   uint32_t alt_to;          /* code index just past its last branch */
@@ -107,9 +160,6 @@ typedef struct {
                                first one */
   uint16_t num_pending;
 } re_compiler;
-
-static void compile_alt(re_compiler *c);  /* forward */
-static void compile_seq(re_compiler *c);  /* forward */
 
 /* Take the message as a String rather than as a C string, for the messages
    that quote a group name: the name is a length-counted slice of the pattern
@@ -200,42 +250,59 @@ op_holds_code_index(uint8_t op)
   }
 }
 
-/* Insert an instruction at position `pos` by shifting code.
-   Adjusts code indices so they still point at the same instructions. */
+/* Open `count` slots at position `pos` by shifting the code once, and leave
+   RE_JMP placeholders in them for the caller to fill. Adjusts code indices
+   so they still point at the same instructions. An alternation reserves its
+   whole SPLIT chain here in one call: the shift and the fixup below each walk
+   the code, so a reservation per branch would walk it once per branch. */
 static void
-insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset)
+insert_insts(re_compiler *c, uint32_t pos, uint32_t count)
 {
   /* The alternation record is positions this does not adjust, so an insertion
      is the end of it; see the record in re_compiler. The alternation that
      writes one does so after its own insertions, and the lookbehind arm has
-     read the record into locals before it inserts anything, so nothing that
-     needs the record loses it here. */
+     read what it needs of the record before it inserts anything, so nothing
+     that needs the record loses it here. */
   c->alt_count = 0;
-  emit(c, RE_JMP, 0, 0);  /* grow array */
-  uint32_t len = c->code_len - 1 - pos;
-  memmove(&c->pat->code[pos + 1], &c->pat->code[pos], sizeof(re_inst) * len);
-  c->pat->code[pos].op = op;
-  c->pat->code[pos].a = a;
-  c->pat->code[pos].offset = offset;
+  for (uint32_t i = 0; i < count; i++) {
+    emit(c, RE_JMP, 0, 0);  /* grow array */
+  }
+  uint32_t len = c->code_len - count - pos;
+  memmove(&c->pat->code[pos + count], &c->pat->code[pos], sizeof(re_inst) * len);
+  for (uint32_t i = 0; i < count; i++) {
+    c->pat->code[pos + i].op = RE_JMP;
+    c->pat->code[pos + i].a = 0;
+    c->pat->code[pos + i].offset = 0;
+  }
 
   /* Fix code indices across the insertion. An index past `pos` shifts down by
-     one. An index equal to `pos` is ambiguous:
-     - code that moved (i > pos) is a backward jump -- e.g. the SPLIT that
-       loops `\d+` back to its class -- and meant the instruction now at
-       pos+1, so it must follow.
+     `count`. An index equal to `pos` is ambiguous:
+     - code that moved (i >= pos + count) is a backward jump -- e.g. the SPLIT
+       that loops `\d+` back to its class -- and meant the instruction now at
+       pos+count, so it must follow.
      - code before the insertion (i < pos) is a forward "skip to here"
-       reference that should stay on the newly inserted instruction. A
+       reference that should stay on the first newly inserted instruction. A
        lookaround is always that second case, since the end of its sub-pattern
        lies ahead of it: leaving the end at `pos` puts the inserted
        instruction after the sub-pattern rather than inside it, which is what
        the quantifier wrapping the whole group wants. */
   for (uint32_t i = 0; i < c->code_len; i++) {
-    if (i == pos) continue;
+    if (i >= pos && i < pos + count) continue;
     if (op_holds_code_index(c->pat->code[i].op) &&
-        (c->pat->code[i].offset > pos || (c->pat->code[i].offset == pos && i > pos))) {
-      c->pat->code[i].offset++;
+        (c->pat->code[i].offset > pos || (c->pat->code[i].offset == pos && i >= pos + count))) {
+      c->pat->code[i].offset = (uint16_t)(c->pat->code[i].offset + count);
     }
   }
+}
+
+/* Insert one instruction at position `pos`; see insert_insts(). */
+static void
+insert_inst(re_compiler *c, uint32_t pos, uint8_t op, uint8_t a, uint16_t offset)
+{
+  insert_insts(c, pos, 1);
+  c->pat->code[pos].op = op;
+  c->pat->code[pos].a = a;
+  c->pat->code[pos].offset = offset;
 }
 
 static int
@@ -253,8 +320,8 @@ next_char(re_compiler *c)
 }
 
 /* Under /x, step over the whitespace between two tokens. Called where one
-   token ends and the next may begin, in compile_seq() and before the
-   quantifier in compile_quantified(), and nowhere else: whitespace inside a
+   token ends and the next may begin, in compile_levels() and before the
+   quantifier in compile_quantifiers(), and nowhere else: whitespace inside a
    token is the token's own, so `a{1, 2}` is not an interval and `(?<a b>x)`
    names the group "a b", as in CRuby, whose tokenizer skips whitespace only
    where it fetches a token. The bytes are the five Onigmo skips; a vertical
@@ -1810,7 +1877,7 @@ parse_quantifier(re_compiler *c, int *min_out, int *max_out, mrb_bool *ranged)
   next_char(c);  /* skip '}' */
   /* A range written backwards names no repeat count, and CRuby reports it
      rather than compiling a repeat that silently drops the upper bound:
-     compile_quantified() would lay out `min` mandatory copies and then a
+     compile_quantifiers() would lay out `min` mandatory copies and then a
      `max - min` loop that runs zero times, which is `{min}`. The check sits
      here, once the `}` is consumed, so that a `{...}` which is no quantifier
      at all is still restored as a literal brace above, and it lets the
@@ -1947,6 +2014,13 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
     case RE_WBOUND: case RE_NWBOUND:
       pc++;
       break;  /* zero-width assertions */
+    case RE_LB_WIDTH:
+      /* A rewind, which consumes nothing. A branch is measured once its
+         rewind is in place, and where the last branch of the body is empty
+         its rewind stands where the other branches exit to, so their walks
+         run through it; see add_lookbehind_widths(). */
+      pc++;
+      break;
     case RE_JMP:
       pc = inst.offset;
       break;
@@ -2061,6 +2135,17 @@ lookbehind_width(re_compiler *c, uint32_t start, uint32_t end)
   return RE_LB_PACK(len, chars);
 }
 
+/* Where branch `i` of an alternation of `n` branches begins, `from` being
+   the first SPLIT of its chain: the chain's last SPLIT falls through into
+   branch 0, and the SPLIT that jumps to branch i stands i places before
+   that; see close_alternation() for the layout. */
+static uint32_t
+branch_head(re_compiler *c, uint32_t from, uint32_t n, uint32_t i)
+{
+  if (i == 0) return from + n - 1;
+  return c->pat->code[from + n - 1 - i].offset;
+}
+
 /*
  * Give the lookbehind at `lb_pos`, whose body is [sub_start, body_end), the
  * rewinds it runs by, and refuse a body that has none.
@@ -2084,49 +2169,47 @@ static void
 add_lookbehind_widths(re_compiler *c, uint32_t lb_pos, uint32_t sub_start,
                       uint32_t body_end)
 {
-  uint16_t widths[RE_MAX_ALTS];
-  uint32_t heads[RE_MAX_ALTS];
-  uint32_t n;
-
   int chars = 0;
   int len = compute_fixed_len(c, sub_start, body_end, &chars);
   if (len >= 0) {
     if (len > 255) compile_error(c, "lookbehind too long (max 255 bytes)");
-    heads[0] = sub_start;
-    widths[0] = RE_LB_PACK(len, chars);
-    n = 1;
+    c->pat->code[lb_pos].a = 1;  /* measured: measure_deferred skips it */
+    insert_inst(c, sub_start, RE_LB_WIDTH, 0, RE_LB_PACK(len, chars));
+    return;
   }
+
   /* The alternation the body left behind is the body's own only when it
      covers all of it: it starts where the body starts and ends at the
      RE_LOOK_END, which stands at body_end - 1. */
-  else if (c->alt_count > 1 && c->alt_from == sub_start &&
-           c->alt_to == body_end - 1) {
-    n = c->alt_count;
-    for (uint32_t i = 0; i < n; i++) {
-      heads[i] = c->alt_starts[i];
-      widths[i] = lookbehind_width(c, heads[i], body_end);
-    }
-  }
-  else {
+  if (!(c->alt_count > 1 && c->alt_from == sub_start &&
+        c->alt_to == body_end - 1)) {
     compile_error(c, "invalid pattern in look-behind");
-    return;  /* not reached */
   }
+  uint32_t n = c->alt_count;
 
   /* With a rewind per branch, a branch can match from another's rewind and
      stop short of where the lookbehind was entered, so the end has to check
      where it landed. One width for the whole body is the width of every path
      through it, and such a body cannot land anywhere else. */
-  if (n > 1) c->pat->code[body_end - 1].a |= RE_LOOK_LANDING;
+  c->pat->code[body_end - 1].a |= RE_LOOK_LANDING;
 
-  /* Insert from the last head down, so that the heads still ahead of the
-     insertion keep the positions they were measured at. A branch's head is
-     what the alternation's SPLIT jumps to, and insert_inst() leaves such a
-     reference on the inserted instruction, so the branch now begins with its
-     rewind. */
-  c->pat->code[lb_pos].a = 1;  /* measured: measure_deferred skips it */
+  /* Each branch gets its rewind before any is measured, from the last head
+     down so that the heads still ahead of an insertion keep their positions.
+     A branch's head is what the alternation's SPLIT jumps to, and
+     insert_inst() leaves such a reference on the inserted instruction, so
+     the branch now begins with its rewind and the chain now names where
+     that rewind stands. The measuring then reads the chain again: what it
+     measures is the branch behind each rewind, which the inserted
+     instructions have moved but not changed. */
   for (uint32_t i = n; i > 0; i--) {
-    insert_inst(c, heads[i - 1], RE_LB_WIDTH, 0, widths[i - 1]);
+    insert_inst(c, branch_head(c, sub_start, n, i - 1), RE_LB_WIDTH, 0, 0);
   }
+  body_end += n;
+  for (uint32_t i = 0; i < n; i++) {
+    uint32_t at = branch_head(c, sub_start, n, i);
+    c->pat->code[at].offset = lookbehind_width(c, at + 1, body_end);
+  }
+  c->pat->code[lb_pos].a = 1;  /* measured: measure_deferred skips it */
 }
 
 /* Parse the option letters of an inline (?...) group. The parser is
@@ -2195,7 +2278,7 @@ emit_char(re_compiler *c, uint8_t ch)
    atom emitted: /Ā+/ compiled as \xC4(\x80)+ and matched one Ā in "ĀĀ". An
    invalid lead byte has a charlen of 1 and still emits alone. Every atom that
    consumes a character has to emit all of its bytes before returning, since
-   what compile_quantified() repeats is the bytes that atom emitted. */
+   what compile_quantifiers() repeats is the bytes that atom emitted. */
 static void
 emit_char_bytes(re_compiler *c, int ch)
 {
@@ -2425,21 +2508,6 @@ add_pending_call(re_compiler *c, uint8_t kind, const char *at, uint32_t len,
   return c->num_pending++;
 }
 
-/* Compile the sub-pattern of a lookaround, whose opener has just been
-   emitted, up to and including the RE_LOOK_END that closes it, and answer
-   where that end stands. The end carries the lookaround's number, from the
-   count the atomic groups use, so that a cut aimed at this lookaround is
-   told from one aimed at a group around or inside it; see bt_match(). The
-   landing bit is not set here: whether it is needed is known only once the
-   body is measured, and add_lookbehind_widths() sets it. */
-static uint32_t
-compile_look_body(re_compiler *c, mrb_bool negative)
-{
-  uint16_t cut = (uint16_t)++c->num_cuts;
-  compile_alt(c);
-  return emit(c, RE_LOOK_END, negative ? RE_LOOK_NEGATED : 0, cut);
-}
-
 /* Read the group a reference names, `<name>` or `'name'` with the parse
    point on the opening delimiter, and answer its number. This is what
    `\k` reads after its letter and what a conditional reads inside its
@@ -2594,28 +2662,63 @@ parse_group_ref(re_compiler *c)
   return group;
 }
 
-/* Compile what a '(' opens, the '(' itself just consumed: a group of any
-   kind, a lookaround, an atomic group, an absent repeater, a conditional or
-   an inline option, through the ')' that closes it where the construct has
-   one. Answers as compile_atom() does for it: TRUE, an atom having been
-   read. */
-static mrb_bool
-open_group(re_compiler *c)
+/* Open a nesting level; see re_level for what one is. The count is what
+   MRB_REGEXP_PARSE_DEPTH_LIMIT bounds, and the limit is met here rather than
+   at the bottom of a recursion: a pattern past it is refused at the level
+   that crosses it, having cost the levels below it and nothing more. */
+static re_level*
+open_level(re_compiler *c, uint8_t kind, uint32_t begin, uint32_t outer_atom_start)
+{
+  if (c->depth >= (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
+    compile_error(c, "parse depth limit over");
+  }
+  if (c->level_count == c->level_capa) {
+    /* Outgrown: the levels move to a String the GC arena holds for the
+       compile, as pending_calls is held (see re_compiler), and double from
+       there. An allocation the allocator refuses is mrb_realloc()'s
+       NoMemoryError, which is the answer a pattern nested past what the
+       machine holds gets, at whatever depth that is. */
+    uint32_t capa = c->level_capa * 2;
+    size_t bytes = sizeof(re_level) * capa;
+    if (mrb_nil_p(c->level_store)) {
+      c->level_store = mrb_str_new(c->mrb, NULL, bytes);
+      memcpy(RSTRING_PTR(c->level_store), c->levels, sizeof(re_level) * c->level_count);
+    }
+    else {
+      mrb_str_resize(c->mrb, c->level_store, (mrb_int)bytes);
+    }
+    c->levels = (re_level*)RSTRING_PTR(c->level_store);
+    c->level_capa = capa;
+  }
+  c->depth++;
+  re_level *lv = &c->levels[c->level_count++];
+  memset(lv, 0, sizeof(*lv));
+  lv->kind = kind;
+  lv->flags = c->flags;
+  lv->begin = begin;
+  lv->atom_start = outer_atom_start;
+  lv->alt_start = c->code_len;
+  return lv;
+}
+
+/* Open the level a '(' begins, the '(' itself just consumed: read the
+   prefix that says which construct it is, emit what the construct puts
+   before its body, and push the level the body is read in. The body is
+   then read by compile_levels() as the sequence it stands in, and
+   close_level() emits what follows it. `begin` and `outer_atom_start`
+   are what the enclosing sequence needs back when the level closes; see
+   re_level. */
+static void
+open_group(re_compiler *c, uint32_t begin, uint32_t outer_atom_start)
 {
   mrb_bool capturing = TRUE;
-
-  /* Options in effect on entry. A group restores them on exit so an
-     inline toggle like (?i) inside it (which sets c->flags for the rest
-     of the group) does not leak past the closing ')'. */
-  uint32_t saved_flags = c->flags;
-
   const char *cap_name = NULL;
   uint32_t cap_name_len = 0;
 
   /* `(?` and nothing more: the prefix that names which group this is
      runs off the end of the pattern. It is reported here because what
      the parser would otherwise be left with is a `?` standing where no
-     atom is, which compile_seq() reads as a quantifier with nothing to
+     atom is, which compile_levels() reads as a quantifier with nothing to
      repeat. */
   if (peek(c) == '?' && c->p + 1 >= c->src_end) {
     compile_error(c, "end pattern in group");
@@ -2631,48 +2734,24 @@ open_group(re_compiler *c)
       mrb_bool negative = (c->p[1] == '!');
       next_char(c); next_char(c);  /* skip ?= or ?! */
       uint32_t la_pos = emit(c, negative ? RE_NEG_LOOKAHEAD : RE_LOOKAHEAD, 0, 0);
-      compile_look_body(c, negative);
-      c->pat->code[la_pos].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-      c->needs_backtrack = TRUE;  /* needs backtracking engine */
-      c->flags = saved_flags;
-      return TRUE;  /* done with this atom */
+      re_level *lv = open_level(c, RE_LEVEL_LOOKAHEAD, begin, outer_atom_start);
+      lv->state = negative;
+      lv->num = (uint16_t)++c->num_cuts;
+      lv->head = la_pos;
+      return;
     }
     else if (c->p[1] == '<' && c->p + 2 < c->src_end && (c->p[2] == '=' || c->p[2] == '!')) {
       /* lookbehind (?<=...) or (?<!...) */
       mrb_bool negative = (c->p[2] == '!');
       next_char(c); next_char(c); next_char(c);  /* skip ?<= or ?<! */
       uint32_t lb_pos = emit(c, negative ? RE_NEG_LOOKBEHIND : RE_LOOKBEHIND, 0, 0);
-      uint32_t sub_start = c->code_len;
       c->alt_count = 0;  /* the record is this body's own; see there */
-      compile_look_body(c, negative);
-      uint32_t body_end = c->code_len;  /* the RE_LOOK_END is at body_end - 1 */
-
-      /* A sub-pattern holding a \g call cannot be measured yet: where
-         the call jumps is not decided until resolve_calls(), and the
-         body it runs may not be written yet. A width of its own per
-         branch is out of reach for one of those, the record above being
-         long gone by then, so it is left with the single carrier it can
-         be given here and measure_deferred_lookbehinds() fills that in
-         once the calls are wired. */
-      mrb_bool deferred = FALSE;
-      for (uint32_t i = sub_start; i < body_end; i++) {
-        if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
-      }
-      if (deferred) {
-        insert_inst(c, sub_start, RE_LB_WIDTH, 0, 0);
-      }
-      else {
-        add_lookbehind_widths(c, lb_pos, sub_start, body_end);
-      }
-      c->pat->code[lb_pos].offset = (uint16_t)c->code_len;
-
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-      c->needs_backtrack = TRUE;  /* needs backtracking engine */
-      c->flags = saved_flags;
-      return TRUE;
+      re_level *lv = open_level(c, RE_LEVEL_LOOKBEHIND, begin, outer_atom_start);
+      lv->state = negative;
+      lv->num = (uint16_t)++c->num_cuts;
+      lv->head = lb_pos;
+      lv->aux = lv->alt_start;  /* where the body's code begins */
+      return;
     }
     else if (c->p[1] == '>') {
       /* atomic group (?>...): the body is a non-capturing group whose
@@ -2690,13 +2769,9 @@ open_group(re_compiler *c)
       next_char(c); next_char(c);  /* skip ?> */
       uint16_t cut = (uint16_t)++c->num_cuts;
       emit(c, RE_ATOMIC, 0, cut);
-      compile_alt(c);
-      emit(c, RE_ATOMIC_END, 0, cut);
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-      c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
-      c->flags = saved_flags;
-      return TRUE;
+      re_level *lv = open_level(c, RE_LEVEL_ATOMIC, begin, outer_atom_start);
+      lv->num = cut;
+      return;
     }
     else if (c->p[1] == '~') {
       /* The absent repeater (?~e): the longest run of text from here
@@ -2715,14 +2790,9 @@ open_group(re_compiler *c)
       next_char(c); next_char(c);  /* skip ?~ */
       emit(c, RE_ABSENT_START, 0, 0);
       uint32_t head = emit(c, RE_ABSENT, 0, 0);
-      compile_alt(c);
-      emit(c, RE_ABSENT_END, 0, 0);
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-      c->pat->code[head].offset = (uint16_t)c->code_len;
-      c->needs_backtrack = TRUE;  /* the Pike VM has no scan of its own */
-      c->flags = saved_flags;
-      return TRUE;
+      re_level *lv = open_level(c, RE_LEVEL_ABSENT, begin, outer_atom_start);
+      lv->head = head;
+      return;
     }
     else if (c->p[1] == '\'' ||
              (c->p[1] == '<' && c->p + 2 < c->src_end &&
@@ -2787,27 +2857,22 @@ open_group(re_compiler *c)
            remainder here rather than returning to the sequence the
            toggle was read in, where the `|` would split at the level the
            toggle was written at and `c` would match with no `a` before
-           it. compile_alt() consumes every `|` and stops at the group's
-           ')' or the end of the pattern, which is where the caller
-           expects the parse point, so what follows is unchanged: the
-           enclosing compile_seq() finds its terminator, a stray ')' at
-           top level is still refused by mrb_re_compile(), and a
-           quantifier with nothing before it is refused by the
-           compile_seq() called from here. */
+           it. The level takes every `|` and closes at the group's ')' or
+           the end of the pattern, consuming neither, which is where the
+           enclosing level expects the parse point, so what follows is
+           unchanged: that level finds its terminator, a stray ')' at top
+           level is still refused by mrb_re_compile(), and a quantifier
+           with nothing before it is refused inside the level. */
         next_char(c);
+        open_level(c, RE_LEVEL_TOGGLE, begin, outer_atom_start);
         c->flags = new_flags;
-        compile_alt(c);
-        c->flags = saved_flags;
-        return TRUE;
+        return;
       }
       else if (peek(c) == ':') {
         next_char(c);
+        open_level(c, RE_LEVEL_OPTION, begin, outer_atom_start);
         c->flags = new_flags;
-        compile_alt(c);
-        c->flags = saved_flags;
-        if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-        next_char(c);
-        return TRUE;
+        return;
       }
       else {
         if (peek(c) < 0) compile_error(c, "end pattern in group");
@@ -2834,10 +2899,10 @@ open_group(re_compiler *c)
          the number as it refuses `\1`.
 
          Two branches at most: a third `|` is `invalid conditional
-         pattern`, as in CRuby, so the bodies are read one sequence at a
-         time rather than through compile_alt(), which would take every
-         `|`. The bodies nest a level as a group's would, and the
-         count is kept the way compile_alt() keeps it.
+         pattern`, as in CRuby, so the level reads the `|` between the
+         bodies itself, where any other level reads every `|` as a branch
+         of its alternation; see compile_levels(). The bodies nest a level
+         as a group's would, and count as one.
 
          One instruction carries the test and the layout is a fork's
          with the choice made by the captures instead of pushed: RE_COND
@@ -2901,27 +2966,9 @@ open_group(re_compiler *c)
       next_char(c);  /* skip the ')' closing the condition */
 
       uint32_t head = emit(c, RE_COND, (uint8_t)group, 0);
-      if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
-        compile_error(c, "parse depth limit over");
-      }
-      compile_seq(c);
-      if (peek(c) == '|') {
-        next_char(c);
-        uint32_t skip = emit(c, RE_JMP, 0, 0);
-        c->pat->code[head].offset = (uint16_t)c->code_len;
-        compile_seq(c);
-        if (peek(c) == '|') compile_error(c, "invalid conditional pattern");
-        c->pat->code[skip].offset = (uint16_t)c->code_len;
-      }
-      else {
-        c->pat->code[head].offset = (uint16_t)c->code_len;
-      }
-      c->depth--;
-      if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-      next_char(c);
-      c->needs_backtrack = TRUE;  /* the Pike VM's threads carry no test of their captures */
-      c->flags = saved_flags;
-      return TRUE;
+      re_level *lv = open_level(c, RE_LEVEL_COND, begin, outer_atom_start);
+      lv->head = head;
+      return;
     }
     else if (c->p[1] == '#') {
       /* preprocess_pattern() removes a terminated comment group before
@@ -2935,7 +2982,7 @@ open_group(re_compiler *c)
          groups (?#...) never get here either, having been removed by
          preprocess_pattern(). Raise here rather than falling through to
          the capturing-group path, which would leave the stray `?` for
-         compile_seq to spin on forever (A1). */
+         compile_levels() to spin on forever (A1). */
       if (c->p[1] == '<') {
         /* `(?<` and nothing more, the only way a '<' reaches here: the
            pattern ends before the character that tells a lookbehind
@@ -2976,33 +3023,22 @@ open_group(re_compiler *c)
     }
   }
 
-  compile_alt(c);
-
-  if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
-  next_char(c);
-
-  if (capturing) {
-    emit(c, RE_SAVE, 0, group * 2 + 1);
-  }
-  c->flags = saved_flags;  /* the options this group opened with */
-  return TRUE;
+  re_level *lv = open_level(c, RE_LEVEL_GROUP, begin, outer_atom_start);
+  lv->state = capturing;
+  lv->num = group;
 }
 
-/* Compile a single atom (character, class, group, etc.). Returns whether one
-   was read: FALSE when what stands at the parse point is not an atom, either a
-   quantifier metacharacter or the end of the sequence, neither of them
-   consumed. An empty group `(?:)` emits nothing and is still an atom, and so
-   does an option toggle `(?i)` whose scope, the rest of the enclosing group,
-   is empty. */
+/* Compile a single atom (character, class, anchor, escape). Returns whether
+   one was read: FALSE when what stands at the parse point is not an atom,
+   either a quantifier metacharacter or the end of the sequence, neither of
+   them consumed. A '(' is not read here: it opens a level, which is
+   compile_levels()'s to push, through open_group(). */
 static mrb_bool
 compile_atom(re_compiler *c)
 {
   int ch = peek(c);
 
   switch (ch) {
-  case '(':
-    next_char(c);
-    return open_group(c);
 
   case '[':
     next_char(c);
@@ -3298,7 +3334,7 @@ compile_atom(re_compiler *c)
 
   case '{':
     {
-      /* `{` opens a repeat only as a valid quantifier, which compile_quantified
+      /* `{` opens a repeat only as a valid quantifier, which compile_quantifiers()
          consumes after an atom. Reaching it here means there is no atom to
          repeat: a real quantifier (e.g. {2}) is an error, like CRuby, and
          anything else (e.g. {a}, a lone {) is a literal `{`. parse_quantifier
@@ -3411,29 +3447,22 @@ idempotent_assertion(const re_inst *code, uint32_t start, uint32_t end)
   return TRUE;
 }
 
-/* Compile atom with quantifiers (*, +, ?, {n,m}) */
+/* Read the quantifiers after an atom, `*`, `+`, `?` and `{n,m}`, and wrap
+   the code the atom emitted, from `begin` to the end of the code, in them.
+   `start` is where the atom itself begins, which is `begin` except after a
+   `\u{...}` list, whose last codepoint alone is the quantifier's; see
+   compile_atom(). */
 static void
-compile_quantified(re_compiler *c)
+compile_quantifiers(re_compiler *c, uint32_t begin, uint32_t start)
 {
-  uint32_t begin = c->code_len;
-  /* atom_start normally stays at `begin`; compile_atom moves it only for a
-     `\u{...}` list, whose leading codepoints are atoms of their own. Saving
-     and restoring it keeps a nested compile_quantified (inside a group) from
-     leaving its own atom behind for this one. */
-  uint32_t saved_atom_start = c->atom_start;
-  c->atom_start = begin;
-  mrb_bool atom = compile_atom(c);
-  uint32_t start = c->atom_start;
-  c->atom_start = saved_atom_start;
   if (c->code_len == begin) {
     /* Nothing emitted. An empty group `(?:)` is an atom all the same, and
        one that matches empty matches empty however it is repeated, so its
        quantifiers are read and emit nothing, as those of `a{0}` are; CRuby
-       compiles `(?:)*` the same way. A stray metacharacter is no atom and
-       leaves the quantifier for compile_seq() to refuse; `(?i)*` is refused
-       there too, as CRuby refuses it, by the compile_seq() that reads the
-       toggle's scope. */
-    if (atom) skip_quantifiers(c);
+       compiles `(?:)*` the same way. `(?i)*` is refused, as CRuby refuses
+       it, but inside the toggle's level, where the `*` stands with no atom
+       before it; see compile_levels(). */
+    skip_quantifiers(c);
     return;
   }
   mrb_bool assertion = idempotent_assertion(c->pat->code, start, c->code_len);
@@ -3622,120 +3651,236 @@ compile_quantified(re_compiler *c)
   }
 }
 
-/* Compile a sequence of quantified atoms */
+/* Mark on the RE_JMP a branch ends with while the alternation it belongs to
+   is still open: the target is the code after the last branch, which is not
+   known until then. close_alternation() finds the level's branches by these
+   marks and clears them. By the time a level closes, every alternation
+   inside it has closed, so the marks left are the level's own; none survives
+   the parse, and the mark mark_empty_loops() writes on the same field
+   afterwards is another matter. */
+#define RE_JMP_BRANCH 1
+
+/* Close the alternation of a level that is closing: give its branches the
+   SPLIT chain that chooses among them and the exits that rejoin after the
+   last, and leave the record the lookbehind arm reads. A level that read no
+   `|` has one branch and nothing to do.
+
+   a|b|c lays out as
+
+     SPLIT c; SPLIT b; a; JMP end; b; JMP end; c; end:
+
+   Each SPLIT falls through to the next, and the chain's final fall-through
+   reaches the first branch, so the engines (which rank a SPLIT's
+   fall-through above its jump) explore branch 0 first. The jump targets are
+   then unwound in reverse, so SPLIT i must jump to branch (n - 1 - i) to
+   keep the remaining branches in source order, leftmost-first across three
+   or more. The chain goes in front of the first branch once the last has
+   been read, which is what moves the branches; the exits are found where
+   they stand by their marks, in the order the branches were read. */
 static void
-compile_seq(re_compiler *c)
+close_alternation(re_compiler *c, re_level *lv)
 {
-  for (;;) {
-    /* One token ends here and the next may begin, so under /x this is where
-       the whitespace between them goes: `a b` is `ab`, and the blanks before
-       a '|' or a ')' are gone by the time compile_alt() looks for one. */
-    skip_extended_space(c);
-    int ch = peek(c);
-    if (ch < 0 || ch == ')' || ch == '|') return;
-    uint32_t code_before = c->code_len;
-    const char *p_before = c->p;
-    compile_quantified(c);
-    if (c->code_len == code_before && c->p == p_before) {
-      /* compile_quantified neither consumed input nor emitted code: the
-         current character is a quantifier metacharacter with no atom to
-         repeat (a leading `*`, `+`, `?`, or one after the toggle `(?i)`).
-         CRuby raises RegexpError here; without this guard peek() never
-         advances and the loop spins forever (A1). */
-      compile_error(c, "target of repeat operator is not specified");
-    }
-  }
-}
-
-/* Compile alternation: seq | seq | ... */
-static void
-compile_alt_body(re_compiler *c)
-{
-  uint32_t alt_start = c->code_len;
-  compile_seq(c);
-
-  if (peek(c) != '|') return;
-
-  /* a|b → SPLIT L1 L2; L1: a; JMP END; L2: b; END:
-     We need to insert SPLIT before already-emitted code for first alt.
-     Strategy: emit JMP after first alt, then for each subsequent alt,
-     insert a SPLIT before it by shifting code. */
-
-  /* Collect all alternatives, then emit SPLIT chain at the end.
-     This avoids insert_inst offset corruption for multi-way alternation. */
-  uint32_t alt_starts[RE_MAX_ALTS];  /* start positions of each alternative */
-  int num_alts = 0;
-  alt_starts[num_alts++] = alt_start;
-
-  while (peek(c) == '|') {
-    next_char(c);
-    emit(c, RE_JMP, 0, 0);  /* placeholder: jump to end */
-    alt_starts[num_alts++] = c->code_len;
-    if (num_alts >= RE_MAX_ALTS) compile_error(c, "too many alternatives");
-    compile_seq(c);
-  }
-
-  if (num_alts <= 1) return;  /* shouldn't happen, but safety */
-
-  /* Now insert SPLIT chain before the alternatives.
-     For n alternatives: n-1 SPLIT instructions, each pointing to
-     their respective alternative. */
-  uint32_t split_count = (uint32_t)(num_alts - 1);
-  /* Insert split_count instructions at alt_starts[0] */
-  for (uint32_t i = 0; i < split_count; i++) {
-    insert_inst(c, alt_starts[0], RE_JMP, 0, 0);  /* placeholder */
-    /* adjust all alt_starts by +1 due to insertion */
-    for (int j = 0; j < num_alts; j++) {
-      alt_starts[j]++;
-    }
-  }
-
-  /* Now set up the SPLIT chain. Each SPLIT falls through to the next, and the
-     chain's final fall-through reaches the first alternative, so the engines
-     (which rank a SPLIT's fall-through above its jump) explore alternative 0
-     first. The jump targets are then unwound in reverse, so SPLIT i must jump
-     to alternative (split_count - i) to keep the remaining alternatives in
-     source order -- i.e. leftmost-first across three or more branches. */
-  for (uint32_t i = 0; i < split_count; i++) {
-    uint32_t pos = alt_starts[0] - split_count + i;
-    c->pat->code[pos].op = RE_SPLIT;
-    c->pat->code[pos].a = 0;
-    c->pat->code[pos].offset = (uint16_t)alt_starts[split_count - i];
-  }
-
-  /* Patch JMPs (they are right before each alt_starts[1..n-1]) to point to end */
+  if (lv->branches == 0) return;
+  uint32_t n = lv->branches + 1;
+  uint32_t split_count = n - 1;
+  insert_insts(c, lv->alt_start, split_count);
+  uint32_t first = lv->alt_start + split_count;  /* where branch 0 now begins */
   uint32_t end = c->code_len;
-  for (int i = 1; i < num_alts; i++) {
-    uint32_t jmp_pos = alt_starts[i] - 1;
-    c->pat->code[jmp_pos].op = RE_JMP;
-    c->pat->code[jmp_pos].offset = (uint16_t)end;
+  uint32_t k = 0;
+  for (uint32_t pc = first; pc < end; pc++) {
+    re_inst *in = &c->pat->code[pc];
+    if (in->op != RE_JMP || in->a != RE_JMP_BRANCH) continue;
+    in->a = 0;
+    in->offset = (uint16_t)end;
+    k++;  /* branch k begins right after the exit of branch k - 1 */
+    c->pat->code[first - k].op = RE_SPLIT;
+    c->pat->code[first - k].a = 0;
+    c->pat->code[first - k].offset = (uint16_t)(pc + 1);
   }
+  mrb_assert(k == split_count);
 
-  /* Leave the branches where the lookbehind arm can find them; see the
-     record's declaration. Nothing moves this code between here and the arm's
-     look at it: a lookbehind body ends with the RE_LOOK_END emitted right
-     after this returns. */
-  for (int i = 0; i < num_alts; i++) c->alt_starts[i] = alt_starts[i];
-  c->alt_count = (uint32_t)num_alts;
-  c->alt_from = alt_starts[0] - split_count;
+  /* Leave the span where the lookbehind arm can find it; see the record's
+     declaration. Nothing moves this code between here and the arm's look at
+     it: a lookbehind body ends with the RE_LOOK_END emitted right after
+     this returns. */
+  c->alt_count = n;
+  c->alt_from = lv->alt_start;
   c->alt_to = end;
 }
 
-/* Bound the parser's own recursion. Every nesting level it descends into is
-   one compile_alt() frame -- compile_alt -> compile_seq -> compile_quantified
-   -> compile_atom, whose group, lookaround, atomic and inline-option arms
-   call compile_alt again -- so the count stands here, at the one entry the
-   recursion passes through, and a pattern that nests deeper is refused rather
-   than run off the C stack. The message is CRuby's for the same refusal; see
-   MRB_REGEXP_PARSE_DEPTH_LIMIT for what the number is and what it costs. */
 static void
-compile_alt(re_compiler *c)
+close_paren(re_compiler *c)
 {
-  if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
-    compile_error(c, "parse depth limit over");
+  if (peek(c) != ')') compile_error(c, "end pattern with unmatched parenthesis");
+  next_char(c);
+}
+
+/* Close the innermost level, the parse point on its ')' or at the end of the
+   pattern: finish its alternation, emit what its construct puts after the
+   body, consume the ')' where the construct owns one, and restore the
+   options it opened with. */
+static void
+close_level(re_compiler *c)
+{
+  re_level *lv = &c->levels[c->level_count - 1];
+
+  if (lv->kind != RE_LEVEL_COND) close_alternation(c, lv);
+  switch (lv->kind) {
+  case RE_LEVEL_PATTERN:
+    /* a ')' that ends the pattern is left for mrb_re_compile() to refuse */
+    break;
+
+  case RE_LEVEL_GROUP:
+    close_paren(c);
+    if (lv->state) emit(c, RE_SAVE, 0, (uint16_t)(lv->num * 2 + 1));
+    break;
+
+  case RE_LEVEL_LOOKAHEAD:
+    /* The end carries the lookaround's number, from the count the atomic
+       groups use, so that a cut aimed at this lookaround is told from one
+       aimed at a group around or inside it; see bt_match(). */
+    emit(c, RE_LOOK_END, lv->state ? RE_LOOK_NEGATED : 0, lv->num);
+    c->pat->code[lv->head].offset = (uint16_t)c->code_len;  /* patch: skip past sub-pattern */
+    close_paren(c);
+    c->needs_backtrack = TRUE;  /* needs backtracking engine */
+    break;
+
+  case RE_LEVEL_LOOKBEHIND: {
+    emit(c, RE_LOOK_END, lv->state ? RE_LOOK_NEGATED : 0, lv->num);
+    uint32_t sub_start = lv->aux;
+    uint32_t body_end = c->code_len;  /* the RE_LOOK_END is at body_end - 1 */
+
+    /* A sub-pattern holding a \g call cannot be measured yet: where the
+       call jumps is not decided until resolve_calls(), and the body it runs
+       may not be written yet. A width of its own per branch is out of reach
+       for one of those, the alternation record being long gone by then, so
+       it is left with the single carrier it can be given here and
+       measure_deferred_lookbehinds() fills that in once the calls are
+       wired. The landing bit is not set on the end here either: whether it
+       is needed is known only once the body is measured, and
+       add_lookbehind_widths() sets it. */
+    mrb_bool deferred = FALSE;
+    for (uint32_t i = sub_start; i < body_end; i++) {
+      if (c->pat->code[i].op == RE_CALL) { deferred = TRUE; break; }
+    }
+    if (deferred) {
+      insert_inst(c, sub_start, RE_LB_WIDTH, 0, 0);
+    }
+    else {
+      add_lookbehind_widths(c, lv->head, sub_start, body_end);
+    }
+    c->pat->code[lv->head].offset = (uint16_t)c->code_len;
+    close_paren(c);
+    c->needs_backtrack = TRUE;  /* needs backtracking engine */
+    break;
   }
-  compile_alt_body(c);
+
+  case RE_LEVEL_ATOMIC:
+    emit(c, RE_ATOMIC_END, 0, lv->num);
+    close_paren(c);
+    c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
+    break;
+
+  case RE_LEVEL_ABSENT:
+    emit(c, RE_ABSENT_END, 0, 0);
+    close_paren(c);
+    c->pat->code[lv->head].offset = (uint16_t)c->code_len;
+    c->needs_backtrack = TRUE;  /* the Pike VM has no scan of its own */
+    break;
+
+  case RE_LEVEL_OPTION:
+    close_paren(c);
+    break;
+
+  case RE_LEVEL_TOGGLE:
+    /* Its scope ends at the ')' of the group it stands in, or at the end of
+       the pattern, and neither is its own to consume. */
+    break;
+
+  case RE_LEVEL_COND:
+    /* With no `no`, the head's offset is the text after the group; with
+       one, the jump that ends `yes` goes there. */
+    c->pat->code[lv->state ? lv->aux : lv->head].offset = (uint16_t)c->code_len;
+    close_paren(c);
+    c->needs_backtrack = TRUE;  /* the Pike VM's threads carry no test of their captures */
+    break;
+  }
+  c->flags = lv->flags;
   c->depth--;
+  c->level_count--;
+}
+
+/* Read the pattern from the parse point, one atom at a time, opening a level
+   at every '(' and closing one at every ')'. The descent a recursive parser
+   makes per level is a push here, so the parse stands in this one C frame
+   at any depth, and what a level costs is the re_level open_level() finds
+   room for. Returns at the end of the pattern, or at a ')' with no level
+   left to close, which is left standing for mrb_re_compile() to refuse.
+
+   A level is the atom its opener began: when it closes, the quantifiers
+   after its ')' bind the code from its `begin`, as those after a character
+   bind the character. Around any atom, c->atom_start is set to where the
+   atom begins and put back afterwards, so that an atom whose `\u{...}` list
+   moved it, inside a level or not, leaves nothing behind for the next one;
+   a level keeps the outer value until its close. */
+static void
+compile_levels(re_compiler *c)
+{
+  open_level(c, RE_LEVEL_PATTERN, c->code_len, c->atom_start);
+  for (;;) {
+    /* One token ends here and the next may begin, so under /x this is where
+       the whitespace between them goes: `a b` is `ab`, and the blanks before
+       a '|' or a ')' are gone by the time the level looks for one. */
+    skip_extended_space(c);
+    int ch = peek(c);
+    re_level *lv = &c->levels[c->level_count - 1];
+
+    if (ch == '|') {
+      next_char(c);
+      if (lv->kind == RE_LEVEL_COND) {
+        /* Two bodies at most: a third is `invalid conditional pattern`, as
+           in CRuby. `yes` ends with a jump past `no`, and the head goes on
+           at `no` where the group has not matched. */
+        if (lv->state) compile_error(c, "invalid conditional pattern");
+        lv->aux = emit(c, RE_JMP, 0, 0);
+        c->pat->code[lv->head].offset = (uint16_t)c->code_len;
+        lv->state = TRUE;
+        continue;
+      }
+      emit(c, RE_JMP, RE_JMP_BRANCH, 0);  /* the branch's exit; see close_alternation() */
+      lv->branches++;
+      continue;
+    }
+
+    if (ch < 0 || ch == ')') {
+      uint8_t kind = lv->kind;
+      uint32_t begin = lv->begin;
+      uint32_t outer = lv->atom_start;
+      close_level(c);
+      if (kind == RE_LEVEL_PATTERN) return;
+      compile_quantifiers(c, begin, begin);
+      c->atom_start = outer;
+      continue;
+    }
+
+    uint32_t begin = c->code_len;
+    uint32_t outer = c->atom_start;
+    c->atom_start = begin;
+    if (ch == '(') {
+      next_char(c);
+      open_group(c, begin, outer);
+      continue;
+    }
+    if (!compile_atom(c)) {
+      /* The character is a quantifier metacharacter with no atom to repeat,
+         a `*`, `+` or `?` opening a sequence or standing after the toggle
+         `(?i)`. CRuby raises RegexpError here; without this the loop would
+         come round to the same character forever (A1). */
+      compile_error(c, "target of repeat operator is not specified");
+    }
+    compile_quantifiers(c, begin, c->atom_start);
+    c->atom_start = outer;
+  }
 }
 
 /* Inside a character class, is `src` the start of a POSIX bracket [:name:]?
@@ -4702,6 +4847,9 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.orig = pattern;
   c.orig_end = pattern + len;
   c.pending_calls = mrb_nil_value();  /* a zero fill is not a nil mrb_value */
+  c.level_store = mrb_nil_value();
+  c.levels = c.levels_inline;
+  c.level_capa = RE_LEVELS_INLINE;
 
   /* Both things the pre-pass removes, a (?#...) group and a `#` comment,
      are spelled with a '#', so a pattern without one is parsed as written.
@@ -4728,7 +4876,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   /* group 0 start */
   emit(&c, RE_SAVE, 0, 0);
 
-  compile_alt(&c);
+  compile_levels(&c);
 
   if (c.p < c.src_end) {
     compile_error(&c, "unmatched close parenthesis");

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -288,43 +288,23 @@ assert("Regexp - a backreference reads no group the running iteration reopened")
 end
 
 assert("Regexp - a pattern nested past the parse depth limit raises") do
-  # The parser recurses once per nesting level, so a deep enough pattern used
-  # to reach the end of the C stack, which is a crash and not an error:
-  # `(?:` x 50000 was a SIGSEGV. MRB_REGEXP_PARSE_DEPTH_LIMIT bounds it, and
-  # CRuby's message for the same refusal is the one raised here.
-  #
-  # A nesting the guard must not refuse: the count has to leave a pattern
-  # inside the limit alone, and a deep one it accepts has to still match. The
-  # depth comes from the build's own limit, since a build may set one below
-  # any figure written here.
+  # MRB_REGEXP_PARSE_DEPTH_LIMIT bounds how many levels a pattern may have
+  # open at once, at CRuby's default, and CRuby's message for the refusal is
+  # the one raised here. The parser keeps its levels on the heap rather than
+  # on the C stack, so reaching the limit costs a test no stack: the refusal
+  # is asked of every build at the limit that build set, which
+  # `Regexp::PARSE_DEPTH_LIMIT` reads back.
   limit = Regexp::PARSE_DEPTH_LIMIT
-  inside = limit > 200 ? 200 : limit - 1
-  if inside > 0
-    assert_equal 0, (Regexp.new("(?:" * inside + "a" + ")" * inside) =~ "a")
-    assert_equal 0, (Regexp.new("(?i)" * inside + "a") =~ "A")
-  end
 
-  # The refusal itself is sized from `Regexp::PARSE_DEPTH_LIMIT`, which reads
-  # back what the build set. Reaching it costs the stack the limit stands for:
-  # the count is checked at the bottom of the recursion, so a pattern past the
-  # limit descends to it before being refused, and at the CRuby-exact default
-  # that is some 2.4 MiB -- more C stack than a Windows thread has at all, and
-  # the very thing the limit exists to keep a pattern from spending. So a
-  # build whose limit stands above what a test may descend is left out rather
-  # than crashed, and the refusal is covered by a build that sets a limit a
-  # test can reach: the `ascii-ctype` build of build_config/ci/gcc-clang.rb
-  # sets 512, which runs on every entry of the CI matrix. The arithmetic that
-  # refuses is the same at any limit.
-  if limit > 512
-    skip "reaching this build's parse depth limit costs more C stack than a test may spend"
-  end
-
-  # Every construct that opens a level is asked, an inline toggle among them:
-  # it encloses the rest of the group it stands in, so it is a level of its
-  # own, and CRuby counts it as one too.
+  # A nesting the guard must not refuse: a pattern inside the limit is left
+  # alone and still matches. Every construct that opens a level is asked
+  # below, an inline toggle among them: it encloses the rest of the group it
+  # stands in, so it is a level of its own, and CRuby counts it as one too.
   fits = limit - 1
-  assert_equal 0, (Regexp.new("(?:" * fits + "a" + ")" * fits) =~ "a")
-  assert_equal 0, (Regexp.new("(?i)" * fits + "a") =~ "A")
+  if fits > 0
+    assert_equal 0, (Regexp.new("(?:" * fits + "a" + ")" * fits) =~ "a")
+    assert_equal 0, (Regexp.new("(?i)" * fits + "a") =~ "A")
+  end
 
   [
     ["(?:" * limit + "a" + ")" * limit, "a plain group"],
@@ -338,6 +318,36 @@ assert("Regexp - a pattern nested past the parse depth limit raises") do
       Regexp.new(pattern)
     end
   end
+end
+
+assert("Regexp - an alternation holds as many branches as the pattern writes") do
+  # The branches were once collected in an array of 64 and the 64th refused
+  # as `too many alternatives`. They are found in the code they were compiled
+  # to now, so the count is the pattern's to choose; Regexp.union over a word
+  # list is where it gets large. The branches stay in source order at any
+  # count, leftmost-first: the first branch that matches wins, however many
+  # after it would match more.
+  words = (1..300).map { |i| "<#{i}>" }
+  re = Regexp.union(words)
+  assert_equal "<300>", re.match("xx <300> yy")[0]
+  assert_equal "<1>", re.match("<1>")[0]
+  assert_nil re.match("<0>")
+  assert_nil re.match("<301>")
+
+  longest_first = Regexp.new((1..100).map { |i| "a" * i }.reverse.join("|"))
+  shortest_first = Regexp.new((1..100).map { |i| "a" * i }.join("|"))
+  assert_equal 100, longest_first.match("a" * 100)[0].size
+  assert_equal 1, shortest_first.match("a" * 100)[0].size
+
+  # A lookbehind body of that many branches carries a rewind per branch, as
+  # a body of two does: `3`, `11` and `222` stand among the seventy, one,
+  # two and three characters wide.
+  alts = (1..70).map { |i| i.to_s(36) * (i % 3 + 1) }
+  behind = Regexp.new("(?<=#{alts.join('|')})!")
+  assert_equal 1, behind =~ "3!"
+  assert_equal 2, behind =~ "11!"
+  assert_equal 3, behind =~ "222!"
+  assert_nil behind =~ "1!"
 end
 
 assert("Regexp - the backtracking engine raises at a limit rather than answer short") do


### PR DESCRIPTION
## Summary

The regexp parser descended one C frame per nesting level, so `MRB_REGEXP_PARSE_DEPTH_LIMIT` had to be sized to the stack each build runs on, and a build that sized it high still crashed: the same binary compiled 2000 nested groups on an 8 MiB stack and died on a 1 MiB one, well inside its default of 4096. The levels a pattern nests are now a stack the parser keeps on the heap, so a compile stands in one C frame at any depth and a pattern the machine cannot hold is refused by the allocator, at whatever depth that is. The limit keeps its value and its message; what it guards now is the agreement with CRuby on where a pattern is refused, which is one value for every build.

## Changes

| File | What |
|---|---|
| `src/re_compile.c` | adds `re_level`, `open_level()`, `open_group()`, `close_level()`, `close_alternation()`, `compile_levels()`, `branch_head()`; removes `compile_alt()`, `compile_alt_body()`, `compile_seq()`, `compile_look_body()`, `RE_MAX_ALTS` and the `alt_starts[]` record; `compile_quantified()` becomes `compile_quantifiers(begin, start)`; `fixed_len_walk()` steps over `RE_LB_WIDTH` |
| `include/re_internal.h` | the comment on `MRB_REGEXP_PARSE_DEPTH_LIMIT` says what it guards now |
| `test/regexp_syntax.rb` | the depth test runs at every build's limit; an alternation of 300 branches, and a lookbehind of 70 |
| `README.md` | the parse depth section loses its stack table |
| `build_config/ci/gcc-clang.rb` | `ascii-ctype` gives up the `MRB_REGEXP_PARSE_DEPTH_LIMIT=512` it set for the test to reach |

### A constant cannot see the stack the build gets

`compile_alt()` called `compile_seq()` called `compile_quantified()` called `compile_atom()`, whose group, lookaround, atomic, absent, conditional and inline-option arms called `compile_alt()` again, and each turn of that cycle kept locals of its own: `alt_starts[64]` in `compile_alt_body()`, the saved options and the group number in `compile_atom()`. What one level cost was the compiler's to decide, 544 bytes at gcc -O3 and 584 at clang -O3 on x86_64, and the fixed part under the parse is the interpreter's, so the limit converted a crash into an error only for the builds that guessed their figure right. The README carried a table of which limit fits which stack for that reason, and the `ascii-ctype` CI build set 512 so that the refusal test could reach a limit somewhere in the matrix without spending the 2.4 MiB the default costs.

The executor made the same move earlier: it backtracks on a heap stack of its own, bounded by `MRB_REGEXP_STACK_LIMIT`, and an allocation it cannot make is `NoMemoryError` rather than a limit. The compiler is the half of the gem that had not followed.

### A level is a push

Each construct that opens a level now pushes an `re_level` (32 bytes, no pointers: what its close needs, and what the level it stands in needs back) and returns; `compile_levels()` is one loop that reads atoms, pushes a level at `(`, and at `)` runs the construct's epilogue off the top of the stack, then the quantifiers that bind to what the level emitted. Eight levels live inline in the compiler struct, which is every pattern anyone writes compiling with no allocation for them; past that they move to a String the GC arena holds for the compile, the way the parked `\g` references already are, so a raise in the middle of a compile leaves nothing to free. `c->depth` is what it was, and the limit is met at the push rather than at the bottom of a recursion.

The first commit is the move of the 380-line `case '('` into `open_group()` with nothing else in it, so that the second reads as itself; `git diff -w` shows the substance of each.

### The branches of an alternation are found in the code

The per-level `alt_starts[64]` was the largest of the locals a level kept, and it was also a refusal: a 64th branch was `too many alternatives`, which `Regexp.union` over a word list reached at 64 words. A branch's exit is the `RE_JMP` emitted at its `|`, whose target is unknown until the alternation closes, so that jump now carries a mark until then, and the close finds the level's branches by their marks: every alternation inside the level has closed by then, so the marks left are its own. The SPLIT chain then goes in front of the first branch as before. The lookbehind arm, which needs the branch heads to give each branch its rewind, reads them off that chain, which is the alternation's own table of where its branches begin, and measures each branch once its rewind is in place rather than before; `fixed_len_walk()` learns to step over an `RE_LB_WIDTH` for the one case where a branch's exit lands on the last branch's rewind, the last branch being empty.

### What is left on the C stack

A nested character class is still read by recursion, `parse_class_operand()` into `parse_nested_class()` into `parse_class_expr()`, at about 500 bytes a level. It is a different shape from the group recursion: each open nest holds a class id, and the class table has 256, so the depth is bounded by a constant rather than by the limit, and a pattern past it is `too many character classes`. The README says so.

## Behaviour

The crash in the Summary, `(?:` × 2000 around an `a`:

```console
$ (ulimit -s 1024; bin/mruby -e 'p Regexp.new("(?:" * 2000 + "a" + ")" * 2000).class')
Segmentation fault (core dumped)        # master
Regexp                                  # this PR, and the same at ulimit -s 128
```

4095 levels compile on a 128 KiB stack, and 4096 raise `parse depth limit over` at every stack size, where master raises it on an 8 MiB stack and crashes on a 1 MiB one. The refusal test in `regexp_syntax.rb` therefore runs at whatever limit the build set, the default included, and no longer skips above 512.

```ruby
Regexp.union((1..300).map { |i| "<#{i}>" })   # was RegexpError (too many alternatives), now /<1>|<2>|...|<300>/
Regexp.new("(?<=" + seventy_branches + ")!")  # a rewind per branch, as with two
```

Every pattern that compiled before compiles to the same code: `rake regexp:difftest` against CRuby 4.0.6 answers `6791 patterns, 353 known differences, no new ones`, the figure the README records.

## Speed

Instructions per compile under callgrind, `Ir(2N) - Ir(N)` over `N = 2000`, on the `full-core` gembox at gcc -O3 (`full.rb` in the harness). The first four cases evaluate a literal per iteration, which compiles it, and match; `nested-n` is `Regexp.new` on `(?:` × n; the two controls compile nothing inside the loop and agree to the instruction.

| case | master | this PR | delta |
|---|---:|---:|---:|
| `"hello world".index("wor")` (control) | 2,320 | 2,320 | 0 |
| `re =~ "xabcy"`, compiled once (control) | 10,831 | 10,831 | 0 |
| `/abc/ =~ "xxabc"` | 14,377 | 14,579 | +202 |
| `/x(a\|b\|c)+y/ =~ "xabcy"` | 24,019 | 24,090 | +71 |
| `"abc".gsub(/b/) { }` | 17,672 | 17,756 | +84 |
| `Regexp.new("(?<=ab\|c\|def)x")` | 12,262 | 12,630 | +368 |
| `nested-4` | 10,407 | 10,643 | +236 |
| `nested-7` | 11,079 | 11,429 | +350 |
| `nested-8` (spills) | 11,320 | 12,669 | +1,349 |
| `nested-12` | 12,226 | 13,673 | +1,447 |

A level costs 262 instructions against 224, the push and the epilogue switch against a call chain; the pattern's own level is one of the eight kept inline, so a pattern nesting eight groups is the first that allocates, about 1,000 instructions once per compile for the String and the GC step it brings. A lookbehind body of branches pays the scan for its marks and reads the chain twice.

An alternation opens its whole SPLIT chain in one shift of the code, `insert_insts()`, rather than one insertion per branch: each insertion shifts the tail and walks the program to move the indices it holds, so a chain opened branch by branch walks the program once per branch. The widest alternation the program size admits, 21,000 single-character branches, compiles in 0.7 ms on the host below, where opening the chain a branch at a time takes 800 ms.

## Size

### Code

`.text` of `bin/mruby` per `ci/gcc-clang` build, gcc 13.3.0, empty build directories, `rake` on both sides, master at `64dead36c`:

| build | master | this PR | delta |
|---|---:|---:|---:|
| bintest | 1,383,078 | 1,382,662 | -416 |
| ascii-ctype | 1,367,542 | 1,367,318 | -224 |
| byte-string | 1,344,902 | 1,344,870 | -32 |
| cxx_abi | 1,415,769 | 1,416,233 | +464 |
| no-float | 1,308,846 | 1,308,430 | -416 |
| no-bigint | 1,267,702 | 1,267,286 | -416 |
| full-debug (-O0) | 1,975,494 | 1,975,046 | -448 |

All of it is `re_compile.o`, 40,481 to 40,065 on `bintest`; `re_exec.o` and `regexp.o` are unchanged. The four mutually recursive functions and their prologues go, and what replaces them is one loop, a switch over nine level kinds, and the level push. The compiler struct trades `alt_starts[64]` (256 bytes) for eight inline levels (256 bytes) and a pointer, a count, a capacity and an `mrb_value`, so `mrb_re_compile()`'s frame grows by 32 bytes on x86_64 (1,440 bytes; 1,392 on i686).

### RAM per level

For a build sizing the limit: a level is 32 bytes on any ABI, the first eight (the pattern's own included) cost no heap, and past them the buffer doubles, so what one pattern can be made to spend is the limit rounded up to a power of two times 32 bytes, plus one String header, and only while it compiles. Raising the limit reserves nothing.

| `MRB_REGEXP_PARSE_DEPTH_LIMIT` | heap one pattern can spend | C stack per level on master (gcc -O3) |
|---|---:|---:|
| 4096 (default) | 128 KiB | 2.2 MiB |
| 512 | 16 KiB | 272 KiB |
| 128 | 4 KiB | 68 KiB |
| 32 | 1 KiB | 17 KiB |

### RAM measured

The default row of that table measured under massif: the `full-core` gembox at gcc -O3, `Regexp.new` on `(?:` × 4095 around an `a`, against the same call on one group. The heap row is what massif attributes to `open_level()` at the peak, the level stack alone; the C stack rows are the process peak:

```console
$ valgrind --tool=massif --stacks=yes --time-unit=B --peak-inaccuracy=0 --detailed-freq=1 bin/mruby -e 'Regexp.new("(?:" * 4095 + "a" + ")" * 4095)'
```

| bytes | master | this PR |
|---|---:|---:|
| heap held by the level stack, 4095 levels | 0 | 131,073 |
| C stack, 4095 levels | 2,236,584 | 8,648 |
| C stack, 1 level | 8,752 | 8,784 |

131,073 is 4096 levels at 32 bytes and the String's terminating NUL, the 128 KiB row of the table above; the master stack grows by 544 bytes a level from the one-group figure, the number `-fstack-usage` gives; this PR's stack at 4095 levels is its stack at one. The process heap peaks at 168,438 bytes on master and 300,299 on this PR: the pattern String and its program are the same on both, the level stack is the difference, and what remains of the gap is that the two builds peak at different points of the compile. The spill at the eighth level is 512 bytes and does not reach the process peak, so it shows in the `nested-8` row above rather than here.

## Testing

- `rake -m test` on the `full-core` gembox (gcc 13.3.0, `-O3`): 2,844 OK, 0 KO, 0 crash at the head, 2,842 at the first commit (which adds no test), and every commit green
- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc, all seven builds: 0 KO, 0 crash; the depth refusal test now runs in every one of them, `full-debug` under `MRB_GC_STRESS` included, where before it ran in `ascii-ctype` alone
- i686 `full-core` (`i686-linux-gnu-gcc`): 2,843 OK, 0 KO, 0 crash
- `MRUBY_CONFIG=host-debug rake regexp:difftest`: `6791 patterns, 353 known differences, no new ones`
- The nested-group pattern at `ulimit -s` 1024, 256 and 128, with 200, 2000, 4095 and 4096 levels
- `-fstack-usage` over `re_compile.c` under gcc -O3, gcc -Os and clang -O3: no function of the recursion cycle is left; `compile_levels()` is a 152-byte frame under clang and inlines into `mrb_re_compile()` under gcc
- massif (`--stacks=yes`) on `Regexp.new` over 1 and 4095 nested groups, master and this PR: the heap grows by the level stack and the C stack does not grow
- prek on each commit; `prettier --check` on the README

## Environment

<details>
<summary>Host, toolchain, and the compile lines</summary>

| | |
|---|---|
| OS | Linux 7.0.0-30-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| clang | Homebrew clang 23.1.0 (`-fstack-usage` only) |
| binutils | 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| valgrind | 3.27.1 |
| base | `64dead36c` |

`re_compile.c` as each `ci/gcc-clang` build compiles it (`-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` dropped):

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-regexp/src/re_compile.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_compile.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Regular expression parsing now supports deeply nested patterns using heap-based tracking, reducing dependence on C stack size.
  - Alternations can handle hundreds of branches while preserving source-order matching.
  - Alternations with differing branch widths are supported inside lookbehind expressions.

- **Bug Fixes**
  - Improved handling of nested regular-expression constructs and lookbehind width calculations.
  - Parse-depth behavior now provides clearer memory usage expectations and reports `NoMemoryError` if required allocation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->