### PR TITLE
mruby-time: compare a `time_t` with `MRB_INT_MIN` before narrowing it

### DIFF
--- a/mrbgems/mruby-time/src/time.c
+++ b/mrbgems/mruby-time/src/time.c
@@ -267,7 +267,7 @@ fixable_time_t_p(time_t v)
   if (MRB_INT_MIN <= MRB_TIME_MIN && MRB_TIME_MAX <= MRB_INT_MAX) return TRUE;
   if (v > (time_t)MRB_INT_MAX) return FALSE;
   if (MRB_TIME_T_UINT) return TRUE;
-  if (MRB_INT_MIN > (mrb_int)v) return FALSE;
+  if (v < (time_t)MRB_INT_MIN) return FALSE;
   return TRUE;
 }
 

--- a/mrbgems/mruby-time/test/time.rb
+++ b/mrbgems/mruby-time/test/time.rb
@@ -203,6 +203,20 @@ assert('Time#to_i', '15.2.19.7.25') do
   assert_operator(2, :eql?, Time.at(2).to_i)
 end
 
+assert('Time#to_i wider than mrb_int') do
+  skip unless Object.const_defined?(:Float)
+  # -20 * 2**32 has zero low 32 bits, so a time_t truncated to a 32-bit
+  # mrb_int reads back as 0
+  sec = -4294967296.0 * 20
+  t = begin
+    Time.at(sec)
+  rescue RangeError
+    skip "time_t is not wider than 32 bits"
+  end
+  assert_equal(-753, t.utc.year)
+  assert_equal(sec, t.to_i.to_f)
+end
+
 assert('Time#usec', '15.2.19.7.26') do
   assert_equal(0, Time.at(1300000000).usec)
   skip unless Object.const_defined?(:Float)


### PR DESCRIPTION
## Summary

`fixable_time_t_p()` in mruby-time checked its lower bound as `MRB_INT_MIN > (mrb_int)v`, narrowing the `time_t` before comparing it. Where `time_t` is wider than `mrb_int`, a negative second count whose low 32 bits happen to fit passed as fixable, and `Time#to_i` answered with those low bits. The bound is now compared in `time_t`, as the upper one already was.

## Changes

| File                              | What                                                                                                    |
| --------------------------------- | ------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-time/src/time.c`   | `fixable_time_t_p()`: compare `v` with `(time_t)MRB_INT_MIN` instead of `(mrb_int)v` with `MRB_INT_MIN` |
| `mrbgems/mruby-time/test/time.rb` | new: `Time#to_i wider than mrb_int`, a `time_t` whose low 32 bits are zero comes back whole             |

### The lower bound was checked after narrowing

The function decides whether a `time_t` fits an `mrb_int`, so that `time_value_from_time_t()` can hand back a plain Integer instead of a Bignum or Float:

```c
  if (MRB_INT_MIN <= MRB_TIME_MIN && MRB_TIME_MAX <= MRB_INT_MAX) return TRUE;
  if (v > (time_t)MRB_INT_MAX) return FALSE;
  if (MRB_TIME_T_UINT) return TRUE;
  if (MRB_INT_MIN > (mrb_int)v) return FALSE;
  return TRUE;
```

The second line compares in `time_t`. The fourth casts `v` to `mrb_int` first, which on a 64-bit `time_t` with a 32-bit `mrb_int` keeps the low 32 bits, and then asks whether what is left is below `MRB_INT_MIN`. For `-20 * 2^32` the low bits are zero, so the answer was "fits" and the Integer returned was `0`. Every negative value below `INT32_MIN` whose low 32 bits read as a value at or above `INT32_MIN` went the same way.

The fourth line now reads `v < (time_t)MRB_INT_MIN`. The third line still keeps an unsigned `time_t` away from that cast, since `(time_t)MRB_INT_MIN` would be a large positive value there.

### Where it is reached

The first line makes the function constant `TRUE` wherever `mrb_int` covers `time_t`, so 64-bit `mrb_int` builds compile none of this and are byte-identical (Size below). The change applies to a `time_t` wider than `mrb_int`: `MRB_INT32` on a 64-bit host, or i686 glibc with `_TIME_BITS=64`.

### The test

`Time#to_i wider than mrb_int` builds a Time from `-4294967296.0 * 20` (a Float, so the literal parses under `MRB_INT32` without mruby-bigint), checks that the year came out as -753, and that `to_i` round-trips the value. The `Time.at` raises `RangeError` where `time_t` is 32 bits, and the test skips there. The assertion holds on master under `MRB_INT64`, and fails on master under `MRB_INT32` with a 64-bit `time_t`, where `to_i` gives `0`.

## Behaviour

On a build whose `time_t` is wider than `mrb_int` (`MRB_INT32` with mruby-bigint on x86-64 here):

```console
$ bin/mruby -e 't = Time.at(-4294967296.0 * 20); p t.utc.year, t.to_i'    # master
-753
0
$ bin/mruby -e 't = Time.at(-4294967296.0 * 20); p t.utc.year, t.to_i'    # this PR
-753
-85899345920
```

CRuby gives `-85899345920`. Without mruby-bigint the second value comes back as the Float `-85899345920.0`, which is what `time_value_from_time_t()` does for any `time_t` outside `mrb_int` on such a build.

The same narrowing put a truncated number into the `RangeError` raised when `gmtime_r` refuses a value:

```console
$ bin/mruby -e 'Time.at(-9223372036854775807)'    # master
-e:1:in at: 1 out of Time range (RangeError)
$ bin/mruby -e 'Time.at(-9223372036854775807)'    # this PR
-e:1:in at: -9223372036854775807 out of Time range (RangeError)
```

Positive values were already right: the upper bound compares in `time_t`, so `Time.at(4294967296.0 * 3 + 5).to_i` gave `12884901893` on master too.

## Size

`.text` of `bin/mruby` for the seven builds of `build_config/ci/gcc-clang.rb` (gcc 13.3, x86-64), two x86-64 full-core builds with `MRB_INT32` (with and without mruby-bigint), and an i686 full-core build with `_TIME_BITS=64` (`i686-linux-gnu-gcc` 13.3), master at `50514b23f` against this PR:

| Build                         | master    | this PR   | delta |
| ----------------------------- | --------- | --------- | ----- |
| `bintest`                     | 1,383,222 | 1,383,222 | 0     |
| `ascii-ctype`                 | 1,367,590 | 1,367,590 | 0     |
| `byte-string`                 | 1,345,142 | 1,345,142 | 0     |
| `cxx_abi`                     | 1,416,825 | 1,416,825 | 0     |
| `no-float`                    | 1,309,150 | 1,309,150 | 0     |
| `no-bigint`                   | 1,267,862 | 1,267,862 | 0     |
| `full-debug` (`-O0`)          | 1,974,982 | 1,974,982 | 0     |
| x86-64 `MRB_INT32`            | 1,378,806 | 1,378,822 | +16   |
| x86-64 `MRB_INT32`, no bigint | 1,263,286 | 1,263,302 | +16   |
| i686 `_TIME_BITS=64`          | 1,450,904 | 1,450,792 | -112  |

The seven CI builds have a 64-bit `mrb_int`, where the function folds to `TRUE`. On the three builds that compile the comparison, the whole delta is `time.o` (`+16`, `+16`, `-112`).

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test` with gcc: eight suites (the seven builds and bintest), KO 0 and Crash 0 in each. The new test runs and passes there through the `MRB_INT64` path.
- `rake -m test` on the three builds that compile the comparison: x86-64 `MRB_INT32` with mruby-bigint (`Total: 2868`, KO 0), x86-64 `MRB_INT32` without it (`Total: 2819`, KO 0), i686 `_TIME_BITS=64` (`Total: 2868`, KO 0).
- The test is red without the fix: master's `time.c` under this PR's test fails `Time#to_i wider than mrb_int` on all three builds that compile the comparison (KO 1 each).
- `prek run` on the changed files passes.

## Environment

<details>

|             |                                                                       |
| ----------- | --------------------------------------------------------------------- |
| OS          | Ubuntu 24.04.4, Linux 7.0.0 x86_64                                    |
| CPU         | AMD Ryzen 9 5950X                                                     |
| C compiler  | gcc 13.3.0 (`CC=gcc`); `i686-linux-gnu-gcc` 13.3.0 for the i686 build |
| binutils    | 2.47 (`size`), 2.42 (`i686-linux-gnu-ld`)                             |
| ruby / rake | 4.0.6 / 13.3.1                                                        |

Compile lines of `time.c` per build (`-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` dropped):

```console
full-debug     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest        gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi        gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float       gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
MRB_INT32      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -w -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_INT32 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
MRB_INT32, no bigint  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -w -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_INT32 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
i686           i686-linux-gnu-gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -D_TIME_BITS=64 -D_FILE_OFFSET_BITS=64 -DMRBGEM_MRUBY_TIME_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The `-w` on the two `MRB_INT32` builds comes from the scratch config that adds the define to `full-core`; it affects diagnostics only.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of dates and times with very large negative timestamps, preventing incorrect results on platforms where timestamp values exceed the standard integer range.
  * Ensured conversions to integer timestamps preserve their original values accurately.

* **Tests**
  * Added coverage for wide-range negative timestamps and verified resulting dates and timestamp conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->