### PR TITLE
mruby-bigint: read `INT64_MIN` back out of a Bignum

### DIFF
--- a/mrbgems/mruby-bigint/core/bigint.c
+++ b/mrbgems/mruby-bigint/core/bigint.c
@@ -5552,8 +5552,15 @@ mrb_bint_as_int64(mrb_state *mrb, mrb_value x)
     u |= m.p[i];
     if (i==0) break;
   }
+  if (m.sn < 0) {
+    /* The negative range reaches one further than the positive one, so the
+       magnitude is compared against |INT64_MIN| here.  That boundary is
+       returned as the constant because negating it as an int64_t overflows. */
+    if (u > (uint64_t)INT64_MAX + 1) goto out_of_range;
+    if (u == (uint64_t)INT64_MAX + 1) return INT64_MIN;
+    return -(int64_t)u;
+  }
   if (u > INT64_MAX) goto out_of_range;
-  if (m.sn < 0) return -(int64_t)u;
   return (int64_t)u;
 }
 #endif

--- a/mrbgems/mruby-bigint/test/bigint.c
+++ b/mrbgems/mruby-bigint/test/bigint.c
@@ -1,0 +1,46 @@
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/internal.h>
+
+/* BigintTest.int64_roundtrip(integer) -> Integer
+ *
+ * Sends an Integer through the int64_t conversion a C extension uses to read
+ * one, then builds an Integer back from the result.  A value the conversion
+ * carries intact therefore comes back equal to itself, and one it refuses
+ * raises RangeError instead.  Whether the argument arrives as a Bignum
+ * depends on the width of mrb_int, so both representations are accepted.
+ */
+static mrb_value
+test_int64_roundtrip(mrb_state *mrb, mrb_value self)
+{
+  mrb_value v;
+  int64_t n;
+
+  mrb_get_args(mrb, "o", &v);
+  if (mrb_integer_p(v)) {
+    n = (int64_t)mrb_integer(v);
+  }
+  else if (mrb_bigint_p(v)) {
+    n = mrb_bint_as_int64(mrb, v);
+  }
+  else {
+    mrb_raisef(mrb, E_TYPE_ERROR, "%Y is not an Integer", v);
+    return mrb_nil_value();
+  }
+
+#ifdef MRB_INT32
+  if (n < MRB_INT_MIN || n > MRB_INT_MAX) {
+    return mrb_bint_new_int64(mrb, n);
+  }
+#endif
+  return mrb_int_value(mrb, (mrb_int)n);
+}
+
+void
+mrb_mruby_bigint_gem_test(mrb_state *mrb)
+{
+  struct RClass *test = mrb_define_module(mrb, "BigintTest");
+
+  mrb_define_module_function(mrb, test, "int64_roundtrip", test_int64_roundtrip,
+                             MRB_ARGS_REQ(1));
+}

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -527,3 +527,21 @@ assert('Bigint Integer#round breaks a tie away from zero') do
   assert_equal(-10000000000000000000000010, (-big - 5).round(-1))
   assert_equal(-big, (-big - 4).round(-1))
 end
+
+assert('Bigint int64 conversion covers the whole signed 64-bit range') do
+  int64_min = -9223372036854775808
+  int64_max = 9223372036854775807
+
+  assert_equal 0, BigintTest.int64_roundtrip(0)
+  assert_equal(-1, BigintTest.int64_roundtrip(-1))
+  assert_equal int64_max, BigintTest.int64_roundtrip(int64_max)
+  assert_equal int64_min + 1, BigintTest.int64_roundtrip(int64_min + 1)
+  assert_equal int64_min, BigintTest.int64_roundtrip(int64_min)
+end
+
+assert('Bigint int64 conversion refuses what int64_t cannot hold') do
+  assert_raise(RangeError) { BigintTest.int64_roundtrip(9223372036854775808) }
+  assert_raise(RangeError) { BigintTest.int64_roundtrip(-9223372036854775809) }
+  assert_raise(RangeError) { BigintTest.int64_roundtrip(10 ** 25) }
+  assert_raise(RangeError) { BigintTest.int64_roundtrip(-(10 ** 25)) }
+end


### PR DESCRIPTION
## Summary

Under `MRB_INT32`, `mrb_bint_as_int64()` refused `INT64_MIN`, the one negative value `int64_t` holds whose magnitude is above `INT64_MAX`, while `mrb_bint_new_int64()` carried that same value in. The sign now picks the bound the magnitude is compared against, and the boundary comes back as `INT64_MIN` rather than negated.

## Changes

| File                                  | What                                                                                        |
| ------------------------------------- | ------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-bigint/core/bigint.c`  | `mrb_bint_as_int64()`: compare the magnitude against the bound of the sign it carries       |
| `mrbgems/mruby-bigint/test/bigint.c`  | new: `BigintTest.int64_roundtrip`, an Integer through `mrb_bint_as_int64()` and back        |
| `mrbgems/mruby-bigint/test/bigint.rb` | two assertions: both ends of the `int64_t` range come back, the values just past them raise |

### The magnitude was compared before the sign

The conversion gathers the magnitude into a `uint64_t` and compared it against `INT64_MAX` before looking at the sign:

```c
  if (u > INT64_MAX) goto out_of_range;
  if (m.sn < 0) return -(int64_t)u;
  return (int64_t)u;
```

`INT64_MIN` has magnitude `INT64_MAX + 1`, so the one negative value that `int64_t` still holds was refused with `RangeError`. The line after was not sound at that value either: converting `2^63` to `int64_t` is implementation-defined, and negating what gcc makes of it overflows.

A negative magnitude is now compared against `|INT64_MIN|`, and the boundary is returned as the constant, since `-(int64_t)u` cannot express it. The positive side is unchanged.

`MRB_INT64` builds are unaffected: there `mrb_bint_as_int64` is a macro for `mrb_bint_as_int` (`include/mruby/internal.h`) and `INT64_MIN` fits `mrb_int`.

### Who reaches it

In-tree the conversion has one caller, `Time.at` on a build whose `time_t` is wider than `mrb_int` (`mrbgems/mruby-time/src/time.c`), and there `gmtime_r` refuses the value a step later, so what changes from Ruby is the message (below). It matters for an extension keeping a signed 64-bit identifier in an Integer: an id built with `mrb_bint_new_int64()` could be stored and not read back.

### The test is in C

Since `Time.at` refuses the value either way, the round trip is tested through the C API an extension would use. The gem gains a test C file, as mruby-array-ext, mruby-fiber and mruby-io have: `BigintTest.int64_roundtrip` sends an Integer through `mrb_bint_as_int64()` and builds one back from the result, so a value the conversion carries comes back equal to itself, and one it refuses raises `RangeError`. Whether the argument arrives as a Bignum depends on the width of `mrb_int`, so the function takes both representations; under `MRB_INT64` the assertions go through the macro and pass on master.

## Behaviour

A 32-bit `mrb_int` with a 64-bit `time_t` (i686 glibc with `_TIME_BITS=64`) is the one place Ruby code reaches the conversion, and there `Time.at` refuses `INT64_MIN` either way. What changes is which check says so:

```console
$ bin/mruby -e 'Time.at(-9223372036854775808)'    # master
-e:1:in at: integer out of range (RangeError)
$ bin/mruby -e 'Time.at(-9223372036854775808)'    # this PR
-e:1:in at: 0 out of Time range (RangeError)
```

The `0` in the second message is mruby-time's own: `fixable_time_t_p()` casts the `time_t` to `mrb_int` before comparing it with `MRB_INT_MIN`, so the value it reports back is truncated. Master shows the same for a value the conversion already carried, `Time.at(-9223372036854775807)` says `1 out of Time range`. That is a separate matter in `mruby-time/src/time.c`, left alone here.

## Size

`.text` of `bin/mruby` for the seven builds of `build_config/ci/gcc-clang.rb` (gcc 13.3, x86-64) and an i686 full-core build (`i686-linux-gnu-gcc` 13.3, where `mrb_int` is 32 bits), master at `50514b23f` against this PR:

| Build                | master    | this PR   | delta |
| -------------------- | --------- | --------- | ----- |
| `bintest`            | 1,383,222 | 1,383,222 | 0     |
| `ascii-ctype`        | 1,367,590 | 1,367,590 | 0     |
| `byte-string`        | 1,345,142 | 1,345,142 | 0     |
| `cxx_abi`            | 1,416,825 | 1,416,825 | 0     |
| `no-float`           | 1,309,150 | 1,309,150 | 0     |
| `no-bigint`          | 1,267,862 | 1,267,862 | 0     |
| `full-debug` (`-O0`) | 1,974,982 | 1,974,982 | 0     |
| i686 full-core       | 1,448,776 | 1,448,856 | +80   |

The changed function is compiled only under `MRB_INT32`, so the x86-64 builds are byte-identical; the +80 is `mrb_bint_as_int64()` in `bigint.o`. The new test file goes into `mrbtest`, not `bin/mruby`.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc: eight suites (the seven builds and bintest), KO 0 and Crash 0 in each. Under `MRB_INT64` the new assertions go through the macro, so this checks that they hold where nothing changed.
- `rake -m test` on three i686 builds, where `mrb_int` is 32 bits and the changed function is compiled: full-core (`Total: 2869`, KO 0), full-core with `MRB_NO_MPZ64BIT` (16-bit limbs, `Total: 2869`, KO 0), and full-core with `_TIME_BITS=64` (`Total: 2869`, KO 0), the build the Behaviour section runs on.
- The test is red without the fix: master's `bigint.c` under this PR's tests on i686 fails `Bigint int64 conversion covers the whole signed 64-bit range` with `integer out of range` (Crash 1, the exception leaving the assertion block).
- `prek run` on the changed files passes.

## Environment

<details>

|             |                                                                        |
| ----------- | ---------------------------------------------------------------------- |
| OS          | Ubuntu 24.04.4, Linux 7.0.0 x86_64                                     |
| CPU         | AMD Ryzen 9 5950X                                                      |
| C compiler  | gcc 13.3.0 (`CC=gcc`); `i686-linux-gnu-gcc` 13.3.0 for the i686 builds |
| binutils    | 2.47 (`size`), 2.42 (`i686-linux-gnu-ld`)                              |
| ruby / rake | 4.0.6 / 13.3.1                                                         |

Compile lines of `bigint.c` per build (`-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` dropped):

```console
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
i686         i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_BIGINT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`no-bigint` has no `bigint.c` to compile. The i686 `_TIME_BITS=64` build adds `-D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64`, the `MRB_NO_MPZ64BIT` one `-DMRB_NO_MPZ64BIT`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected conversion of negative big integers at the minimum signed 64-bit value, preventing overflow and preserving the expected result.

- **Tests**
  - Added coverage for signed 64-bit integer round-trip conversions, including boundary values.
  - Added validation that values outside the supported 64-bit range raise an appropriate error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->