### PR TITLE
mruby-io: drop the callback behind `IO#sysread` and `IO#syswrite`

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -18,15 +18,12 @@
 #include <sys/stat.h>
 
 /* A descriptor and the bytes moved through it go through the HAL, so what a
-   platform is asked for here is the width of a size and of a mode, the open
-   flags it names, and the way it reports a child's exit. */
+   platform is asked for here is the open flags it names and the way it
+   reports a child's exit. */
 #if defined(_WIN32)
   #include <winsock.h>    /* getsockopt(), to tell a socket from a descriptor */
   #include <stdlib.h>
   #define WEXITSTATUS(x) (x)
-  typedef int fsize_t;
-  typedef int fmode_t;
-  typedef int fssize_t;
 
   #ifndef O_TMPFILE
     #define O_TMPFILE O_TEMPORARY
@@ -35,9 +32,6 @@
 #else
   #include <sys/wait.h>   /* WEXITSTATUS() */
   #include <unistd.h>
-  typedef size_t fsize_t;
-  typedef mode_t fmode_t;
-  typedef ssize_t fssize_t;
 #endif
 
 #ifdef _MSC_VER
@@ -751,7 +745,7 @@ io_s_sysclose(mrb_state *mrb, mrb_value klass)
 }
 
 static int
-io_cloexec_open(mrb_state *mrb, const char *pathname, int flags, fmode_t mode)
+io_cloexec_open(mrb_state *mrb, const char *pathname, int flags, mrb_int mode)
 {
   int retry = FALSE;
   char *fname = mrb_locale_from_utf8(pathname, -1);
@@ -799,7 +793,7 @@ io_s_sysopen(mrb_state *mrb, mrb_value klass)
 
   const char *pat = RSTRING_CSTR(mrb, path);
   int flags = io_mode_to_flags(mrb, mode);
-  mrb_int fd = io_cloexec_open(mrb, pat, flags, (fmode_t)perm);
+  mrb_int fd = io_cloexec_open(mrb, pat, flags, perm);
   return mrb_fixnum_value(fd);
 }
 
@@ -809,16 +803,18 @@ eof_error(mrb_state *mrb)
   mrb_raise(mrb, E_EOF_ERROR, "end of file reached");
 }
 
+/* The unbuffered readers (#sysread, #pread) hand the descriptor a string of
+   `maxlen` bytes and trim it to what arrived. Sizing the string comes first;
+   a read of nothing is answered here with an empty string and asks the
+   stream for nothing, not even to be open. */
 static mrb_value
-io_read_common(mrb_state *mrb,
-    fssize_t (*readfunc)(mrb_state*, int, void*, fsize_t, off_t),
-    mrb_value io, mrb_value buf, mrb_int maxlen, off_t offset)
+io_sysread_buf(mrb_state *mrb, mrb_value buf, mrb_int maxlen)
 {
   if (maxlen < 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "negative expanding string size");
   }
   else if (maxlen == 0) {
-    return mrb_str_new(mrb, NULL, maxlen);
+    return mrb_str_new(mrb, NULL, 0);
   }
 
   if (mrb_nil_p(buf)) {
@@ -831,27 +827,23 @@ io_read_common(mrb_state *mrb,
   else {
     mrb_str_modify(mrb, RSTRING(buf));
   }
+  return buf;
+}
 
-  struct mrb_io *fptr = io_get_read_fptr(mrb, io);
-  int ret = readfunc(mrb, fptr->fd, RSTRING_PTR(buf), (fsize_t)maxlen, offset);
-  if (ret < 0) {
+static mrb_value
+io_sysread_done(mrb_state *mrb, struct mrb_io *fptr, mrb_value buf, mrb_int n)
+{
+  if (n < 0) {
     mrb_sys_fail(mrb, "sysread failed");
   }
-  if (RSTRING_LEN(buf) != ret) {
-    buf = mrb_str_resize(mrb, buf, ret);
+  if (RSTRING_LEN(buf) != n) {
+    buf = mrb_str_resize(mrb, buf, n);
   }
-  if (ret == 0 && maxlen > 0) {
+  if (n == 0) {
     fptr->eof = 1;
     eof_error(mrb);
   }
   return buf;
-}
-
-static fssize_t
-sysread(mrb_state *mrb, int fd, void *buf, fsize_t nbytes, off_t offset)
-{
-  (void)offset;
-  return (fssize_t)mrb_hal_io_read(mrb, fd, buf, nbytes);
 }
 
 static mrb_value
@@ -862,7 +854,11 @@ io_sysread(mrb_state *mrb, mrb_value io)
 
   mrb_get_args(mrb, "i|S", &maxlen, &buf);
 
-  return io_read_common(mrb, sysread, io, buf, maxlen, 0);
+  buf = io_sysread_buf(mrb, buf, maxlen);
+  if (maxlen == 0) return buf;
+  struct mrb_io *fptr = io_get_read_fptr(mrb, io);
+  mrb_int n = mrb_hal_io_read(mrb, fptr->fd, RSTRING_PTR(buf), (size_t)maxlen);
+  return io_sysread_done(mrb, fptr, buf, n);
 }
 
 static mrb_value
@@ -900,33 +896,18 @@ io_seek(mrb_state *mrb, mrb_value io)
 }
 
 static mrb_value
-io_write_common(mrb_state *mrb,
-    fssize_t (*writefunc)(mrb_state*, int, const void*, fsize_t, off_t),
-    struct mrb_io *fptr, const void *buf, mrb_ssize blen, off_t offset)
-{
-  int fd = io_get_write_fd(fptr);
-  fssize_t length = writefunc(mrb, fd, buf, (fsize_t)blen, offset);
-  if (length == -1) {
-    mrb_sys_fail(mrb, "syswrite");
-  }
-  return mrb_int_value(mrb, (mrb_int)length);
-}
-
-static fssize_t
-syswrite(mrb_state *mrb, int fd, const void *buf, fsize_t nbytes, off_t offset)
-{
-  (void)offset;
-  return (fssize_t)mrb_hal_io_write(mrb, fd, buf, nbytes);
-}
-
-static mrb_value
 io_syswrite(mrb_state *mrb, mrb_value io)
 {
   mrb_value buf;
 
   mrb_get_args(mrb, "S", &buf);
 
-  return io_write_common(mrb, syswrite, io_get_write_fptr(mrb, io), RSTRING_PTR(buf), RSTRING_LEN(buf), 0);
+  int fd = io_get_write_fd(io_get_write_fptr(mrb, io));
+  mrb_int n = mrb_hal_io_write(mrb, fd, RSTRING_PTR(buf), (size_t)RSTRING_LEN(buf));
+  if (n == -1) {
+    mrb_sys_fail(mrb, "syswrite");
+  }
+  return mrb_int_value(mrb, n);
 }
 
   /* def write(string) */
@@ -940,9 +921,9 @@ static mrb_int
 fd_write_buf(mrb_state *mrb, int fd, const char *ptr, mrb_int len)
 {
   if (len == 0) return 0;
-  fssize_t sum = 0;
-  while (sum < (fssize_t)len) {
-    fssize_t n = mrb_hal_io_write(mrb, fd, ptr + sum, (size_t)(len - sum));
+  mrb_int sum = 0;
+  while (sum < len) {
+    mrb_int n = mrb_hal_io_write(mrb, fd, ptr + sum, (size_t)(len - sum));
     if (n == -1) {
       if (errno == EINTR) continue;
       mrb_sys_fail(mrb, "syswrite");
@@ -1774,32 +1755,12 @@ io_sync(mrb_state *mrb, mrb_value io)
 # define io_pread   mrb_notimplement_m
 # define io_pwrite  mrb_notimplement_m
 #else
-static off_t
-value2off(mrb_state *mrb, mrb_value offv)
-{
-  return (off_t)mrb_as_int(mrb, offv);
-}
-
 /* pread/pwrite are POSIX-only positional I/O, compiled only where the
    platform provides pread(2)/pwrite(2) (see MRB_USE_IO_PREAD_PWRITE in
    mruby/io.h). They call the platform functions directly rather than going
    through the IO HAL: the HAL has no positional entry point, and emulating
    them with seek + read/write would be slower and non-atomic for no gain
-   on the only platforms that compile this code. The mrb_state parameter is
-   unused but keeps the readfunc/writefunc callback signature uniform. */
-static fssize_t
-sys_pread(mrb_state *mrb, int fd, void *buf, fsize_t nbytes, off_t offset)
-{
-  (void)mrb;
-  return (fssize_t)pread(fd, buf, nbytes, offset);
-}
-
-static fssize_t
-sys_pwrite(mrb_state *mrb, int fd, const void *buf, fsize_t nbytes, off_t offset)
-{
-  (void)mrb;
-  return (fssize_t)pwrite(fd, buf, nbytes, offset);
-}
+   on the only platforms that compile this code. */
 
 /*
  * call-seq:
@@ -1814,7 +1775,12 @@ io_pread(mrb_state *mrb, mrb_value io)
 
   mrb_get_args(mrb, "io|S!", &maxlen, &off, &buf);
 
-  return io_read_common(mrb, sys_pread, io, buf, maxlen, value2off(mrb, off));
+  off_t offset = (off_t)mrb_as_int(mrb, off);
+  buf = io_sysread_buf(mrb, buf, maxlen);
+  if (maxlen == 0) return buf;
+  struct mrb_io *fptr = io_get_read_fptr(mrb, io);
+  mrb_int n = (mrb_int)pread(fptr->fd, RSTRING_PTR(buf), (size_t)maxlen, offset);
+  return io_sysread_done(mrb, fptr, buf, n);
 }
 
 /*
@@ -1828,7 +1794,13 @@ io_pwrite(mrb_state *mrb, mrb_value io)
 
   mrb_get_args(mrb, "So", &buf, &off);
 
-  return io_write_common(mrb, sys_pwrite, io_get_write_fptr(mrb, io), RSTRING_PTR(buf), RSTRING_LEN(buf), value2off(mrb, off));
+  off_t offset = (off_t)mrb_as_int(mrb, off);
+  int fd = io_get_write_fd(io_get_write_fptr(mrb, io));
+  mrb_int n = (mrb_int)pwrite(fd, RSTRING_PTR(buf), (size_t)RSTRING_LEN(buf), offset);
+  if (n == -1) {
+    mrb_sys_fail(mrb, "syswrite");
+  }
+  return mrb_int_value(mrb, n);
 }
 #endif /* MRB_USE_IO_PREAD_PWRITE */
 


### PR DESCRIPTION
## Summary

`IO#sysread` and `IO#pread` shared one body and `IO#syswrite` and `IO#pwrite` another, each reached through a function pointer that stood for the descriptor call. Every adapter behind the pointer discarded an argument, and three typedefs existed on both platforms to spell its type. The four methods now make their own call; what they share, the sizing of the string before a read and the trim after it, stays as two helpers.

## Changes

| File                | What                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mruby-io/src/io.c` | `io_read_common()` becomes `io_sysread_buf()` and `io_sysread_done()`, called around the read that `io_sysread()` and `io_pread()` each make themselves; `io_write_common()`, the `sysread()`, `syswrite()`, `sys_pread()` and `sys_pwrite()` adapters and `value2off()` are deleted; the `fsize_t`, `fssize_t` and `fmode_t` typedefs go, `fd_write_buf()` counting in `mrb_int` and `io_cloexec_open()` taking the mode as the `mrb_int` the HAL takes |

### What the pointer cost

`io_read_common()` took a `readfunc` of five parameters so that one body could call `mrb_hal_io_read()` for `sysread` and pread(2) for `pread`. `sysread()` and `syswrite()` accepted an offset they had nowhere to pass; `sys_pread()` and `sys_pwrite()` accepted an `mrb_state` they had no use for, and a comment said the parameter was there to keep the signature uniform. `fsize_t`, `fssize_t` and `fmode_t` were defined once for Windows and once for POSIX so that the pointer's type could be written, and little else read them: `fd_write_buf()` counted in `fssize_t` bytes the HAL returns as `mrb_int`, and `io_cloexec_open()` cast a mode to `fmode_t` on its way to a HAL function that takes `mrb_int`.

What the two readers share is real: the string is sized to `maxlen` before the read and trimmed to what arrived after it, with an empty read reported as `EOFError`. That is now `io_sysread_buf()` and `io_sysread_done()`, and the read between them is written out in each method. A read of nothing is answered by the sizing helper with an empty string before the stream is looked at, which is what the shared body did. The writers shared three lines, and each now has them.

## Behaviour

Nothing observable changes on a stream. `IO#pwrite` converts the offset before it checks that the stream is open for writing, where the old code passed both as arguments to the shared body and left the order to the compiler; `IO#pread` already converted first.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory at the same path with `rake`; base is master 2f26baa96.

| build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,383,286 | 1,383,350 |   +64 |
| ascii-ctype      | 1,367,750 | 1,367,814 |   +64 |
| byte-string      | 1,345,110 | 1,345,174 |   +64 |
| cxx_abi          | 1,416,009 | 1,416,057 |   +48 |
| no-float         | 1,309,214 | 1,309,278 |   +64 |
| no-bigint        | 1,267,926 | 1,267,990 |   +64 |
| full-debug (-O0) | 1,975,494 | 1,975,382 |  -112 |

All of it is `io.o`. At `-O3` gcc had already inlined the shared bodies and the adapters into the four methods, so no call disappears: in `bintest`, `io_sysread` and `io_pread` each grow by 48 bytes, the same calls with the test on `maxlen` made twice and the byte count compared as `mrb_int` where it was an `int`, and `io_syswrite` and `io_pwrite` shrink by 14 and 22. At `-O0` the deleted functions are the whole of the difference.

## Testing

- host (`build_config/default.rb`, gcc): mrbtest 2,622 (OK 2,554 / Skip 68) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/host-debug.rb` with clang 23.1.0: mrbtest 2,865 (OK 2,853 / Skip 12) / bintest 147 (OK 146 / Skip 1), KO 0 / Crash 0, no warning from `io.c`
- `build_config/ci/gcc-clang.rb`, seven builds (`full-debug` under `MRB_GC_STRESS`), gcc: mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1)
- `build_config/cross-mingw-winetest.rb` under wine: mrbtest 2,847 (OK 2,800 / Skip 47) / bintest 100 (OK 92 / Skip 8), KO 0 / Crash 0; `IO#pread` and `IO#pwrite` skip there, so what the Windows build checks is that `io.c` compiles without the typedefs
- the `IO#pread` and `IO#pwrite` tests in `mruby-io/test/io.rb` run in every Linux build above
- `prek run` on the commit

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Ubuntu 24.04.4, Linux 7.0.0-30-generic x86_64      |
| CPU        | AMD Ryzen 9 5950X                                  |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| clang      | Homebrew clang 23.1.0                              |
| binutils   | GNU ld 2.47.20260726                               |
| mingw      | x86_64-w64-mingw32-gcc (GCC) 13-win32, wine-11.0   |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-io/src/io.c` from `rake --verbose` in each build, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_REGEXP_PARSE_DEPTH_LIMIT=512 -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal file and stream I/O handling across supported platforms.
  - Improved consistency in low-level read and write operations, including positioned I/O.
  - Simplified internal buffer and result handling for system-level operations.
  - No changes were made to exported interfaces or user-facing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->