### PR TITLE
string.c: stop unsharing the buffer the Unicode case walk only reads

### DIFF
--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -199,7 +199,7 @@ end
 
 assert('String#swapcase! - a frozen receiver') do
   skip unless UNICODECASE
-  # The Unicode walk raises from inside mrb_str_modify_keep_cr(), the same site
+  # The Unicode walk raises from its own mrb_check_frozen(), the same site
   # String#downcase! raises from, before the ASCII loop str_swapcase_bang
   # otherwise runs.
   assert_raise(FrozenError) { "Ä".freeze.swapcase! }

--- a/src/string.c
+++ b/src/string.c
@@ -2387,7 +2387,16 @@ mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode m
      not be recorded as holding one character per byte. */
   if (RSTR_BINARY_P(s) || str_ascii_p(s)) return -1;
 
-  mrb_str_modify_keep_cr(mrb, s);
+  /* The walk only reads the string and builds its answer beside it, so a
+     buffer the string shares is read where it is rather than copied first:
+     the copy would go unwritten, and str_replace() lets go of a shared buffer
+     by dropping the reference where it would free a private one. A string
+     the walk leaves as it was keeps what it carried, coderange included, and
+     one it changes takes the answer's along with the bytes, so nothing here
+     is prepared for a write. What is still owed is the frozen check: a
+     frozen receiver is turned away before anything is read, whether or not
+     the walk would have changed it, which is what CRuby's bang forms do. */
+  mrb_check_frozen(mrb, s);
 
   return str_case_convert_utf8(mrb, str, mode) ? 1 : 0;
 }

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -542,15 +542,34 @@ assert('String#downcase - a receiver above the embedded buffer') do
 end if UNICODECASE
 
 assert('String case conversion - a frozen receiver') do
-  # Only upcase! reaches str_modify_keep_cr()'s check on its own: the other
-  # three raise from a second modify further in, so they answer FrozenError
-  # whether or not that check is there and pin nothing about it.
+  # upcase! and capitalize! find nothing to change in 'Ä' and would answer
+  # nil without the walk's own mrb_check_frozen(), so they are what pins it.
+  # downcase! changes the character and raises from str_replace() further in,
+  # so it answers FrozenError whether or not that check is there.
   assert_raise(FrozenError) { 'Ä'.freeze.upcase! }
   assert_raise(FrozenError) { 'Ä'.freeze.downcase! }
   assert_raise(FrozenError) { 'Ä'.freeze.capitalize! }
-  # An all-ASCII receiver never enters the walk and is the other half of what
-  # that one check guards.
+  # An all-ASCII receiver never enters the walk and raises from the ASCII
+  # loop's own mrb_str_modify_keep_cr() instead.
   assert_raise(FrozenError) { 'AB'.freeze.downcase! }
+end if UNICODECASE
+
+assert('String case conversion - a receiver sharing its buffer') do
+  # A copy above the embedded buffer shares the bytes of what it was copied
+  # from, and the walk reads them where they are rather than unsharing first.
+  # Converting the copy must leave the original holding what it held, and a
+  # copy the walk finds nothing to change in must still read as what it was.
+  src = "ÄÖÜ" * 20
+  copy = src.dup
+  assert_equal "äöü" * 20, copy.downcase!
+  assert_equal "ÄÖÜ" * 20, src
+  copy = src.dup
+  assert_nil copy.upcase!
+  assert_equal "ÄÖÜ" * 20, copy
+  assert_equal "ÄÖÜ" * 20, src
+  # A literal above the embedded buffer can read its bytes from the program
+  # itself, and lets go of them the same way, without freeing them.
+  assert_equal "äöüäöüäöüäöüäöüäöüäöüäöüäöüäöü", "ÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜ".downcase!
 end if UNICODECASE
 
 assert('String case conversion - ASCII only') do


### PR DESCRIPTION
## Summary

`String#downcase`, `#upcase` and `#capitalize` copy the receiver with `mrb_str_dup()`, which shares the buffer, and run the bang form over the copy. The Unicode walk then unshared that buffer, copying it in full, and built its answer in a second string that `str_replace()` handed over, freeing the copy with nothing written to it. The walk now asks the frozen check alone and reads the shared bytes where they are, so a non-ASCII string above the embed limit is copied once per conversion rather than twice.

## Changes

| File | What |
|---|---|
| `src/string.c` | `mrb_str_case_convert_unicode()` calls `mrb_check_frozen()` where it called `mrb_str_modify_keep_cr()` |
| `test/t/string.rb` | a conversion of a copy leaves the original as it was; the frozen-receiver comment names the new raise site |
| `mrbgems/mruby-string-ext/test/string.rb` | the `swapcase!` frozen-receiver comment names the new raise site |

### The unshare copied a buffer nothing wrote to

`str_case_convert_utf8()` reads the receiver and writes into a string of its own, because a mapping can change how many bytes a character takes; at the end `str_replace()` moves that string's bytes into the receiver. What `mrb_str_modify_keep_cr()` did before the walk was therefore a copy of the source that the walk never wrote and `str_replace()` freed. `str_replace()` already handles a receiver that shares its buffer, by dropping the reference where it would free a private one, and a receiver the walk finds nothing to change in is left untouched, so the buffer can stay shared for the length of the walk. A shared buffer is safe to read for that long: it is refcounted and the receiver holds a reference, an `FSHARED` one is marked through `aux.fshared`, and a `NOFREE` one is the program's own bytes.

The coderange needs no reset either. `mrb_str_modify_keep_cr()` turned a `BROKEN` reading back to `UNKNOWN` before a write; here a receiver the walk changes takes the answer's reading along with its bytes, and one it refuses, or leaves alone, keeps what it carried, which is still true of it.

### The frozen check stays

CRuby raises `FrozenError` from a bang form on a frozen receiver whether or not the conversion would change anything, and so did mruby, from inside `mrb_str_modify_keep_cr()`. `mrb_check_frozen()` at the same point keeps that: the receiver is turned away before anything is read. The existing frozen-receiver test pins it through `'Ä'.freeze.upcase!`, the one call of the four that no later write would catch, and its comment now names the check it reaches.

## Speed

Instructions per call under callgrind, `Ir(2N) - Ir(N)` over `N`, on the `full-core` gembox at gcc -O3 (`case_bench.rb` in the harness). Each case is one non-bang conversion of a string built once; the two controls never reach the unshare on either side.

| case | bytes | master | this PR | delta |
|---|---:|---:|---:|---:|
| `"Ä".downcase` (embedded, control) | 2 | 1,580 | 1,554 | -26 |
| `("abc" * 80).upcase` (ASCII, control) | 240 | 4,154 | 4,154 | 0 |
| `("Ä" * 16).downcase` | 32 | 10,383 | 10,082 | -301 |
| `("ÄÖÜ" * 40).downcase` | 240 | 62,167 | 61,865 | -302 |
| `("ÄÖÜ" * 40).upcase` (nothing to change) | 240 | 80,388 | 79,496 | -892 |
| `("ÄÖÜ" * 500).downcase` | 3,000 | 751,273 | 751,247 | -26 |

What goes is one `malloc`, one copy and one `free` per call, which glibc prices by the state of its arena rather than by the bytes: 300 instructions at 32 and at 240 bytes. The `upcase` row is the case where the copy outlived the walk, since a receiver the walk leaves alone kept the copy until the sweep freed it, and the bins glibc kept for those frees are what the later `malloc` calls paid for. The embedded control loses the 26 instructions of the `mrb_str_modify_keep_cr()` call itself, which had nothing to unshare there. The ASCII control never reaches the walk and agrees to the instruction.

The 3,000-byte row is noise around zero rather than a saving, and it is worth saying why. The totals at N = 1,000, 2,000, 4,000 and 8,000 put this PR 581, 494, 463 and 455 instructions per call under master; the one function whose self cost differs between the two binaries by more than 40,000 instructions at N = 8,000 is glibc's `__memcmp_avx2_movbe`, which the walk calls once per character to ask whether the mapping changed anything, and it is dearer on this PR by 126 per call there and by 487 per call between N = 8,000 and 16,000. The source it compares against sits at a different offset from the answer's buffer on each side, since one side reads the shared buffer and the other read its copy, and what `memcmp` costs at one alignment against another is glibc's, not this change's. The malloc, the copy and the free of 3,000 bytes are cheap in instructions at that size, so the row is the alignment term with little left to hide it.

## Size

`.text` of `bin/mruby` per `ci/gcc-clang` build, gcc 13.3.0, empty build directories, `rake` on both sides, master at `64dead36c`:

| build | master | this PR | delta |
|---|---:|---:|---:|
| bintest | 1,383,078 | 1,383,078 | 0 |
| ascii-ctype | 1,367,542 | 1,367,542 | 0 |
| byte-string | 1,344,902 | 1,344,902 | 0 |
| cxx_abi | 1,415,769 | 1,415,769 | 0 |
| no-float | 1,308,846 | 1,308,846 | 0 |
| no-bigint | 1,267,702 | 1,267,702 | 0 |
| full-debug (-O0) | 1,975,494 | 1,975,494 | 0 |

`string.o` is the same size in every build too: `mrb_check_frozen()` is a function, and the call replaces a call of the same shape at each of the four sites the walk is inlined into (`objdump -dr` shows four fewer relocations against `mrb_str_modify_keep_cr` and four more against `mrb_check_frozen`).

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc 13.3.0, all seven builds, empty build directories: full-debug, bintest and cxx_abi 2,863 each, ascii-ctype 2,851, no-bigint 2,817, byte-string 2,779, no-float 2,598, and bintest's 147 command tests; every suite 0 KO, 0 crash, no compiler warning. The new test and the two whose comments changed run in the five UTF-8 builds and skip in `byte-string` and `ascii-ctype`.
- `rake -m test` on the default config (byte strings): 2,619 total, 0 KO, 0 crash
- prek on the commit

## Environment

<details>
<summary>Host, toolchain, and the compile lines</summary>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-30-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X 16-Core Processor |
| gcc | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47.20260726 |
| CRuby | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| valgrind | 3.27.1 |
| base | `64dead36c` |

`string.c` as each `ci/gcc-clang` build compiles it, and as the bench build does (`-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped):

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/string.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# bench (full-core gembox, default flags)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode string case conversion for strings sharing their underlying data.
  * Ensured converting a copied string does not alter the original.
  * Preserved correct behavior when no characters require conversion.
  * Enabled appropriate in-place conversion for larger string literals.
  * Maintained consistent errors when attempting to modify frozen strings.

* **Tests**
  * Added coverage for shared-buffer strings, unchanged conversions, large literals, and frozen receivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->