### PR TITLE
mruby-process: build a reaped status without re-entering the VM

### DIFF
--- a/mrbgems/mruby-process/src/status.c
+++ b/mrbgems/mruby-process/src/status.c
@@ -13,8 +13,9 @@
 ** it builds when this gem happens to be present, and that has to keep
 ** working without either gem depending on the other.  `Process::Status.new`
 ** is undefined here as it is in CRuby, so the seam is not a constructor but
-** the allocate-and-#initialize pair `mrb_obj_new()` performs, which is also
-** how Process.waitpid builds the status it publishes.
+** the allocate-and-#initialize pair `mrb_obj_new()` performs.  This gem
+** reaches the same two integers without that call; see
+** mrb_process_status_new() at the end of this file.
 */
 
 #include <mruby.h>
@@ -69,26 +70,14 @@ status_flag(mrb_state *mrb, mrb_value self, unsigned int flag)
 }
 
 /*
- * Wraps a platform wait status for the process +pid+.  +raw_status+ is the
- * value the platform reported the process with, as Process.waitpid passes
- * on and as Process::Status#to_i gives back.
+ * Write the two integers a status is made of.
  *
- * Reached by allocating an instance and initializing it rather than through
- * `new`, which this class does not have.  Private, as mruby makes every
- * #initialize.
- *
- * A Process::Status is frozen once built, as CRuby freezes the one it leaves
- * in <code>$?</code>.  What a process did is over by the time there is a
- * status for it, and every question a status answers is read back from the
- * two integers set here.  An instance of a subclass is left unfrozen, since
- * whatever else it is made of is set after this returns.
+ * Both the #initialize below and the constructor at the end of this file
+ * write through here, so a status reads the same whichever built it.
  */
-static mrb_value
-status_initialize(mrb_state *mrb, mrb_value self)
+static void
+status_set(mrb_state *mrb, mrb_value self, mrb_int pid, mrb_int raw_status)
 {
-  mrb_int pid, raw_status;
-
-  mrb_get_args(mrb, "ii", &pid, &raw_status);
   /* A port reads a raw status as the `int` the platform reported, so a value
      that does not fit one would be answered about from bits nobody wrote:
      #to_i would give back what was passed in while #exited? and the rest
@@ -111,6 +100,30 @@ status_initialize(mrb_state *mrb, mrb_value self)
   if (mrb_obj_class(mrb, self) == status_class(mrb)) {
     mrb_obj_freeze(mrb, self);
   }
+}
+
+/*
+ * Wraps a platform wait status for the process +pid+.  +raw_status+ is the
+ * value the platform reported the process with, as Process.waitpid passes
+ * on and as Process::Status#to_i gives back.
+ *
+ * Reached by allocating an instance and initializing it rather than through
+ * `new`, which this class does not have.  Private, as mruby makes every
+ * #initialize.
+ *
+ * A Process::Status is frozen once built, as CRuby freezes the one it leaves
+ * in <code>$?</code>.  What a process did is over by the time there is a
+ * status for it, and every question a status answers is read back from the
+ * two integers set here.  An instance of a subclass is left unfrozen, since
+ * whatever else it is made of is set after this returns.
+ */
+static mrb_value
+status_initialize(mrb_state *mrb, mrb_value self)
+{
+  mrb_int pid, raw_status;
+
+  mrb_get_args(mrb, "ii", &pid, &raw_status);
+  status_set(mrb, self, pid, raw_status);
   return self;
 }
 
@@ -352,11 +365,29 @@ mrb_value
 mrb_process_status_new(mrb_state *mrb, mrb_int pid, mrb_int raw_status)
 {
   struct RClass *status = status_class(mrb);
-  mrb_value argv[2];
+  mrb_value self = mrb_obj_value(MRB_OBJ_ALLOC(mrb, MRB_TT_OBJECT, status));
 
-  argv[0] = mrb_int_value(mrb, pid);
-  argv[1] = mrb_int_value(mrb, raw_status);
-  return mrb_obj_new(mrb, status, 2, argv);
+  /* Written straight into the object where #initialize is the one below,
+     rather than through mrb_obj_new(), which would call it back through the
+     VM.  What a wait reported cannot be asked for a second time, and until
+     it is written it exists only in the arguments to this call, so the
+     stretch between reaping a child and recording what it did is no place to
+     run a method that a program can replace.  Struct and Data tell their own
+     #initialize from a replaced one the same way.
+
+     A replaced one is still called, since a program that wrote it asked for
+     it to run; what it does with the status is then its own business. */
+  if (mrb_func_basic_p(mrb, self, MRB_SYM(initialize), status_initialize)) {
+    status_set(mrb, self, pid, raw_status);
+  }
+  else {
+    mrb_value argv[2];
+
+    argv[0] = mrb_int_value(mrb, pid);
+    argv[1] = mrb_int_value(mrb, raw_status);
+    mrb_funcall_argv(mrb, self, MRB_SYM(initialize), 2, argv);
+  }
+  return self;
 }
 
 void

--- a/mrbgems/mruby-process/test/process.rb
+++ b/mrbgems/mruby-process/test/process.rb
@@ -348,6 +348,43 @@ assert('Process.waitpid') do
   io.close
 end
 
+assert('Process.waitpid through a replaced Process::Status#initialize') do
+  # A status is written into the object without calling #initialize where it
+  # is the one the gem defines, so that the stretch between reaping a child
+  # and recording what it did runs no method a program can replace.  One that
+  # was replaced is still called: writing it is asking for it to run, and by
+  # then the status it is handed is the one the wait reported.
+  skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
+  io = ProcessTestUtil.spawn("exit 6")
+  skip "IO.popen is not available" unless io
+
+  io.read
+  pid = io.pid
+  seen = nil
+  Process::Status.class_eval do
+    alias_method :__test_initialize, :initialize
+    define_method(:initialize) do |child, raw_status|
+      seen = [child, raw_status]
+      __test_initialize(child, raw_status)
+    end
+  end
+  begin
+    assert_equal pid, Process.waitpid(pid)
+    assert_kind_of Array, seen
+    assert_equal pid, seen[0]
+    # The status it built is the one published, and reads as any other does.
+    assert_equal pid, $?.pid
+    assert_equal 6, $?.exitstatus
+    assert_equal seen[1], $?.to_i
+  ensure
+    Process::Status.class_eval do
+      alias_method :initialize, :__test_initialize
+      remove_method :__test_initialize
+    end
+    io.close
+  end
+end
+
 assert('Process.waitpid with Process::WNOHANG') do
   skip ProcessTestUtil.child_reason if ProcessTestUtil.child_reason
   # `exec` so that the pid this knows is the one that sleeps.  IO.popen runs


### PR DESCRIPTION
## Summary

`Process.waitpid` reaped a child and then handed `Process::Status#initialize` back to the VM to record what it found. A wait cannot be made twice, so that call is the one place where what the child did exists nowhere but in the arguments being passed, and it ran a method a program is free to replace. The status is now written into the object directly, the way `Struct.new` and `Data.new` write theirs.

## Changes

| File                                    | What                                                                                                      |
| --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-process/src/status.c`    | added `status_set()`; `mrb_process_status_new()` allocates and writes rather than calling `mrb_obj_new()` |
| `mrbgems/mruby-process/test/process.rb` | added `Process.waitpid through a replaced Process::Status#initialize`                                     |

### The window a wait opens

`mrb_process_status_new()` reached `#initialize` through `mrb_obj_new()`, which allocates an instance and then calls the method through the VM. `CONTRIBUTING.md` names that call under "Avoid re-entering the VM from C", and this caller is the sharpest case of it: `waitpid(2)` has already returned by the time the status is built, the child is gone, and the pid and the raw status live only in the arguments to that call until they are written into the object. Anything that goes wrong in between loses them for good, and `$?` keeps whatever it held before.

`status_set()` is now where the two integers are written and where the object is frozen, and both `#initialize` and `mrb_process_status_new()` go through it, so a status reads the same whichever built it.

### A replaced `#initialize` is still called

`mrb_func_basic_p()` tells the gem's own `#initialize` from one a program wrote, exactly as `mrb_struct_new()` and `mrb_data_new()` do for theirs. The gem's own is skipped and written through; a replaced one is still called, since writing it is asking for it to run. What that method then does with the status is its own business, and the test pins that it is reached and that the status it builds is the one published.

`IO.popen` is untouched. `mruby-io` builds the status it sets `$?` to through `mrb_obj_new()`, which is the seam between the two gems and is deliberately not a C entry point either of them exports; that path is unchanged.

## Behaviour

Nothing a program can observe changes where `Process::Status#initialize` is the one this gem defines, which is every build that does not replace it. `$?` after a wait is the same frozen `Process::Status`, carrying the same pid and raw status, with the same empty `instance_variables`.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, gcc 13.3.0, base `50514b23f`.

| Build              |    master |   This PR | Delta |
| ------------------ | --------: | --------: | ----: |
| `bintest`          | 1,383,222 | 1,383,334 |  +112 |
| `ascii-ctype`      | 1,367,590 | 1,367,702 |  +112 |
| `byte-string`      | 1,345,142 | 1,345,254 |  +112 |
| `cxx_abi`          | 1,416,825 | 1,416,937 |  +112 |
| `no-float`         | 1,309,150 | 1,309,262 |  +112 |
| `no-bigint`        | 1,267,862 | 1,267,974 |  +112 |
| `full-debug` (-O0) | 1,974,982 | 1,975,158 |  +176 |

All of it is `status.o`, whose `.text` goes from 3,858 to 3,970 in the `bintest` build: the allocation and the branch that the constructor now carries itself instead of borrowing from `mrb_obj_new()`.

## Testing

`rake -m test` green at the commit, on `default`, on all seven `ci/gcc-clang` builds, and under ASAN/UBSAN (`gcc-asan`).

| Config     | Total |    OK |  KO | Crash | Skip |
| ---------- | ----: | ----: | --: | ----: | ---: |
| `default`  | 2,624 | 2,557 |   0 |     0 |   67 |
| `gcc-asan` | 2,868 | 2,857 |   0 |     0 |   11 |

The new test replaces `Process::Status#initialize`, waits for a child, and asserts that the replacement was reached with the reaped pid and that `$?` reads back through it; the original is restored in an `ensure`.

## Environment

<details>

|              |                                              |
| ------------ | -------------------------------------------- |
| OS           | Ubuntu 24.04, Linux 7.0.0-31-generic         |
| CPU          | x86_64, 32 threads                           |
| C compiler   | gcc 13.3.0                                   |
| C++ compiler | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links) |
| binutils     | GNU ld 2.47.20260726                         |
| CRuby        | 4.0.6                                        |

Compile lines, as `rake --verbose` printed them for `mrbgems/mruby-process/src/status.c`, with `-MMD -c`, `-I`, `-o` and the path-mapping flags dropped:

```console
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DHAVE_SYS_RESOURCE_H -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DHAVE_SYS_RESOURCE_H -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_SYS_RESOURCE_H -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DHAVE_SYS_RESOURCE_H -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DHAVE_SYS_RESOURCE_H -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DHAVE_SYS_RESOURCE_H -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DHAVE_SYS_RESOURCE_H -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Process::Status` creation when its initializer is customized, preserving the expected process ID, raw status, and published process status values.

* **Tests**
  * Added coverage confirming `Process.waitpid` correctly handles customized `Process::Status#initialize` implementations and child processes exiting with a status code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->