### PR TITLE
mruby-io: four wrong answers from the read buffer

### DIFF
--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1913,7 +1913,7 @@ io_buf_shift(struct mrb_io_buf *buf, mrb_int n)
    returned: bytes are put in front of the descriptor by #ungetc, and held back
    across a fill by #gets, and a stream is not at its end while they are
    there. */
-static void
+static int
 io_fill_buf_comp(mrb_state *mrb, struct mrb_io *fptr)
 {
   struct mrb_io_buf *buf = fptr->buf;
@@ -1923,7 +1923,7 @@ io_fill_buf_comp(mrb_state *mrb, struct mrb_io *fptr)
      room to read into. What is already there is what the stream hands out. */
   if (keep >= MRB_IO_BUF_SIZE) {
     fptr->eof = 0;
-    return;
+    return 0;
   }
   if (buf->start > 0) {
     memmove(buf->mem, buf->mem+buf->start, keep);
@@ -1933,6 +1933,7 @@ io_fill_buf_comp(mrb_state *mrb, struct mrb_io *fptr)
   if (n < 0) mrb_sys_fail(mrb, 0);
   buf->len = (short)(keep + n);
   fptr->eof = (buf->len == 0);
+  return n;
 }
 
 static void
@@ -2138,9 +2139,9 @@ io_gets(mrb_state *mrb, mrb_value io)
     outbuf = mrb_str_new(mrb, NULL, 0);
   }
 
+  mrb_int rslen = rs_given ? RSTRING_LEN(rs) : 0;
   for (;;) {
     if (rs_given) {                /* with RS */
-      mrb_int rslen = RSTRING_LEN(rs);
       mrb_int idx = io_find_index(fptr, RSTRING_PTR(rs), rslen);
       if (idx >= 0) {              /* found */
         mrb_int n = idx+rslen;
@@ -2151,16 +2152,31 @@ io_gets(mrb_state *mrb, mrb_value io)
         return outbuf;
       }
     }
-    if (limit_given) {
-      if (limit <= buf->len) {
+    /* A separator of more than one byte can lie across the seam between what
+       this fill read and what the next one will, and the scan above sees only
+       one side of it. Its first rslen-1 bytes stay behind so that the next
+       scan reads them beside what follows. Room to read into has to be left,
+       or the fill below has nowhere to put the other side. */
+    mrb_int keep = 0;
+    if (rslen > 1) {
+      keep = (rslen - 1 < buf->len) ? rslen - 1 : buf->len;
+      if (keep >= MRB_IO_BUF_SIZE) keep = MRB_IO_BUF_SIZE - 1;
+    }
+    mrb_int avail = buf->len - keep;
+    if (limit_given && limit <= avail) {
+      io_buf_cat(mrb, outbuf, buf, limit);
+      return outbuf;
+    }
+    if (limit_given) limit -= avail;
+    io_buf_cat(mrb, outbuf, buf, avail);
+    if (io_fill_buf_comp(mrb, fptr) == 0) {
+      /* The descriptor has no more to give, so whatever was held back for the
+         seam ends the last line rather than starting a separator. */
+      if (limit_given && limit < buf->len) {
         io_buf_cat(mrb, outbuf, buf, limit);
         return outbuf;
       }
-      limit -= buf->len;
-    }
-    io_buf_cat_all(mrb, outbuf, buf);
-    io_fill_buf(mrb, fptr);
-    if (fptr->eof) {
+      io_buf_cat_all(mrb, outbuf, buf);
       if (RSTRING_LEN(outbuf) == 0) return mrb_nil_value();
       return outbuf;
     }

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -942,22 +942,28 @@ fd_write(mrb_state *mrb, int fd, mrb_value str)
 
 #define FD_WRITE_LIT(mrb, fd, s) fd_write_buf(mrb, fd, "" s "", sizeof(s) - 1)
 
-/* Helper function to prepare IO object for writing by adjusting buffer state */
+/* Writing to a stream that has read ahead of what the caller consumed puts
+   the descriptor's position back where the caller stands, so the write lands
+   where the reader left off. Only a stream whose two ends share one seekable
+   descriptor has such a position to give back. */
 static void
 io_prepare_write(mrb_state *mrb, struct mrb_io *fptr)
 {
-  if (fptr->buf && fptr->buf->len > 0) {
-    int fd = io_get_write_fd(fptr);
-    off_t n;
+  if (fptr->buf == NULL || fptr->buf->len == 0) return;
+  /* Reads come from `fd` and writes go to `fd2`, which carries a position of
+     its own that owes nothing to what was read. */
+  if (fptr->fd2 != -1) return;
 
-    /* get current position */
-    n = (off_t)mrb_hal_io_lseek(mrb, fd, 0, MRB_IO_SEEK_CUR);
-    if (n == -1) mrb_sys_fail(mrb, "lseek");
-    /* move cursor */
-    n = (off_t)mrb_hal_io_lseek(mrb, fd, (mrb_int)(n - fptr->buf->len), MRB_IO_SEEK_SET);
-    if (n == -1) mrb_sys_fail(mrb, "lseek(2)");
-    fptr->buf->start = fptr->buf->len = 0;
+  off_t n = (off_t)mrb_hal_io_lseek(mrb, fptr->fd, 0, MRB_IO_SEEK_CUR);
+  if (n == -1) {
+    /* A pipe or a socket has no position at all, so nothing was taken from it
+       that a seek could hand back. The read-ahead stays for the reader. */
+    if (errno == ESPIPE) return;
+    mrb_sys_fail(mrb, "lseek");
   }
+  n = (off_t)mrb_hal_io_lseek(mrb, fptr->fd, (mrb_int)(n - fptr->buf->len), MRB_IO_SEEK_SET);
+  if (n == -1) mrb_sys_fail(mrb, "lseek(2)");
+  fptr->buf->start = fptr->buf->len = 0;
 }
 
 static mrb_value

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -1908,34 +1908,43 @@ io_buf_shift(struct mrb_io_buf *buf, mrb_int n)
   buf->len -= (short)n;
 }
 
-#ifdef MRB_UTF8_STRING
+/* Read after what the buffer already holds, keeping those bytes. `eof` is
+   the answer to what the buffer can hand out and not to what the last read(2)
+   returned: bytes are put in front of the descriptor by #ungetc, and held back
+   across a fill by #gets, and a stream is not at its end while they are
+   there. */
 static void
 io_fill_buf_comp(mrb_state *mrb, struct mrb_io *fptr)
 {
   struct mrb_io_buf *buf = fptr->buf;
   int keep = buf->len;
 
-  memmove(buf->mem, buf->mem+buf->start, keep);
+  /* #ungetc can grow the buffer past MRB_IO_BUF_SIZE, and then there is no
+     room to read into. What is already there is what the stream hands out. */
+  if (keep >= MRB_IO_BUF_SIZE) {
+    fptr->eof = 0;
+    return;
+  }
+  if (buf->start > 0) {
+    memmove(buf->mem, buf->mem+buf->start, keep);
+    buf->start = 0;
+  }
   int n = mrb_hal_io_read(mrb, fptr->fd, buf->mem+keep, MRB_IO_BUF_SIZE-keep);
   if (n < 0) mrb_sys_fail(mrb, 0);
-  if (n == 0) fptr->eof = 1;
-  buf->start = 0;
-  buf->len += (short)n;
+  buf->len = (short)(keep + n);
+  fptr->eof = (buf->len == 0);
 }
-#endif
 
 static void
 io_fill_buf(mrb_state *mrb, struct mrb_io *fptr)
 {
-  struct mrb_io_buf *buf = fptr->buf;
-
-  if (buf->len > 0) return;
-
-  int n = mrb_hal_io_read(mrb, fptr->fd, buf->mem, MRB_IO_BUF_SIZE);
-  if (n < 0) mrb_sys_fail(mrb, 0);
-  if (n == 0) fptr->eof = 1;
-  buf->start = 0;
-  buf->len = (short)n;
+  /* Bytes to hand out already, so the descriptor is not asked again and the
+     stream is not at its end whatever an earlier read(2) reported. */
+  if (fptr->buf->len > 0) {
+    fptr->eof = 0;
+    return;
+  }
+  io_fill_buf_comp(mrb, fptr);
 }
 
 static mrb_value
@@ -1943,8 +1952,6 @@ io_eof(mrb_state *mrb, mrb_value io)
 {
   struct mrb_io *fptr = io_get_read_fptr(mrb, io);
 
-  if (fptr->eof) return mrb_true_value();
-  if (fptr->buf->len > 0) return mrb_false_value();
   io_fill_buf(mrb, fptr);
   return mrb_bool_value(fptr->eof);
 }

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -862,17 +862,9 @@ io_sysread(mrb_state *mrb, mrb_value io)
 }
 
 static mrb_value
-io_sysseek(mrb_state *mrb, mrb_value io)
+io_seek_to(mrb_state *mrb, struct mrb_io *fptr, mrb_int offset, mrb_int whence)
 {
-  mrb_int offset, whence = -1;
-
-  mrb_get_args(mrb, "i|i", &offset, &whence);
-  if (whence < 0) {
-    whence = 0;
-  }
-
-  struct mrb_io *fptr = io_get_open_fptr(mrb, io);
-  off_t pos = (off_t)mrb_hal_io_lseek(mrb, fptr->fd, (mrb_int)offset, (int)whence);
+  off_t pos = (off_t)mrb_hal_io_lseek(mrb, fptr->fd, offset, (int)whence);
   if (pos == -1) {
     mrb_sys_fail(mrb, "sysseek");
   }
@@ -883,11 +875,43 @@ io_sysseek(mrb_state *mrb, mrb_value io)
   return mrb_int_value(mrb, (mrb_int)pos);
 }
 
+static void
+io_seek_args(mrb_state *mrb, mrb_int *offset, mrb_int *whence)
+{
+  *whence = -1;
+  mrb_get_args(mrb, "i|i", offset, whence);
+  if (*whence < 0) {
+    *whence = MRB_IO_SEEK_SET;
+  }
+}
+
+static mrb_value
+io_sysseek(mrb_state *mrb, mrb_value io)
+{
+  mrb_int offset, whence;
+
+  io_seek_args(mrb, &offset, &whence);
+  return io_seek_to(mrb, io_get_open_fptr(mrb, io), offset, whence);
+}
+
 static mrb_value
 io_seek(mrb_state *mrb, mrb_value io)
 {
-  mrb_value pos = io_sysseek(mrb, io);
+  mrb_int offset, whence;
+
+  io_seek_args(mrb, &offset, &whence);
+
   struct mrb_io *fptr = io_get_open_fptr(mrb, io);
+  if (whence == MRB_IO_SEEK_CUR && fptr->buf && fptr->buf->len > 0) {
+    /* The descriptor sits at the end of what was read ahead, and the caller
+       sits at the front of it. A relative seek counts from where the caller
+       is, so what is still buffered is given back to the descriptor first. */
+    if (offset < MRB_INT_MIN + fptr->buf->len) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "seek offset too far back for mrb_int");
+    }
+    offset -= fptr->buf->len;
+  }
+  mrb_value pos = io_seek_to(mrb, fptr, offset, whence);
   if (fptr->buf) {
     fptr->buf->start = 0;
     fptr->buf->len = 0;

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -655,6 +655,28 @@ assert('IO.popen with err option') do
   end
 end
 
+assert('IO#write to a duplex stream after a buffered read') do
+  # The read caught more than the line it handed out, and what stayed behind
+  # says nothing about where the write end stands.
+  #
+  # The read below is the one the write has to survive, and it has to happen
+  # while the write end is still open. Windows stands in `findstr` for `cat`,
+  # and that holds its output until its input is closed, so there is nothing
+  # to read until the test is over.
+  skip "no command that writes a line back as it arrives" if MRubyIOTestUtil.win?
+  begin
+    io = IO.popen($cat, "r+")
+    io.write "a\nb\n"
+    assert_equal "a\n", io.gets
+    io.write "c\n"
+    io.close_write
+    assert_equal "b\nc\n", io.read
+    io.close
+  rescue NotImplementedError => e
+    skip e.message
+  end
+end
+
 assert('IO#close_write') do
   begin
     io = IO.popen($cat, "r+")

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -559,6 +559,35 @@ assert('IO#gets - paragraph mode') do
   io.close
 end
 
+assert('IO#gets - separator across a buffer boundary') do
+  buf_size = 4096  # copied from io.c
+  dir = MRubyIOTestUtil.mkdtemp("mruby-io-test.XXXXXX")
+  path = "#{dir}/straddle"
+  begin
+    # Each separator starts on the last byte one fill can reach and ends in
+    # what the next one reads.
+    ["ab", "\n\n"].each do |sep|
+      head = "x" * (buf_size - 1)
+      File.open(path, "wb") { |f| f.write "#{head}#{sep}yy#{sep}" }
+      File.open(path, "rb") do |f|
+        assert_equal "#{head}#{sep}", f.gets(sep)
+        assert_equal "yy#{sep}", f.gets(sep)
+        assert_nil f.gets(sep)
+      end
+      # The tail of a separator left unmatched at the end of the file is
+      # still part of the last line.
+      File.open(path, "wb") { |f| f.write "#{head}#{sep[0]}" }
+      File.open(path, "rb") do |f|
+        assert_equal "#{head}#{sep[0]}", f.gets(sep)
+        assert_nil f.gets(sep)
+      end
+    end
+  ensure
+    File.delete(path) rescue nil
+    MRubyIOTestUtil.rmdir dir
+  end
+end
+
 assert('IO.popen') do
   begin
     $? = nil

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -101,6 +101,43 @@ assert('IO#eof?', '15.2.20.5.6') do
   io.close
 end
 
+assert('IO#eof? is answered again after the end') do
+  # Bytes put back after the end are there to be read, and so are bytes that
+  # reach a file after a reader has seen the end of it.
+  io = IO.open(IO.sysopen($mrbtest_io_rfname))
+  begin
+    io.read
+    assert_true io.eof?
+    io.ungetc("z")
+    assert_false io.eof?
+    assert_equal "z", io.getc
+    assert_true io.eof?
+  ensure
+    io.close
+  end
+
+  dir = MRubyIOTestUtil.mkdtemp("mruby-io-test.XXXXXX")
+  path = "#{dir}/growing"
+  begin
+    File.open(path, "w") { |f| f.write "one\n" }
+    io = File.open(path)
+    begin
+      assert_equal "one\n", io.gets
+      assert_nil io.gets
+      assert_true io.eof?
+      File.open(path, "a") { |f| f.write "two\n" }
+      assert_false io.eof?
+      assert_equal "two\n", io.gets
+      assert_nil io.gets
+    ensure
+      io.close
+    end
+  ensure
+    File.delete(path) rescue nil
+    MRubyIOTestUtil.rmdir dir
+  end
+end
+
 assert('IO#flush', '15.2.20.5.7') do
   # Note: mruby-io does not have any buffer to be flushed now.
   io = IO.new(IO.sysopen($mrbtest_io_wfname))

--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -480,6 +480,26 @@ assert('IO#pos=, IO#seek') do
   io.close
 end
 
+assert('IO#seek from the current position') do
+  # $mrbtest_io_msg is "mruby io test\n", and reading a byte of it buffers
+  # the rest. A relative seek counts from the byte the caller is at, not from
+  # the end of what the buffer read ahead.
+  io = IO.open(IO.sysopen($mrbtest_io_rfname))
+  begin
+    assert_equal 'm', io.getc
+    assert_equal 1, io.pos
+    assert_equal 1, io.seek(0, IO::SEEK_CUR)
+    assert_equal 1, io.pos
+    assert_equal 'r', io.getc
+    assert_equal 5, io.seek(3, IO::SEEK_CUR)
+    assert_equal ' io test', io.read(8)
+    assert_equal 2, io.seek(-11, IO::SEEK_CUR)
+    assert_equal 'u', io.getc
+  ensure
+    io.close
+  end
+end
+
 assert('IO#rewind') do
   fd = IO.sysopen $mrbtest_io_rfname
   io = IO.new(fd)


### PR DESCRIPTION
## Summary

Four things the read buffer answered wrongly, all of them reachable from ordinary code: a stream stayed at its end once it had reached it, a separator that fell across a fill was never seen, a relative seek counted from the wrong byte, and a write to a socket or a bidirectional pipe raised `Errno::ESPIPE`.

## Changes

| File                          | What                                                                                                                                                                                                                                       |
| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `mrbgems/mruby-io/src/io.c`   | `io_fill_buf_comp()` returns the byte count and leaves `MRB_UTF8_STRING`; `io_fill_buf()` defers to it; `io_seek_args()` / `io_seek_to()` split out of `io_sysseek()`; early returns in `io_prepare_write()`; the hold-back in `io_gets()` |
| `mrbgems/mruby-io/test/io.rb` | Four tests, one per fix                                                                                                                                                                                                                    |

### `eof` was a latch rather than an answer

`fptr->eof` was set when read(2) returned 0 and cleared only by `IO#sysseek`, while `io_fill_buf()` returned early without reading whenever the buffer held anything. Every reader tested the flag before the buffer, so once set it stood.

It now says what the buffer can hand out, which is what the readers were already asking it for. Both the `#ungetc` case and the growing-file case want a fill that keeps what is already buffered, so `io_fill_buf()` defers to the compacting one and that comes out from under `MRB_UTF8_STRING`. A buffer that `IO#ungetc` grew past `MRB_IO_BUF_SIZE` has no room left to read into and hands out what it holds.

### A separator could hide in the seam between two fills

`io_find_index()` scans only the bytes the buffer holds, and when it found nothing `io_gets()` moved the whole buffer into the line and refilled from empty. A separator of more than one byte whose first byte ended one fill and whose rest began the next was never compared as a whole. Paragraph mode and `"\r\n"` are the two that meet this in ordinary use, since the boundary is wherever 4096 bytes happen to land.

The trailing `rslen-1` bytes now stay in the buffer for the next scan. Holding back only when the buffer already holds `rslen` bytes is not enough: the tail left by a separator that matched repeatedly can be shorter than that. When the descriptor gives nothing more, what was held back ends the line rather than starting a separator.

### A relative seek counted from the read ahead

`IO#seek` handed its arguments to the `IO#sysseek` body and only then threw the buffer away, so an `IO::SEEK_CUR` offset counted from wherever the last fill had reached. The gap is whatever the buffer holds, up to 4096 bytes. `IO::SEEK_SET` and `IO::SEEK_END` name a place the buffer has no say in, and `IO#pos` already subtracts it, so those were right and stay as they are.

The buffered count now comes off the offset before the seek. Splitting the argument reading out of `io_sysseek()` is what lets `IO#seek` look at `whence` first; `IO#sysseek` is unbuffered by definition and keeps its own meaning.

### A write seeked a descriptor that has no position

`io_prepare_write()` put the descriptor's position back by however much the read buffer held, so that a write to a stream read through would land where the caller stood. It did that for every stream with a non-empty buffer, and asked `io_get_write_fd()` for the descriptor to seek while subtracting a count read through the other one.

A stream writing to `fd2` has a write position that owes nothing to what was read from `fd`, and a pipe or a socket has no position at all. Both now leave the read ahead where it is for the reader to go on with.

## Behaviour

```ruby
# 1. the end of a stream can be reached more than once
f.read; f.ungetc("z"); f.getc   # was nil, now "z"
r.gets                          # was nil forever once the file had ended,
                                # now reads what was appended since

# 2. a separator across the 4096-byte seam
File.write(path, "x" * 4095 + "\n\n" + "y" * 10 + "\n\n")
File.open(path) { |f| [f.gets(""), f.gets("")] }
# was [<the whole file>, nil], now [4097 bytes, "yyyyyyyyyy\n\n"]

# 3. IO::SEEK_CUR
File.write(path, "0123456789")
f = File.open(path); f.getc
f.seek(1, IO::SEEK_CUR); f.read   # was "", now "23456789"

# 4. a reply written after a buffered read
a, b = UNIXSocket.pair
b.write "a\nb\n"
a.gets                            # "a\n", and "b\n" stays buffered
a.write "c\n"                     # was Errno::ESPIPE, now writes
```

All four now agree with CRuby. `IO#sysseek`, `IO#pos`, `IO::SEEK_SET` and `IO::SEEK_END` are unchanged.

## Size

`.text` of `bin/mruby`, gcc 13.3.0, the seven `build_config/ci/gcc-clang.rb` builds, clean build dirs and `rake all` on both sides, base `50514b23f`.

| Build              |    master |   This PR | Delta |
| ------------------ | --------: | --------: | ----: |
| `bintest`          | 1,383,222 | 1,383,382 |  +160 |
| `ascii-ctype`      | 1,367,590 | 1,367,750 |  +160 |
| `byte-string`      | 1,345,142 | 1,345,510 |  +368 |
| `cxx_abi`          | 1,416,825 | 1,417,145 |  +320 |
| `no-float`         | 1,309,150 | 1,309,326 |  +176 |
| `no-bigint`        | 1,267,862 | 1,268,022 |  +160 |
| `full-debug` (-O0) | 1,974,982 | 1,975,462 |  +480 |

All of it is `io.o`: its `.text` moves +160 in `bintest` and +368 in `byte-string`, matching the binary deltas. `byte-string` carries more than the rest because `io_fill_buf_comp()` used to be compiled out entirely without `MRB_UTF8_STRING` and is now part of every build.

## Testing

- `MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds green, no KO, no Crash, no Warning. The default host build is green too.
- Each of the four commits builds and passes the whole suite on its own.
- Differential runs against CRuby 4.0.6 on the same generated files: 480 fixed cases over ten data lengths around the 4096-byte boundary crossed with six separators and a limit, and 300 pseudo-random cases of up to 9000 bytes over the alphabet `a b \n` with separators of one to four bytes. `IO#gets` output is byte-identical to CRuby in all of them, and the lines always rejoin into the file. Adding an `IO#ungetc` of up to 20000 bytes before the reads keeps that identity.
- `valgrind --leak-check=full` on `bin/mrbtest` and on both differential scripts: 0 errors.
- A clean `ci/gcc-clang` build with gcc reports no new warnings.

## Environment

<details>

|              |                                                                     |
| ------------ | ------------------------------------------------------------------- |
| OS           | Ubuntu 24.04.4 LTS                                                  |
| Kernel       | Linux 7.0.0-31-generic x86_64                                       |
| CPU          | AMD Ryzen 9 5950X, 16 cores / 32 threads                            |
| C compiler   | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)                         |
| C++ compiler | `cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; g++ 13.3.0 links |
| binutils     | GNU ld 2.47.20260726                                                |
| valgrind     | 3.27.1                                                              |
| CRuby        | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM                       |

Compile lines for `mrbgems/mruby-io/src/io.c`, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` removed.

```console
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/io.c

# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c

# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/io.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relative seeking so positions reflect the actual current byte position, including buffered reads.
  * Improved end-of-file handling when streams receive additional data after EOF.
  * Fixed `IO#gets` detection for separators spanning internal read boundaries.
  * Improved writing to duplex process streams after buffered reads.
  * Improved handling of non-seekable streams and buffered input.
  * Improved stream position handling when reading and writing use separate descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->