### PR TITLE
build: print the size.json of each build with `rake size`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,8 @@ jobs:
         run: rake defines
       - name: Build
         run: rake -m test:build
+      - name: Size
+        run: rake size
       - name: Test
         run: rake test:run
 
@@ -108,6 +110,9 @@ jobs:
       - name: Build
         run: |
           COSMO_ROOT=~/cosmo rake -m test:build MRUBY_CONFIG=cosmopolitan
+      - name: Size
+        run: |
+          COSMO_ROOT=~/cosmo rake size MRUBY_CONFIG=cosmopolitan
       - name: Test
         run: |
           COSMO_ROOT=~/cosmo rake test:run MRUBY_CONFIG=cosmopolitan
@@ -135,6 +140,11 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           rake -m test:build
+      - name: Size
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          rake size
       - name: Test
         shell: cmd
         run: |

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -64,7 +64,9 @@ Every target also leaves a `size.json` in its build directory: the byte
 counts of `libmruby.a` and the executables, text, data and bss sections and
 all, each with the object files it is made of, so that two builds can be
 subtracted down to the object that grew. The file names the commit it was
-built from, and `rake size.json` is the build asked for by that name. The
+built from, and `rake size.json` is the build asked for by that name;
+`rake size` builds and then prints the file's artifacts as a table, one
+per target, as CI does after each build. The
 `size` program is found by the C compiler's prefix, or named with
 `conf.size = "arm-none-eabi-size"`; a build whose objects none can read
 keeps its file sizes and carries `null` sections.

--- a/lib/mruby/size_report.rb
+++ b/lib/mruby/size_report.rb
@@ -41,6 +41,19 @@ module MRuby
       end
     end
 
+    # Print the report of every build that has one, a table per build, the
+    # way a CI log is read: each artifact with its file size and sections.
+    # The objects stay in the file; three hundred rows a build are what a
+    # diff subtracts, not what a person scans.
+    def self.print
+      MRuby.targets.each_value do |build|
+        next if build.internal?
+
+        report = new(build)
+        report.print if File.exist?(report.path)
+      end
+    end
+
     # The commit the source tree sits at, or nil where neither the
     # repository nor the archive the tree was unpacked from could say.
     def self.commit
@@ -132,6 +145,33 @@ module MRuby
       _pp "GEN", path.relative_path
     rescue SystemCallError => e
       warn "#{path.relative_path} not written: #{e.message}"
+    end
+
+    # The columns of an entry, in the order the file holds them.
+    COLUMNS = %w[file_size text data bss].freeze
+
+    # The table of the file as written, not of a fresh measurement: what is
+    # printed is what a later build subtracts from.
+    def print
+      data = JSON.parse(File.read(path))
+      rows = data["artifacts"].map do |name, entry|
+        [name, *COLUMNS.map { |column| entry[column] ? entry[column].to_s : "-" }]
+      end
+      return if rows.empty?
+
+      head = "Size of '#{data['target']}'"
+      head << " at #{data['commit'][0, 10]}" if data["commit"]
+      head << " (dirty)" if data["dirty"]
+      puts "#{head}:"
+      table = [["", *COLUMNS], *rows]
+      widths = table.transpose.map { |column| column.map(&:size).max }
+      table.each do |row|
+        cells = row.each_with_index.map do |cell, i|
+          i.zero? ? cell.ljust(widths[i]) : cell.rjust(widths[i])
+        end
+        puts "  #{cells.join('  ')}".rstrip
+      end
+      puts
     end
 
     def report

--- a/tasks/size.rake
+++ b/tasks/size.rake
@@ -12,4 +12,11 @@ end
 desc "build, and write the size.json of each build"
 task "size.json" => :all
 
-task :size => "size.json"
+# Asking for the size is asking for the report, printed: what CI shows after
+# each build, and what a checkout answers with about the last build it made.
+# `:build` rather than `:all`, so that a build already made answers with the
+# tables alone and not the build summary over again.
+desc "build, and print the size.json of each build"
+task :size => :build do
+  MRuby::SizeReport.print
+end


### PR DESCRIPTION
## Summary

Every build writes a `size.json` (#7450), a file for a later build to subtract from, and reading one by eye means opening it and picking the totals out from among a few hundred objects. `rake size` now builds and then prints each build's artifacts as a table, and each CI job runs it between its build and test steps, so the sizes of every build stand in the log of a run.

## Changes

| File                          | What                                                                          |
| ----------------------------- | ----------------------------------------------------------------------------- |
| `lib/mruby/size_report.rb`    | `SizeReport.print` and `SizeReport#print`: the table of a written `size.json` |
| `tasks/size.rake`             | `rake size` builds and prints; it depends on `:build` rather than `:all`      |
| `.github/workflows/build.yml` | a `Size` step after `Build` in each of the three jobs                         |
| `doc/guides/compile.md`       | one sentence on `rake size`                                                   |

### What the table shows

One table per target: each artifact of the file with its `file_size`, `text`, `data` and `bss`, under the target's name and the first ten characters of the commit the tree was built from, marked `(dirty)` where the tree differed from it. The columns carry the names the file uses, so a row reads back into the JSON without a key. A section the build could not measure, one whose objects no `size` program could read, prints as `-`. The objects stay in the file: three hundred rows a build are what a diff subtracts, not what a person scans.

The table is of the file as written rather than of a fresh measurement, so what is printed is what a later build subtracts from.

### `rake size` depends on `:build`

`rake size` was an alias of `rake size.json`, which depends on `:all`. `:all` prints the build summary and writes the lockfile after building, so a `rake size` run after a build would repeat the summary above the tables. The task now depends on `:build`, whose action already writes the file (`tasks/size.rake`), so a tree already built answers with the tables alone. `rake size.json` is unchanged.

### The CI step

Each job runs `rake size` between `Build` and `Test`, so the tables are in the log whether or not the tests pass. On a tree the `Build` step has just made, the step is a no-op build followed by the print, under a second on the machine below.

## Behaviour

`rake size` on a built default configuration:

```console
$ rake size
GEN   build/host/compile_commands.json -> 198 entries
GEN   compile_commands.json -> from 'host'
GEN   build/host/size.json
Size of 'host' at 2f26baa965 (dirty):
                   file_size     text    data  bss
  lib/libmruby.a    18627508  1692399  114240   13
  bin/mirb          10916056  1875585  117864   96
  bin/mrbc           3189320   597443   10340   64
  bin/mrdb          10895856  1860915  117952   96
  bin/mruby         10728792  1836279  116936   72
  bin/mruby-strip   10734528  1841044  116808   64
```

A build whose `size` program could not be run keeps its file sizes and prints `-` for the sections, here a configuration with `conf.size = "no-such-size"`:

```console
size.json of 'sizenull': no-such-size could not be run, so no section sizes are measured
GEN   build/sizenull/size.json
Size of 'sizenull' at 2f26baa965 (dirty):
                  file_size  text  data  bss
  lib/libmruby.a    8778110     -     -    -
  bin/mrbc          3188048     -     -    -
```

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test:build`, then `rake size`, the two CI steps in order: one table for each of the seven targets, no build summary between them. `rake test:run` after that: eight suites (the seven targets and bintest), KO 0 and Crash 0 in each.
- `rake -m all` of the default configuration, then `rake size` twice: the second run rebuilds nothing and prints the same table.
- A scratch configuration with `conf.size = "no-such-size"` prints `-` for every section.
- `prek run` on the changed files and `prettier --check` on the Markdown and the workflow pass.
- The fork's Actions run of this branch, the eleven jobs finished at submission green with the `Size` step in each log, the two mingw jobs still running: https://github.com/takumin/mruby/actions/runs/33794879267 . The Windows-VC job measures its sections too, through a `size` program its runner carries.

## Environment

<details>

- Linux x86_64 (kernel 7.0.0)
- Homebrew clang 23.1.0 (`CC=clang`), llvm-size 23.1.0
- ruby 4.0.6, rake 13.3.1

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a size-reporting step to GCC/Clang, Cosmopolitan, and Windows builds in CI.
  * Added tabular size reports showing artifact and section sizes, target commits, and build status.
  * Updated `rake size` to build targets and print size reports.

* **Documentation**
  * Clarified that `rake size.json` builds the recorded target, while `rake size` builds and displays per-target size tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->