### PR TITLE
hash.c: copy a String key where an entry is inserted, not before the search

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -273,6 +273,7 @@ static void ht_init(
   mrb_state *mrb, struct RHash *h, uint32_t size,
   hash_entry *ea, uint32_t ea_capa, hash_table *ht, uint32_t ib_bit);
 static void ht_set(mrb_state *mrb, struct RHash *h, mrb_value key, mrb_value val);
+static mrb_value h_key_for(mrb_state *mrb, struct RHash *h, mrb_value key);
 
 static uint32_t
 next_power2(uint32_t v)
@@ -613,6 +614,7 @@ ar_set(mrb_state *mrb, struct RHash *h, mrb_value key, mrb_value val)
   }
   else {
     uint32_t ea_capa = ar_ea_capa(h), ea_n_used = ar_ea_n_used(h);
+    key = h_key_for(mrb, h, key);
     if (ea_capa == ea_n_used) {
       if (size == ea_n_used) {
         if (size == AR_MAX_SIZE) {
@@ -990,6 +992,7 @@ ht_set(mrb_state *mrb, struct RHash *h, mrb_value key, mrb_value val)
         mrb_assert(ht_size(h) == ea_n_used);
         mrb_raise(mrb, E_ARGUMENT_ERROR, "hash too big");
       }
+      key = h_key_for(mrb, h, key);
       if (ea_n_used == ht_ea_capa(h)) ht_adjust_ea(mrb, h, ea_n_used, EA_MAX_CAPA);
       ib_it_set(it, ea_n_used);
       ea_set(ht_ea(h), ea_n_used, key, val);
@@ -1069,12 +1072,22 @@ ht_rehash(mrb_state *mrb, struct RHash *h)
   size <= AR_MAX_SIZE ? ht_to_ar(mrb, h) : ht_adjust_ea(mrb, h, size, ea_capa);
 }
 
+/*
+ * The key an entry is given: an unfrozen `String` is stored as a frozen copy,
+ * so that changing the caller's string cannot move an entry away from the
+ * place its hash code put it.
+ *
+ * This is asked for where an entry is inserted, not where a key is looked up
+ * or an entry overwritten. A store to a key the table already has keeps the
+ * key it already holds and copies nothing.
+ */
 static mrb_value
-h_key_for(mrb_state *mrb, mrb_value key)
+h_key_for(mrb_state *mrb, struct RHash *h, mrb_value key)
 {
   if (mrb_string_p(key) && !mrb_frozen_p(mrb_str_ptr(key))) {
     key = mrb_str_dup(mrb, key);
     mrb_str_ptr(key)->frozen = 1;
+    mrb_field_write_barrier_value(mrb, (struct RBasic*)h, key);
   }
   return key;
 }
@@ -1448,8 +1461,9 @@ mrb_hash_fetch(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value def)
  * its value is updated. If `key` does not exist, a new entry is created.
  * The hash is modified in place.
  *
- * If the `key` is a `MRB_TT_STRING` and not frozen, it will be duplicated
- * and the duplicate will be frozen before use.
+ * If a new entry is created and the `key` is a `MRB_TT_STRING` and not frozen,
+ * it will be duplicated and the duplicate will be frozen before use. Updating
+ * an entry that is already there keeps the key it holds and duplicates nothing.
  * Write barriers are triggered for garbage collection purposes for the key and value.
  *
  * @param mrb The mruby state.
@@ -1461,7 +1475,6 @@ MRB_API void
 mrb_hash_set(mrb_state *mrb, mrb_value hash, mrb_value key, mrb_value val)
 {
   hash_modify(mrb, hash);
-  key = h_key_for(mrb, key);
   h_set(mrb, mrb_hash_ptr(hash), key, val);
   mrb_field_write_barrier_value(mrb, mrb_basic_ptr(hash), key);
   mrb_field_write_barrier_value(mrb, mrb_basic_ptr(hash), val);

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -253,6 +253,13 @@ end
       assert_predicate(h_k, :frozen?)
       assert_not_predicate(k, :frozen?)
 
+      # a store to a key the hash already has keeps the key it holds
+      size = h.size
+      h.__send__(meth, k, 2)
+      assert_equal(size, h.size)
+      assert_same(h_k, h.keys[-1])
+      assert_equal(2, h[k])
+
       # frozen string key
       k = "_immutable".freeze
       h.__send__(meth, k, 2)


### PR DESCRIPTION
## Summary

Storing into a `Hash` under an unfrozen `String` key froze a copy of the key before the search, so a store to a key the table already held allocated a string, found the entry that copy was not needed for, wrote the value, and dropped the copy. Only an insertion keeps the key it is given, so that is where the copy is made now.

## Changes

| File             | What                                                                                                                                                                            |
| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/hash.c`     | `h_key_for()` takes the `RHash` and write-barriers the copy it returns; `ar_set()` and `ht_set()` call it on the branch that adds an entry; `mrb_hash_set()` no longer calls it |
| `test/t/hash.rb` | `Hash#[]=` and `Hash#store` state that a store to a key the hash already has keeps the key it holds                                                                             |

### The copy belongs where the entry is kept

An unfrozen `String` key is stored as a frozen copy so that mutating the caller's string cannot move an entry away from the place its hash code put it. `mrb_hash_set()` made that copy before it handed the key to `h_set()`, which is one step too early: `h_set()` reaches `ar_set()` or `ht_set()`, and each of those first searches, and only keeps the key on the branch where no entry was found. On the other branch the entry already there keeps its own key and the fresh copy is dropped, so the allocation, the copy of the bytes, and the garbage it leaves bought nothing.

`ar_set()` and `ht_set()` now ask for the key on that insert branch. The search still runs against the key the caller passed, which is content-equal to the copy and so hashes and compares the same, and the copy that goes into the entry is made once the entry is known to be new.

### The barrier on the copy

The copy is a fresh white object being stored into a hash that may be black, so it needs `mrb_field_write_barrier_value()`; before this change `mrb_hash_set()` covered it, because `key` had been reassigned to the copy by the time it barriered. `h_key_for()` now does it itself, next to the allocation, which also covers `mrb_hash_merge()`: it reaches `h_set()` without passing through `mrb_hash_set()`, and got the guarantee only because the hash it merges from had already frozen its own keys. `mrb_hash_set()` keeps its barrier for the keys it stores as they are.

The barrier grays the value rather than the hash, so issuing it before `ea_set()` writes the entry is safe: what it protects is the copy, not the slot.

## Behaviour

Nothing observable changes. A `String` key stored for the first time is still a frozen copy of the caller's string, an already frozen key is still stored as it is, and an update keeps the key that is already there. Hash literals, `Hash[]`, `store`, `merge`, `update`, and a delete followed by a re-insert were checked to still freeze their keys. The doc comment on `mrb_hash_set()` said the key is duplicated and frozen "before use"; it now says which of the two cases does that.

## Speed

```ruby
# store to a key already there, 8-entry hash (an AR hash)
h = {}
8.times { |i| h["key" + i.to_s] = i }
k = "key3"
N.times { h[k] = 1 }

# store to a key already there, 64-entry hash (an HT hash): 64.times above

# controls
k = "key3".freeze                     # the same store, already frozen key
h = {}; 8.times { |i| h[i] = i }; N.times { h[3] = 1 }   # Integer key
k = "fresh"; N.times { h[k] = 1; h.delete(k) }           # a new entry each time
```

Instructions per iteration, `valgrind --tool=callgrind`, taken as `Ir(200,000) - Ir(100,000)` over 100,000 so that startup, parse and GC init cancel:

| case                                        |   master |  this PR |   delta |
| ------------------------------------------- | -------: | -------: | ------: |
| store to a key already there, 8-entry hash  | 1,684.94 | 1,209.99 | -474.95 |
| store to a key already there, 64-entry hash | 1,655.65 | 1,167.00 | -488.65 |
| the same store with an already frozen key   | 1,219.00 | 1,210.00 |   -9.00 |
| the same store with an `Integer` key        |   942.00 |   941.00 |   -1.00 |
| insert then delete, one unfrozen key        | 3,221.33 | 3,230.10 |   +8.77 |

The store now costs what it costs with a frozen key, to two decimal places, which is the copy being gone. The two controls that keep their key move by the one test `mrb_hash_set()` no longer makes. Inserting an entry costs 9 instructions more: the barrier on the copy, which `mrb_hash_set()` used to fold into the barrier it makes anyway.

Wall clock for the same five cases at 5,000,000 iterations, minimum of seven rounds, the two binaries run alternately on one pinned core (`taskset -c 7`), `build_config/default.rb` with gcc:

| case                                        | master | this PR |
| ------------------------------------------- | -----: | ------: |
| store to a key already there, 8-entry hash  | 0.57 s |  0.35 s |
| store to a key already there, 64-entry hash | 0.54 s |  0.32 s |
| the same store with an already frozen key   | 0.37 s |  0.34 s |
| the same store with an `Integer` key        | 0.29 s |  0.29 s |
| insert then delete, one unfrozen key        | 1.12 s |  1.07 s |

The noise floor on this host is worth about 5%, which is where the three control rows sit; the two store rows are a third off and show up in both measurements.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `size -A`, gcc, both sides built from an empty directory at the same path with `rake`; base is master 50514b23f.

| build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,383,222 | 1,383,206 |   -16 |
| ascii-ctype      | 1,367,590 | 1,367,574 |   -16 |
| byte-string      | 1,345,142 | 1,345,126 |   -16 |
| cxx_abi          | 1,416,825 | 1,416,793 |   -32 |
| no-float         | 1,309,150 | 1,309,102 |   -48 |
| no-bigint        | 1,267,862 | 1,267,846 |   -16 |
| full-debug (-O0) | 1,974,982 | 1,975,078 |   +96 |

All of it is `hash.o`, whose `.text` moves by the same amount in every build. The benchmarks above were taken on `build_config/default.rb`, where `bin/mruby` goes from 1,291,646 to 1,291,630 (-16). In that build the copy-and-freeze leaves `mrb_hash_set` (332 to 144 bytes) and `mrb_hash_aset`, which had it inlined (351 to 205), for the insert branches of `ht_set` (1,670 to 1,849) and `ar_set` (2,202 to 2,231). `mrb_hash_except_keys` grows 113 in the other direction: the smaller `mrb_hash_set` crosses gcc's inline threshold there, and the `call mrb_hash_set` in its object becomes the body. At `-O0` nothing is inlined, so the extra call and the barrier are added rather than moved.

## Testing

- host (`build_config/default.rb`, gcc): mrbtest 2,623 (OK 2,556 / Skip 67) / bintest 130 (OK 129 / Skip 1), KO 0 / Crash 0
- `build_config/ci/gcc-clang.rb`, seven builds, gcc: mrbtest KO 0 / Crash 0 in every build, bintest 147 (OK 146 / Skip 1). `full-debug` builds with `MRB_GC_STRESS`, which is what exercises the barrier on the copy
- `build_config/host-debug.rb` with clang 23.1.0: mrbtest 2,867 (OK 2,856 / Skip 11) / bintest 147 (OK 146 / Skip 1), KO 0 / Crash 0, no warning from `hash.c`
- the `Hash#[]=` and `Hash#store` tests in `test/t/hash.rb` carry no guard, so the added case runs in every build above, against both an AR hash and an HT hash
- a script covering a hash literal, `Hash[]`, `Hash#[]=`, `Hash#store`, `Hash#merge`, `Hash#update`, a delete followed by a re-insert, an insert into an HT hash, an update of each representation, and a key that arrives frozen, prints the same eleven `ok` lines on both binaries
- `prek run` on the commit

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Ubuntu 24.04.4, Linux 7.0.0-31-generic x86_64      |
| CPU        | AMD Ryzen 9 5950X                                  |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| clang      | Homebrew clang 23.1.0                              |
| binutils   | GNU ld 2.47.20260726                               |
| valgrind   | valgrind-3.27.1                                    |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `src/hash.c` from `rake --verbose` in each build, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
host:        gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/hash.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/hash.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/hash.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating an existing hash entry with a string key now preserves the original key object.
  * Overwriting a value no longer changes the hash size or unexpectedly freezes or duplicates the caller’s string key.
  * Hash key behavior is now correctly documented and verified by tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->