### PR TITLE
hash.c: hash a Symbol key by the symbol, not by mrb_fixnum()

### DIFF
--- a/benchmark/bm_hash_access.rb
+++ b/benchmark/bm_hash_access.rb
@@ -1,0 +1,28 @@
+# Repeated lookups of the same keys in the same hashes. Every `[]` and `[]=`
+# here searches its entry from scratch, so the phases isolate the two halves
+# of that search: hashing the key, which walks a string but not a symbol, and
+# probing for it, which does the same work either way. The last phase pays
+# both twice, once for the read and once for the write.
+
+REPEAT = 30_000
+
+STR_KEYS = (0...64).map { |i| "key#{i}" }
+SYM_KEYS = STR_KEYS.map { |s| s.to_sym }
+
+str_hash = {}
+STR_KEYS.each_with_index { |k, i| str_hash[k] = i }
+
+sym_hash = {}
+SYM_KEYS.each_with_index { |k, i| sym_hash[k] = i }
+
+counts = {}
+STR_KEYS.each { |k| counts[k] = 0 }
+
+sum = 0
+
+REPEAT.times { STR_KEYS.each { |k| sum += str_hash[k] } }
+REPEAT.times { SYM_KEYS.each { |k| sum += sym_hash[k] } }
+REPEAT.times { STR_KEYS.each { |k| counts[k] += 1 } }
+
+raise "unexpected sum" unless sum == 2 * REPEAT * 2016
+raise "unexpected count" unless counts[STR_KEYS[0]] == REPEAT

--- a/src/hash.c
+++ b/src/hash.c
@@ -348,8 +348,14 @@ mrb_obj_hash_code(mrb_state *mrb, mrb_value key)
     break;
   case MRB_TT_TRUE:
   case MRB_TT_FALSE:
-  case MRB_TT_SYMBOL:
     hash_code = U32(mrb_fixnum(key));
+    break;
+  case MRB_TT_SYMBOL:
+    /* Not mrb_fixnum(): 64-bit word boxing keeps a symbol above the fixnum
+       shift, so truncating what mrb_fixnum() returns to 32 bits leaves a single
+       bit of the symbol and splits a symbol-keyed table across two probe
+       chains. */
+    hash_code = U32(mrb_symbol(key));
     break;
   case MRB_TT_INTEGER:
     if (mrb_fixnum_p(key)) {


### PR DESCRIPTION
## Summary

`mrb_obj_hash_code()` read a `Symbol` key with `U32(mrb_fixnum(key))`, which under the default word boxing on 64-bit takes one of two values over every symbol there is. A `Hash` grown past the array representation therefore held its whole table on two probe chains, and each lookup walked one of them.

## Changes

| File | What |
|---|---|
| `src/hash.c` | `mrb_obj_hash_code()` reads a `Symbol` key with `mrb_symbol()` |
| `benchmark/bm_hash_access.rb` | new; repeated lookups over string keys, symbol keys, and read-modify-write |

### Where word boxing keeps a symbol

`boxing_word.h` writes a symbol at `WORDBOX_SYMBOL_SHIFT`, which is 32 on a 64-bit platform, while `mrb_fixnum()` shifts the word down by `WORDBOX_FIXNUM_SHIFT`, which is 1. A symbol `S` therefore reaches `U32()` as `S << 31 | 0xe`, whose low 32 bits are `((S & 1) << 31) | 0xe`: the parity of the symbol and nothing else. Run those two through the finalizer at the end of `mrb_obj_hash_code()` and they come out `0x8cbcb986` and `0x3d1e8824`, so every `Symbol` in a program addressed one of two index buckets. `ib_it_next()` probes by triangular numbers from there, deterministically, so the chain a key ended up on was as long as the number of same-parity keys inserted before it.

Nothing shows below 17 entries, where a `Hash` is still an array searched linearly. At 17 the index buckets appear and the cost starts growing with the table.

### What else hashes through this

`mruby-set`, and in `mruby-array-ext` the khash behind `Array#|`, `#&`, `#-`, `#uniq` and `#intersect?` once the operands pass eight elements, take their hash codes from the same function, so a symbol element cost the same walk there.

### The other boxings

They told symbols apart already, but by accident of the layout rather than by asking for the symbol, and one of them not soundly. Word boxing on a 32-bit platform puts a symbol at bit 5 and `mrb_fixnum()` shifts by 1, so the bits survive; NaN boxing keeps a symbol in the low 32 bits, which is exactly what `U32()` takes. Under `MRB_NO_BOXING`, `mrb_fixnum()` reads `value.i` where `SET_SYM_VALUE()` wrote `value.sym`, and with a 64-bit `mrb_int` that member is four bytes wider than what was written; which four bytes `U32()` then takes is up to the byte order. `mrb_symbol()` is right in all four.

## Speed

Lookups of one key in the same hash, 200,000 iterations:

```ruby
N = 200_000

def measure(h, k)
  t = Time.now
  sum = 0
  N.times { sum += h[k] }
  ((Time.now - t) * 1000).round
end

[17, 64, 256, 1024].each do |n|
  str = (0...n).map { |i| "key#{i}" }
  sym = str.map { |s| s.to_sym }
  hs = {}; str.each_with_index { |k, i| hs[k] = i }
  hy = {}; sym.each_with_index { |k, i| hy[k] = i }
  puts "#{n}\t#{measure(hs, str[n / 2])}\t#{measure(hy, sym[n / 2])}"
end
```

Wall clock in ms, minimum of ten alternating rounds pinned to one core, default configuration:

| entries | symbol, master | symbol, this PR | ratio | string, master | string, this PR |
|---|---|---|---|---|---|
| 17 | 19 | 12 | 1.6x | 14 | 14 |
| 64 | 32 | 12 | 2.7x | 15 | 15 |
| 256 | 84 | 12 | 7.0x | 14 | 15 |
| 1024 | 279 | 12 | 23x | 14 | 15 |

This host swings by a factor of two between a quiet core and a busy one, which is why the string columns are there: the ratios above stand well clear of that, but no reading here is worth a percent or two. The same cases under callgrind are, `Ir(200k) - Ir(100k)` over 100,000 iterations, so the interpreter start-up cancels and one lookup is left:

| entries | symbol, master | symbol, this PR | ratio | string, master | string, this PR |
|---|---|---|---|---|---|
| 17 | 1,890 | 1,073 | 1.76x | 1,200 | 1,202 |
| 64 | 3,221 | 1,073 | 3.00x | 1,221 | 1,223 |
| 256 | 8,765 | 1,073 | 8.17x | 1,236 | 1,238 |
| 1024 | 29,771 | 1,073 | 27.7x | 1,236 | 1,238 |

The symbol column is now flat in the size of the table, and sits below the string column because hashing a symbol reads one word where hashing a string walks it. The two instructions the string rows gain are the extra `switch` arm.

Instructions per operation over 256 symbols, measured the same way:

| operation | master | this PR | ratio |
|---|---|---|---|
| `a.uniq`, 512 elements | 8,789,888 | 146,003 | 60x |
| `a & b` | 9,454,996 | 198,687 | 48x |
| `a \| b` | 16,361,608 | 235,173 | 70x |
| `Set#include?` | 1,754 | 1,207 | 1.45x |

## Size

`.text` of `bin/mruby`, `size -A`, `MRUBY_CONFIG=ci/gcc-clang`, `CC=gcc CXX=g++ LD=gcc`, each build from an empty directory at the same worktree path:

| build | master | this PR | delta |
|---|---|---|---|
| bintest | 1,383,222 | 1,383,462 | +240 |
| ascii-ctype | 1,367,590 | 1,367,830 | +240 |
| byte-string | 1,345,142 | 1,345,382 | +240 |
| cxx_abi | 1,416,825 | 1,416,873 | +48 |
| no-float | 1,309,150 | 1,309,422 | +272 |
| no-bigint | 1,267,862 | 1,268,102 | +240 |
| full-debug (-O0) | 1,974,982 | 1,974,998 | +16 |

The default configuration, which the benchmarks above were taken on, moves 1,291,646 to 1,291,886, +240.

In the bintest build all of it is `hash.o`, whose `.text` goes 24,352 to 24,592. `nm -S` puts +22 in `mrb_obj_hash_code()` and the rest in the copies gcc inlines into it: `ht_delete` +119, `ib_it_init` +108, `ht_init` +16, `ht_get` +7. That is +272 against a section delta of +240; the difference is alignment padding the object gives back.

## Testing

`rake -m test`, `MRUBY_CONFIG=ci/gcc-clang`, `CC=gcc CXX=g++ LD=gcc`, at the head of the branch:

| build | total | OK | KO | Crash | Skip |
|---|---|---|---|---|---|
| bintest | 2,867 | 2,848 | 0 | 0 | 19 |
| ascii-ctype | 2,855 | 2,834 | 0 | 0 | 21 |
| byte-string | 2,783 | 2,716 | 0 | 0 | 67 |
| cxx_abi | 2,867 | 2,848 | 0 | 0 | 19 |
| no-float | 2,602 | 2,507 | 0 | 0 | 95 |
| no-bigint | 2,821 | 2,789 | 0 | 0 | 32 |
| full-debug | 2,867 | 2,857 | 0 | 0 | 10 |

The integration tests that run alongside them: 147 total, 146 OK, 0 KO, 1 skipped.

Both commits are green on their own under the default configuration: 2,623 total, 2,556 OK, 0 KO, 0 crashes, 67 skipped, and 130 integration tests with 129 OK.

## Environment

<details>

| | |
|---|---|
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16 cores |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| C++ compiler | `gcc -x c++ -std=gnu++03` for `cxx_abi`; g++ 13.3.0 links it |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| valgrind | valgrind-3.27.1 |
| base | `50514b23f` |

The compile line for `src/hash.c` in each build, as `rake --verbose` printed it, with `-MMD -c`, `-ffile-prefix-map`, `-I` and `-o` dropped:

```console
host (default configuration)
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved symbol-keyed hash lookups on 64-bit systems.
  - Fixed cases where symbol keys could be placed in inconsistent lookup paths, improving hash table reliability and access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->