### PR TITLE
mruby-compiler: look presym ids up instead of deriving them from an offset

### DIFF
--- a/mrbgems/mruby-compiler/include/mrc_presym.h
+++ b/mrbgems/mruby-compiler/include/mrc_presym.h
@@ -13,12 +13,12 @@ enum mrc_opsym {
 #undef MRC_SYM_2
 };
 
-#define MRC_OPSYM_2(name) mrc_sym_offset(MRC_OPSYM_2__##name)
-#define MRC_SYM_1(name)   mrc_sym_offset(MRC_SYM_1__##name)
-#define MRC_SYM_2(name)   mrc_sym_offset(MRC_SYM_2__##name)
+#define MRC_OPSYM_2(name) mrc_presym_id(MRC_OPSYM_2__##name)
+#define MRC_SYM_1(name)   mrc_presym_id(MRC_SYM_1__##name)
+#define MRC_SYM_2(name)   mrc_presym_id(MRC_SYM_2__##name)
 
 void mrc_init_presym(pm_constant_pool_t *pool);
-mrc_sym mrc_sym_offset(mrc_sym sym);
+mrc_sym mrc_presym_id(mrc_sym sym);
 
 MRC_END_DECL
 

--- a/mrbgems/mruby-compiler/src/mrc_presym.c
+++ b/mrbgems/mruby-compiler/src/mrc_presym.c
@@ -22,24 +22,30 @@ static mrc_sym_entry symTable[] = {
   {0, NULL} // sentinel
 };
 
-static uint32_t offset = 0;
+/* mrc_presym.inc numbers its literals from 1 in table order, which is what
+   lets the enum in mrc_presym.h index this array; slot 0 stays unused. */
+static mrc_sym presym_ids[sizeof(symTable) / sizeof(symTable[0])];
 
-mrc_sym mrc_sym_offset(mrc_sym sym)
+mrc_sym
+mrc_presym_id(mrc_sym sym)
 {
-  return sym + offset;
+  mrc_assert(0 < sym && sym < sizeof(presym_ids) / sizeof(presym_ids[0]));
+  return presym_ids[sym];
 }
 
 void
 mrc_init_presym(pm_constant_pool_t *pool)
 {
-  offset = pool->size;
+  /* The pool is not necessarily empty here: when the compile context carries
+     enclosing scopes (an eval or a binding), the parser has already interned
+     those scopes' local names, and a local can be named after a presym
+     literal; an anonymous rest parameter is stored under the name `*`. The
+     insert then hands back the id that name already has, so the presym ids
+     are not contiguous and have to be recorded one by one. */
   for (int i = 0; ; i++) {
     if (symTable[i].lit == NULL) { break; }
-#ifdef MRC_DEBUG
-    pm_constant_id_t id = pm_constant_pool_insert_constant(pool, (const uint8_t *)symTable[i].lit, strlen(symTable[i].lit));
-    mrc_assert(id == symTable[i].index + offset);
-#else
-    pm_constant_pool_insert_constant(pool, (const uint8_t *)symTable[i].lit, strlen(symTable[i].lit));
-#endif
+    mrc_assert(symTable[i].index == i + 1);
+    presym_ids[symTable[i].index] =
+      (mrc_sym)pm_constant_pool_insert_constant(pool, (const uint8_t *)symTable[i].lit, strlen(symTable[i].lit));
   }
 }

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -250,3 +250,21 @@ assert('symbol GC keeps the names of live global variables') do
 
   assert_true global_variables.include?("$symbol_gc_eval_global".to_sym)
 end
+
+assert('eval in a scope whose locals are named after a presym literal') do
+  # An anonymous rest parameter is recorded under the local name `*`, which is
+  # also one of the compiler's presym literals. Parsing the eval interns the
+  # enclosing scope's local names into the constant pool first, so `*` is
+  # already there when the presym literals go in and they no longer land on
+  # consecutive pool ids. The compiler used to derive every presym id from one
+  # offset, which gave each presym past `*` the id of its neighbour, so
+  # `StandardError` resolved to `call` and `each` to `__case_eqq`.
+  q = 1
+  results = []
+  [11].each { |*|
+    results << eval("begin; raise 'x'; rescue => e; 'caught'; end")
+    results << eval("s = 0; for i in [1, 2, 3]; s += i; end; s")
+    results << eval("q")
+  }
+  assert_equal ['caught', 6, 1], results
+end


### PR DESCRIPTION
## Summary

`mrc_init_presym()` derived every presym id by adding the pool size it read before the first insert, which is only correct while the pool holds none of the presym literals. Parsing an `eval` or a `binding` interns the enclosing scopes' local names first, and an anonymous parameter is stored under the name its operator spells, so `*`, `&` and `**` can already be there. Recording the id each insert returns removes the assumption.

## Changes

| File                                          | What                                                                                          |
| --------------------------------------------- | --------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/include/mrc_presym.h` | `mrc_sym_offset()` becomes `mrc_presym_id()`; the three lookup macros follow it               |
| `mrbgems/mruby-compiler/src/mrc_presym.c`     | the `offset` static becomes a `presym_ids[]` table filled from each insert's return value     |
| `mrbgems/mruby-eval/test/eval.rb`             | a case that evaluates `rescue`, `for` and a plain local lookup inside a `{ \|*\| ... }` block |

### The pool is not empty when the presym literals go in

`mrc_init_presym()` runs from `mrc_pm_parser_init()` right after `pm_parser_init()`. When the compile context carries enclosing scopes, `pm_parser_init()` writes those scopes' local names into the constant pool, so the pool already holds entries before the first presym literal is inserted. That much the offset accounted for, since it was read at the same point.

What it did not account for is a collision. An anonymous parameter is recorded under the local name its operator spells, and all three of those names are presym literals as well; they are the names `search_upvar()` reports on in `codegen.c`:

| parameter   | local name | presym literal                |
| ----------- | ---------- | ----------------------------- |
| `def m(&)`  | `&`        | `MRC_OPSYM_2(and)`, number 5  |
| `def m(**)` | `**`       | `MRC_OPSYM_2(pow)`, number 9  |
| `def m(*)`  | `*`        | `MRC_OPSYM_2(mul)`, number 12 |

`pm_constant_pool_insert_constant()` hands back the id such a name already has, so the literal does not land where `index + offset` says it does, and every literal after it is off by one. Printing each insert's return value next to what the assertion expects, for an `eval` inside a `{ |*| ... }` block:

```
PRESYM MISMATCH: lit=* number=12 offset=2 got_id=2  expected=14
PRESYM MISMATCH: lit=/ number=13 offset=2 got_id=14 expected=15
...
PRESYM MISMATCH: lit=each number=22 offset=2 got_id=23 expected=24
PRESYM MISMATCH: lit=__case_eqq number=23 offset=2 got_id=24 expected=25
PRESYM MISMATCH: lit=StandardError number=24 offset=2 got_id=25 expected=26
PRESYM MISMATCH: lit=call number=25 offset=2 got_id=26 expected=27
```

`*` is the one literal that was already in the pool, and the only one whose `got_id` is not exactly one below its `expected`. Reading `StandardError` as `24 + 2` therefore lands on `call`, and `each` as `22 + 2` lands on `__case_eqq`.

### The assertion was the only thing that noticed

Under `MRC_DEBUG` this fires as

```
mruby: mrbgems/mruby-compiler/src/mrc_presym.c:40: mrc_init_presym: Assertion `id == symTable[i].index + offset' failed.
```

Of the seven `build_config/ci/gcc-clang.rb` builds only `full-debug` defines `MRC_DEBUG`. In the other six, and in a default `rake` build, the ids are still wrong, just silently: every presym past the collision takes the id of its neighbour and the `eval` miscompiles.

### The fix

Record the id each insert returns in a lookup table and have the accessor read it back, which is correct whether or not the literal was already in the pool. The accessor is renamed `mrc_presym_id()` because it no longer offsets anything; only the three macros in `mrc_presym.h` call it.

The assertion is kept, restated as the invariant that is actually ours rather than an assumption about the pool: the numbers in `mrc_presym.inc` run from 1 in table order, which is what makes the enum in `mrc_presym.h` usable as an index into the table.

## Behaviour

On `master`, plain `rake` build, all three anonymous-parameter shapes break every `eval` in their scope:

```ruby
E = "begin; raise 'x'; rescue => e; 'caught'; end"

def star(*)  ; p [:star,  eval(E)] ; end
def amp(&)   ; p [:amp,   eval(E)] ; end
def kw(**)   ; p [:kw,    eval(E)] ; end
def named(y) ; p [:named, eval(E)] ; end

star; amp {}; kw; named 1
# master:  the first three raise NameError: uninitialized constant call
#          [:named, "caught"]
# this PR: [:star, "caught"], [:amp, "caught"], [:kw, "caught"], [:named, "caught"]
```

A `rescue` with no class named looks up `StandardError`, which is where the shifted id turns into that message. A `for` loop in the same position calls a method the receiver does not have, for the same reason:

```ruby
def m
  q = 1
  [11].each { |*|
    p((eval("s = 0; for i in [1, 2, 3]; s += i; end; s") rescue "FAIL"))
    p((eval("q") rescue "FAIL"))
  }
end
m
# master:  "FAIL", 1
# this PR: 6,      1
```

The plain local lookup works either way: the ids it needs sit before the collision.

## Size

`bin/mruby` `.text` from `size -A`, `build_config/ci/gcc-clang.rb` with `CC=gcc CXX=g++ LD=gcc`, empty build dirs, both refs measured in the same worktree path, base `50514b23f`.

| build              |    master |   this PR | delta |
| ------------------ | --------: | --------: | ----: |
| `bintest`          | 1,383,222 | 1,383,254 |   +32 |
| `ascii-ctype`      | 1,367,590 | 1,367,622 |   +32 |
| `byte-string`      | 1,345,142 | 1,345,174 |   +32 |
| `cxx_abi`          | 1,416,825 | 1,416,857 |   +32 |
| `no-float`         | 1,309,150 | 1,309,182 |   +32 |
| `no-bigint`        | 1,267,862 | 1,267,894 |   +32 |
| `full-debug` (-O0) | 1,974,982 | 1,975,078 |   +96 |

All of it is `mrc_presym.o`: `.text` 104 to 131 in the six `-O3` builds and 257 to 350 in `full-debug`, plus `.bss` 4 to 212 in every build, which is the table of 53 `mrc_sym` replacing the single `uint32_t` `offset`.

## Testing

`rake -m test` with gcc 13.3.0, 0 KO and 0 crashes in every suite:

| config         | build                   | total |  KO | Crash |
| -------------- | ----------------------- | ----: | --: | ----: |
| default        | `host`                  | 2,624 |   0 |     0 |
| default        | bintest                 |   130 |   0 |     0 |
| `ci/gcc-clang` | `bintest`               | 2,868 |   0 |     0 |
| `ci/gcc-clang` | `bintest` command tests |   147 |   0 |     0 |
| `ci/gcc-clang` | `ascii-ctype`           | 2,856 |   0 |     0 |
| `ci/gcc-clang` | `byte-string`           | 2,784 |   0 |     0 |
| `ci/gcc-clang` | `cxx_abi`               | 2,868 |   0 |     0 |
| `ci/gcc-clang` | `no-float`              | 2,603 |   0 |     0 |
| `ci/gcc-clang` | `no-bigint`             | 2,822 |   0 |     0 |
| `ci/gcc-clang` | `full-debug`            | 2,868 |   0 |     0 |

The `ci/gcc-clang` set was run a second time under clang 23.1.0, with the same totals and the same 0 KO / 0 Crash.

Reverting only the two compiler files, the new case fails on a release build as well, so it is not merely an assertion guard:

```
NameError: eval in a scope whose locals are named after a presym literal => uninitialized constant call (mrbgems: mruby-eval)
```

It lives in `mrbgems/mruby-eval/test/` rather than under `mrbgems/mruby-compiler/test/`, whose test state has neither `eval` nor `binding` and so never reaches `pm_parser_init()` with enclosing scopes.

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Ubuntu 24.04.4, Linux 7.0.0-31-generic x86_64      |
| CPU        | AMD Ryzen 9 5950X                                  |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| clang      | Homebrew clang 23.1.0                              |
| binutils   | GNU ld 2.47.20260726                               |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines of `mrbgems/mruby-compiler/src/mrc_presym.c` from `rake --verbose` in each build, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/mrc_presym.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/mrc_presym.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `eval` could produce incorrect results when used inside a scope with an anonymous rest parameter named `*`.
  - Improved handling of symbol identifiers during compilation, making symbol processing more reliable across different configurations.

- **Tests**
  - Added coverage for `eval` expressions involving exception handling, loops, and local-variable access in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->