### PR TITLE
unicase.c: binary-search the folding difference from the range walks

### DIFF
--- a/src/unicase.c
+++ b/src/unicase.c
@@ -175,18 +175,27 @@ mrb_uni_case_map(enum mrb_case_kind kind, uint32_t cp, char *buf)
 
 /* Whether the folding difference holds a run over any of [lo, hi]. A caller
    walking the lowercase runs asks this to know whether the difference has
-   something to say about the span it is about to report whole. */
+   something to say about the span it is about to report whole. Runs ascend
+   and never overlap, so their ends ascend too: the first run whose end
+   reaches lo is the only one that can start before hi, and the search below
+   keeps its start, since the last run it steps h down to is that one. */
 static mrb_bool
 fold_diff_touches(uint32_t lo, uint32_t hi)
 {
   const struct case_table *t = &case_tables[MRB_CASE_KIND_FOLD];
-  for (size_t i = 0; i < t->run_count; i++) {
+  size_t l = 0, h = t->run_count;
+  uint32_t start = UINT32_MAX;  /* past any hi, so no run found means FALSE */
+  while (l < h) {
+    size_t mid = l + (h - l) / 2;
     case_run r;
-    case_run_at(t->runs, i, &r);
-    if (r.start > hi) return FALSE;  /* runs ascend, so nothing later can hit */
-    if (r.start + (r.count - 1) * r.stride >= lo) return TRUE;
+    case_run_at(t->runs, mid, &r);
+    if (r.start + (r.count - 1) * r.stride < lo) l = mid + 1;
+    else {
+      h = mid;
+      start = r.start;
+    }
   }
-  return FALSE;
+  return start <= hi;
 }
 
 uint32_t


### PR DESCRIPTION
## Summary

`fold_diff_touches()` walked the folding difference's runs one at a time although they are sorted and disjoint, and both range walks ask it once per lowercase run. It now binary-searches them the way `case_run_for()` already does over the same packed runs.

## Changes

| File            | What                                                                            |
| --------------- | ------------------------------------------------------------------------------- |
| `src/unicase.c` | `fold_diff_touches()` binary-searches the folding runs instead of scanning them |

### The guard read as an oversight beside `case_run_for()`

The comment on the linear loop named the property that makes a binary search available, that the runs ascend, and then walked them anyway. Two functions above, `case_run_for()` binary-searches the same runs on the same property. Since the runs never overlap, their ends ascend along with their starts, so a lower bound on "end reaches `lo`" lands on the only run that can start before `hi`, and one comparison finishes the answer.

The search keeps the start of the run it settles on rather than unpacking that run a second time. gcc inlines the guard into both `fold_range_of()` and `unfold_range_of()`, so every unpack in it is paid for twice in `.text`; the two-unpack form cost 352 bytes against the 288 below.

## Speed

Ir per iteration is `(Ir(2N) - Ir(N)) / N` under callgrind, on the `bintest` build of `ci/gcc-clang` (`MRB_UTF8_STRING` with `mruby-regexp`), N = 10,000 and 1,000 for the last row.

```ruby
n = ARGV[0].to_i
i = 0
while i < n
  Regexp.new("[\u{80}-\u{FFFF}]", Regexp::IGNORECASE)
  i += 1
end
```

| pattern               |  master | this PR | change |
| --------------------- | ------: | ------: | -----: |
| `[a-z]`               |  13,524 |  13,524 |      0 |
| `\u{C0}`              |  16,346 |  16,346 |      0 |
| `[\u{C0}-\u{C5}]`     |  59,707 |  59,477 |  -0.4% |
| `[\u{13A0}-\u{13F5}]` |  85,290 |  85,124 |  -0.2% |
| `[\u{80}-\u{FFFF}]`   | 308,807 | 229,554 | -25.7% |

The first two rows never reach the guard, so they are the control. The wide class is where the walks ask it most: once per lowercase run overlapping the span, each answered by a scan that stopped only at the first folding run past `hi`.

## Size

`.text` of `bin/mruby` per `ci/gcc-clang` build, base `64dead36c`, empty build directories, `CC=gcc`:

| build              |    master |   this PR | delta |
| ------------------ | --------: | --------: | ----: |
| bintest            | 1,383,078 | 1,383,366 |  +288 |
| ascii-ctype        | 1,367,542 | 1,367,542 |     0 |
| byte-string        | 1,344,902 | 1,344,902 |     0 |
| cxx_abi            | 1,415,769 | 1,416,073 |  +304 |
| no-float           | 1,308,846 | 1,309,134 |  +288 |
| no-bigint          | 1,267,702 | 1,267,990 |  +288 |
| full-debug (`-O0`) | 1,975,494 | 1,975,542 |   +48 |

The whole of it is in `unicase.o`: `fold_range_of()` grows from 982 to 1,068 bytes and `unfold_range_of()` from 965 to 1,174, the inlined search replacing the inlined loop in each. The two builds without the tables (`ascii-ctype`, `byte-string`) do not move.

## Testing

`CC=gcc CXX=g++ LD=gcc MRUBY_CONFIG=ci/gcc-clang rake -m test`: all seven builds pass with KO 0, Crash 0, Warning 0. The default config passes as well. No behaviour changes; the existing `unicode_case.rb` rows are the correctness check.

## Environment

<details>
<summary>Host and compile lines</summary>

|          |                                             |
| -------- | ------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                          |
| Kernel   | Linux 7.0.0-30-generic                      |
| CPU      | AMD Ryzen 9 5950X                           |
| gcc      | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)     |
| binutils | GNU ld 2.47.20260726                        |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) |
| valgrind | 3.27.1                                      |

`src/unicase.c` per build, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved the efficiency of internal case-folding range lookups without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->