### PR TITLE
mruby-regexp: no walk over a pattern's program spends C stack in proportion to it

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -232,7 +232,9 @@ Two engines, chosen automatically at compile time by pattern analysis.
 
 - **Pike VM (NFA simulation)** for patterns without backreferences, non-greedy
   quantifiers, lookaround, atomic groups, absent repeaters, conditionals or
-  subexpression calls. O(pattern x text), so it is immune to ReDoS.
+  subexpression calls. O(pattern x text), so it is immune to ReDoS. The branch
+  a fork leaves for later waits on a stack the search owns, so a step spends a
+  constant amount of C stack however often the pattern forks.
 - **Backtracking engine** for the rest, whose state the Pike VM's threads have
   no stack to hold. It backtracks on a heap stack of its own, so a search
   spends a constant amount of C stack however long the subject is. Bounded by
@@ -388,6 +390,12 @@ A build that cannot make the allocation raises `NoMemoryError`. A nested
 character class is the one construct still read by recursion, at about 500
 bytes of C stack a level, which the class table bounds at 256 levels whatever
 the limit.
+
+The passes that read the finished program keep their branches on stacks of
+their own as well: the anchor and first-byte scans, the marks on the
+repetitions that can run empty, and the width of a lookbehind. What a compile
+spends on the C stack follows neither the pattern's length nor how often it
+forks.
 
 ### What the build decides
 

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -1905,44 +1905,67 @@ typedef struct {
 #define RE_FLEN_BUSY (-2)   /* being measured: reaching it again is a cycle,
                                and a cycle is a body of no fixed width */
 
-static int fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end,
-                          int *chars_out, int depth,
-                          re_flen_memo *memo, uint32_t memo_base,
-                          uint32_t memo_len);
 static int fixed_len_span(re_compiler *c, uint32_t start, uint32_t end,
                           int *chars_out, int depth);
 
-/* The measure from `pc` to `end`, remembered under the table when `pc` is one
-   the table covers. Without it a chain of forks is measured once per path
-   through it, both arms of every fork walking the whole tail, and `(?:a|b)`
-   thirty times over is 2^30 walks of a pattern a hundred bytes long. */
-static int
-fixed_len_at(re_compiler *c, uint32_t pc, uint32_t end, int *chars_out,
-             int depth, re_flen_memo *memo, uint32_t memo_base,
-             uint32_t memo_len)
+/* A measure the walk left standing while it takes another. A fork is two
+   measures of its own and the walk can only answer once both are in, so what
+   it had taken before the fork waits here, with what the first arm answered
+   once that is known, and a pc the table covers waits here to be filled from
+   the measure it asked for. */
+#define FLEN_MEMO  0   /* fill this pc's slot with what comes back */
+#define FLEN_ARM_A 1   /* the fork's first arm is being measured */
+#define FLEN_ARM_B 2   /* its second, with the first's measure in hand */
+
+typedef struct {
+  uint32_t pc;      /* MEMO: the pc measured. ARM_A: the fork itself. */
+  int32_t len;      /* the arms: the measure taken before the fork */
+  int32_t chars;
+  int32_t a_len;    /* ARM_B: what the first arm answered */
+  int32_t a_chars;
+  uint8_t kind;
+} flen_frame;
+
+typedef struct {
+  flen_frame *at;      /* `given` until the walk outgrows it, the heap after */
+  flen_frame *given;   /* the room the caller carved out, and never freed */
+  uint32_t top;
+  uint32_t capa;
+} flen_stack;
+
+/* Room for one more measure, once the room the caller gave is all in use.
+   FALSE is the allocator having refused it, which the walk reports as a body
+   of no fixed width, the answer it gives for everything else it cannot
+   measure (see fixed_len_span()). */
+static mrb_bool
+flen_grow(mrb_state *mrb, flen_stack *s)
 {
-  if (!memo || pc < memo_base || pc - memo_base >= memo_len) {
-    return fixed_len_walk(c, pc, end, chars_out, depth, memo, memo_base, memo_len);
+  uint32_t capa = s->capa ? s->capa * 2 : 8;
+  flen_frame *p;
+  if (s->at == s->given) {
+    p = (flen_frame*)mrb_malloc_simple(mrb, sizeof(flen_frame) * capa);
+    /* A span the caller found no fork in is given no room at all, and a walk
+       that leaves the span by a jump can still want some: there is nothing to
+       carry over, and memcpy() is owed a pointer whatever the length is. */
+    if (p && s->capa) memcpy(p, s->given, sizeof(flen_frame) * s->capa);
   }
-  re_flen_memo *slot = &memo[pc - memo_base];
-  if (slot->len == RE_FLEN_BUSY) return -1;
-  if (slot->len != RE_FLEN_NEW) {
-    *chars_out = slot->chars;
-    return slot->len;
+  else {
+    p = (flen_frame*)mrb_realloc_simple(mrb, s->at, sizeof(flen_frame) * capa);
   }
-  slot->len = RE_FLEN_BUSY;
-  int chars = 0;
-  int len = fixed_len_walk(c, pc, end, &chars, depth, memo, memo_base, memo_len);
-  if (len < 0) {
-    /* Leave the slot BUSY: a body with one unmeasurable path has no fixed
-       width at all, so no later question about this pc has a different
-       answer, and the compile is about to be refused either way. */
-    return -1;
-  }
-  slot->len = len;
-  slot->chars = chars;
-  *chars_out = chars;
-  return len;
+  if (!p) return FALSE;
+  s->at = p;
+  s->capa = capa;
+  return TRUE;
+}
+
+/* Leave a measure standing. Inline: this stands where the recursive call it
+   replaced stood, in the walk's own loop. */
+static inline mrb_bool
+flen_push(mrb_state *mrb, flen_stack *s, const flen_frame *f)
+{
+  if (s->top == s->capa && !flen_grow(mrb, s)) return FALSE;
+  s->at[s->top++] = *f;
+  return TRUE;
 }
 
 /*
@@ -1952,23 +1975,64 @@ fixed_len_at(re_compiler *c, uint32_t pc, uint32_t end, int *chars_out,
  * advances one byte whatever the instruction is, and stores in *chars_out
  * the character count a UTF-8 subject needs. Returns -1 if the sub-pattern
  * has no fixed width (a quantifier, or a fork whose arms disagree).
+ *
+ * A measure the walk cannot finish before taking another stands on `stack`
+ * rather than in a C frame of its own, so a body forking as often as it is
+ * long is measured on the stack any build has: a body of 1,500 `(?:a|a)`
+ * used to need more than 256 KiB of one and 3,000 more than 512 KiB.
+ * What a pc is worth is remembered in the
+ * table `memo` covers, without which a chain of forks is measured once per
+ * path through it, both arms of every fork walking the whole tail, and
+ * `(?:a|b)` thirty times over is 2^30 walks of a pattern a hundred bytes
+ * long.
  */
 static int
 fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
                int depth, re_flen_memo *memo, uint32_t memo_base,
-               uint32_t memo_len)
+               uint32_t memo_len, flen_frame *room, uint32_t room_capa)
 {
   int len = 0;
   int chars = 0;
   uint32_t pc = start;
+  int r_len = 0, r_chars = 0;  /* the measure being handed back */
+  int ret = -1;
+  flen_stack stack;
+  stack.at = stack.given = room;
+  stack.top = 0;
+  stack.capa = room_capa;
 
   /* The walk runs to `end` rather than while it is below it, because a call
      steps outside the span: an inline occurrence of a called group is a jump
      to the trampoline after the pattern and a jump back. The bound below is
      what keeps a walk that misses `end` finite; a cycle without RE_SPLIT does
      not exist, and RE_SPLIT answers -1. */
+  goto walk;  /* the measure asked for here is not one the table holds */
+
+ enter:
+  /* Measure from `pc` to `end`, through the table where it covers this pc:
+     a measure already taken is the answer, one being taken is a cycle and no
+     fixed width, and one not taken yet is left to fill on the way back. */
+  if (memo && pc >= memo_base && pc - memo_base < memo_len) {
+    re_flen_memo *slot = &memo[pc - memo_base];
+    if (slot->len == RE_FLEN_BUSY) goto fail;
+    if (slot->len != RE_FLEN_NEW) {
+      r_len = slot->len;
+      r_chars = slot->chars;
+      goto unwind;
+    }
+    slot->len = RE_FLEN_BUSY;
+    flen_frame f;
+    f.kind = FLEN_MEMO;
+    f.pc = pc;
+    f.len = f.chars = f.a_len = f.a_chars = 0;
+    if (!flen_push(c->mrb, &stack, &f)) goto fail;
+  }
+  len = 0;
+  chars = 0;
+
+ walk:
   while (pc != end) {
-    if (pc >= c->code_len) return -1;
+    if (pc >= c->code_len) goto fail;
     re_inst inst = c->pat->code[pc];
     switch (inst.op) {
     case RE_CHAR: {
@@ -2038,25 +2102,27 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
          A loop closes with a backward fork, so this is also where a body
          that repeats is refused: the memo marks the pc it is measuring and
          reaching it again answers -1. */
-      int a_chars = 0, b_chars = 0;
-      int a = fixed_len_at(c, pc + 1, end, &a_chars, depth, memo, memo_base, memo_len);
-      if (a < 0) return -1;
-      int b = fixed_len_at(c, inst.offset, end, &b_chars, depth, memo, memo_base, memo_len);
-      if (b < 0) return -1;
-      if (a != b || a_chars != b_chars) return -1;
-      *chars_out = chars + a_chars;
-      return len + a;
+      flen_frame f;
+      f.kind = FLEN_ARM_A;
+      f.pc = pc;
+      f.len = len;
+      f.chars = chars;
+      f.a_len = f.a_chars = 0;
+      if (!flen_push(c->mrb, &stack, &f)) goto fail;
+      pc = pc + 1;
+      goto enter;
     }
     case RE_LOOK_END:
-      *chars_out = chars;
-      return len;
+      r_len = len;
+      r_chars = chars;
+      goto unwind;
     case RE_CALL: {
       /* The call runs the body it points at, so the body's measure is this
          instruction's. The depth bound is what answers a recursive call:
          distinct groups nest no deeper than there are groups, so a walk
          past that is going round a cycle, which no fixed length fits --
          CRuby refuses recursion in a lookbehind the same way. */
-      if (depth > RE_MAX_CAPTURES) return -1;
+      if (depth > RE_MAX_CAPTURES) goto fail;
       uint32_t body = inst.offset;
       uint32_t close = body;
       while (close < c->code_len &&
@@ -2064,23 +2130,76 @@ fixed_len_walk(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
                c->pat->code[close].a == inst.a)) {
         close++;
       }
-      if (close >= c->code_len) return -1;
+      if (close >= c->code_len) goto fail;
       int sub_chars = 0;
       /* The body is measured to its own end, so it gets a table of its own:
-         what a pc is worth is its distance to the end being asked about. */
+         what a pc is worth is its distance to the end being asked about. The
+         depth bound above is what keeps this a call and not a walk of its
+         own: a body nests no deeper than there are groups. */
       int sub_len = fixed_len_span(c, body, close, &sub_chars, depth + 1);
-      if (sub_len < 0) return -1;
+      if (sub_len < 0) goto fail;
       len += sub_len;
       chars += sub_chars;
       pc++;
       break;
     }
     default:
-      return -1;  /* unknown/variable-length instruction */
+      goto fail;  /* unknown/variable-length instruction */
     }
   }
-  *chars_out = chars;
-  return len;
+  r_len = len;
+  r_chars = chars;
+
+ unwind:
+  /* Hand the measure to whatever was left standing for it. */
+  if (stack.top == 0) {
+    *chars_out = r_chars;
+    ret = r_len;
+    goto done;
+  }
+  {
+    flen_frame *f = &stack.at[--stack.top];
+    switch (f->kind) {
+    case FLEN_MEMO: {
+      re_flen_memo *slot = &memo[f->pc - memo_base];
+      slot->len = r_len;
+      slot->chars = r_chars;
+      goto unwind;
+    }
+    case FLEN_ARM_A: {
+      /* The first arm is measured; keep it and measure the second, which the
+         fork's offset opens. */
+      flen_frame b;
+      b.kind = FLEN_ARM_B;
+      b.pc = f->pc;
+      b.len = f->len;
+      b.chars = f->chars;
+      b.a_len = r_len;
+      b.a_chars = r_chars;
+      uint32_t arm = c->pat->code[f->pc].offset;
+      if (!flen_push(c->mrb, &stack, &b)) goto fail;
+      pc = arm;
+      goto enter;
+    }
+    default: {  /* FLEN_ARM_B */
+      if (r_len != f->a_len || r_chars != f->a_chars) goto fail;
+      r_len = f->len + f->a_len;
+      r_chars = f->chars + f->a_chars;
+      goto unwind;
+    }
+    }
+  }
+
+ fail:
+  /* A slot left BUSY is one whose measure was refused: a body with one
+     unmeasurable path has no fixed width at all, so no later question about
+     that pc has a different answer, and the compile is about to be refused
+     either way. */
+  ret = -1;
+
+ done:
+  if (stack.at != room) mrb_free(c->mrb, stack.at);
+  return ret;
 }
 
 /* Measure [start, end) with whatever table the span needs. A span holding no
@@ -2102,17 +2221,32 @@ fixed_len_span(re_compiler *c, uint32_t start, uint32_t end, int *chars_out,
       break;
     }
   }
-  if (!needs_memo) return fixed_len_walk(c, start, end, chars_out, depth, NULL, 0, 0);
+  /* A span with no fork and no table has nothing to leave standing either:
+     what the walk keeps is a fork's other arm and a pc whose slot is to be
+     filled, and this span holds neither. */
+  if (!needs_memo) {
+    return fixed_len_walk(c, start, end, chars_out, depth, NULL, 0, 0, NULL, 0);
+  }
 
   uint32_t span = end > start ? end - start : 0;
-  /* mrb_malloc_simple(), not mrb_malloc(): a raise here would longjmp past
+  uint32_t slots = span ? span : 1;
+  /* The measures the walk leaves standing are carved out of the same block
+     as the table, so measuring a span asks the allocator once: a slot to
+     fill and an arm to take are one apiece per pc the walk stands on, and
+     the walk grows its own stack where a path it did not expect wants more.
+
+     mrb_malloc_simple(), not mrb_malloc(): a raise here would longjmp past
      the frees of the spans measuring around this one. A refusal is reported
      as a body of no fixed width, which is what the caller does with every
      other answer it cannot use. */
-  re_flen_memo *memo = (re_flen_memo*)mrb_malloc_simple(c->mrb, sizeof(re_flen_memo) * (span ? span : 1));
+  uint32_t room = slots + 8;
+  if (room > 1024) room = 1024;  /* past a body of this size, let it grow */
+  re_flen_memo *memo = (re_flen_memo*)mrb_malloc_simple(
+      c->mrb, sizeof(re_flen_memo) * slots + sizeof(flen_frame) * room);
   if (!memo) return -1;
   for (uint32_t i = 0; i < span; i++) memo[i].len = RE_FLEN_NEW;
-  int len = fixed_len_walk(c, start, end, chars_out, depth, memo, start, span);
+  int len = fixed_len_walk(c, start, end, chars_out, depth, memo, start, span,
+                           (flen_frame*)(memo + slots), room);
   mrb_free(c->mrb, memo);
   return len;
 }

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -4224,79 +4224,108 @@ has_named_group(const char *src, mrb_int len)
   return FALSE;
 }
 
+/* Instructions the anchor and first-byte walks mark and keep pcs for without
+   asking the allocator for room. A program this long or shorter is scanned
+   from the frame of the scan that calls them, which is most of what a pattern
+   spells: the marks and the pcs are five bytes an instruction. */
+#define RE_WALK_INLINE 128
+
+/* A walk's marks and the pcs it has yet to take, one apiece per instruction,
+   in one block: the pcs come first, since the marks are bytes and would leave
+   them unaligned. NULL is the allocator having refused, which leaves the scan
+   that asked unbuilt. What these walks answer moves a search along and is
+   nothing a pattern's answer depends on, so a build with nothing left
+   compiles the pattern and scans it the long way. */
+static uint32_t*
+walk_room(mrb_state *mrb, uint32_t n)
+{
+  return (uint32_t*)mrb_malloc_simple(mrb, (size_t)n * (sizeof(uint32_t) + 1));
+}
+
 /*
  * Compute the set of bytes that could be the first consumed byte of a match.
  * Walks bytecode from pc=0, following epsilon transitions (SAVE, JMP, SPLIT).
  * Returns TRUE if the set is narrower than "any byte" (i.e., useful for skip).
+ *
+ * Every path has to answer TRUE for the set to be one, so a path that
+ * answers FALSE ends the walk there; the others put their bytes in `bm` and
+ * hand the walk back the branch a fork left on `stack`, newest first, which
+ * is the order taking one in a call of its own gave.
  */
 static mrb_bool
 first_set_walk(const re_inst *code, uint32_t code_len,
                const re_charclass *classes, uint32_t pc,
-               uint8_t *bm, uint8_t *seen)
+               uint8_t *bm, uint8_t *seen, uint32_t *stack)
 {
-  while (pc < code_len) {
-    if (seen[pc]) return TRUE;  /* already visited */
-    seen[pc] = 1;
-    switch (code[pc].op) {
-    case RE_SAVE:
-    case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
-    case RE_WBOUND: case RE_NWBOUND:
-    case RE_ATOMIC: case RE_ATOMIC_END:
-      pc++;
-      continue;  /* zero-width, keep walking */
-    case RE_JMP:
-      pc = code[pc].offset;
-      continue;
-    case RE_CALL:
-      /* The body runs where the call stands, so its first bytes are the
-         call's. What follows a body that can complete without consuming is
-         unknown to this walk, which has no call stack; that path ends at
-         the body's RE_RETURN, whose default below answers FALSE. */
-      pc = code[pc].offset;
-      continue;
-    case RE_SPLIT:
-    case RE_COND:  /* either body may run first; the walk cannot know which */
-      /* both branches: pc+1 and offset */
-      if (!first_set_walk(code, code_len, classes, code[pc].offset, bm, seen))
+  uint32_t top = 0;
+
+  for (;;) {
+    while (pc < code_len) {
+      if (seen[pc]) goto next;  /* already visited */
+      seen[pc] = 1;
+      switch (code[pc].op) {
+      case RE_SAVE:
+      case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
+      case RE_WBOUND: case RE_NWBOUND:
+      case RE_ATOMIC: case RE_ATOMIC_END:
+        pc++;
+        continue;  /* zero-width, keep walking */
+      case RE_JMP:
+        pc = code[pc].offset;
+        continue;
+      case RE_CALL:
+        /* The body runs where the call stands, so its first bytes are the
+           call's. What follows a body that can complete without consuming is
+           unknown to this walk, which has no call stack; that path ends at
+           the body's RE_RETURN, whose default below answers FALSE. */
+        pc = code[pc].offset;
+        continue;
+      case RE_SPLIT:
+      case RE_COND:  /* either body may run first; the walk cannot know which */
+        /* both branches: pc+1 and offset */
+        stack[top++] = pc + 1;
+        pc = code[pc].offset;
+        continue;
+      case RE_SPLITNG:
+        stack[top++] = code[pc].offset;
+        pc = pc + 1;
+        continue;
+      case RE_BYTE:
+        return FALSE;  /* always non-ASCII: bm covers ASCII only */
+      case RE_CHAR:
+        if (code[pc].a >= 128) return FALSE;  /* non-ASCII: bm covers ASCII only */
+        bm[code[pc].a >> 3] |= (1 << (code[pc].a & 7));
+        goto next;
+      case RE_CLASS: {
+        const re_charclass *cc = &classes[code[pc].a];
+        for (int i = 0; i < 16; i++) bm[i] |= cc->bitmap[i];
+        if (!class_is_ascii_only(cc)) return FALSE;  /* non-ASCII possible */
+        goto next;
+      }
+      case RE_NCLASS: {
+        /* negated class: complement of bitmap. Too many bits; not useful. */
         return FALSE;
-      pc++;
-      continue;
-    case RE_SPLITNG:
-      if (!first_set_walk(code, code_len, classes, pc + 1, bm, seen))
+      }
+      case RE_ANY: case RE_ANY_NL:
+        return FALSE;  /* any byte possible */
+      case RE_MATCH:
+        /* Reaching MATCH via epsilon transitions means the regex can match
+           zero characters at any position. Skipping bytes that aren't in the
+           first-byte set would skip past valid empty-match positions, so the
+           optimization isn't safe -- bail out and accept any starting byte. */
         return FALSE;
-      pc = code[pc].offset;
-      continue;
-    case RE_BYTE:
-      return FALSE;  /* always non-ASCII: bm covers ASCII only */
-    case RE_CHAR:
-      if (code[pc].a >= 128) return FALSE;  /* non-ASCII: bm covers ASCII only */
-      bm[code[pc].a >> 3] |= (1 << (code[pc].a & 7));
-      return TRUE;
-    case RE_CLASS: {
-      const re_charclass *cc = &classes[code[pc].a];
-      for (int i = 0; i < 16; i++) bm[i] |= cc->bitmap[i];
-      if (!class_is_ascii_only(cc)) return FALSE;  /* non-ASCII possible */
-      return TRUE;
+      default:
+        return FALSE;
+      }
     }
-    case RE_NCLASS: {
-      /* negated class: complement of bitmap. Too many bits; not useful. */
-      return FALSE;
-    }
-    case RE_ANY: case RE_ANY_NL:
-      return FALSE;  /* any byte possible */
-    case RE_MATCH:
-      /* Reaching MATCH via epsilon transitions means the regex can match
-         zero characters at any position. Skipping bytes that aren't in the
-         first-byte set would skip past valid empty-match positions, so the
-         optimization isn't safe -- bail out and accept any starting byte. */
-      return FALSE;
-    default:
-      return FALSE;
-    }
+    /* Walked off the end without hitting MATCH or a consuming op. Treat as
+       empty-matchable, same as RE_MATCH. */
+    return FALSE;
+
+  next:
+    if (top == 0) return TRUE;
+    pc = stack[--top];
   }
-  /* Walked off the end without hitting MATCH or a consuming op. Treat as
-     empty-matchable, same as RE_MATCH. */
-  return FALSE;
 }
 
 /*
@@ -4310,46 +4339,85 @@ first_set_walk(const re_inst *code, uint32_t code_len,
  * own before the join (one before it would have been the walk's answer
  * already), so its value is the join's, which the visit that explored the
  * join contributed.
+ *
+ * The branch of a fork the walk has yet to take waits on `stack`, newest
+ * first, and every branch that ends folds its value into the answer. NONE
+ * ends the whole walk where the recursion returned it up: what it says is
+ * that a path asserts nothing, and no other path can make up for it.
  */
 static uint8_t
-anchor_walk(const re_inst *code, uint32_t code_len, uint32_t pc, uint8_t *seen)
+anchor_walk(const re_inst *code, uint32_t code_len, uint32_t pc, uint8_t *seen,
+            uint32_t *stack)
 {
-  while (pc < code_len) {
-    if (seen[pc]) return RE_ANCHOR_BOT;
-    seen[pc] = 1;
-    switch (code[pc].op) {
-    case RE_BOT:
-      return RE_ANCHOR_BOT;
-    case RE_BOL:
-      return RE_ANCHOR_BOL;
-    case RE_SAVE:
-    case RE_EOL: case RE_EOT: case RE_EOTNL:
-    case RE_WBOUND: case RE_NWBOUND:
-    case RE_ATOMIC: case RE_ATOMIC_END:
-      pc++;
-      continue;
-    case RE_JMP:
-      pc = code[pc].offset;
-      continue;
-    case RE_CALL:
-      /* The body runs where the call stands, as in first_set_walk(); a body
-         that completes without consuming ends at its RE_RETURN, whose
-         default answers NONE. */
-      pc = code[pc].offset;
-      continue;
-    case RE_SPLIT:
-    case RE_SPLITNG:
-    case RE_COND: {  /* a fork to this walk: both bodies are paths */
-      uint8_t other = anchor_walk(code, code_len, code[pc].offset, seen);
-      if (other == RE_ANCHOR_NONE) return RE_ANCHOR_NONE;
-      uint8_t mine = anchor_walk(code, code_len, pc + 1, seen);
-      return mine < other ? mine : other;
+  uint8_t best = RE_ANCHOR_BOT;  /* the neutral value for the min */
+  uint32_t top = 0;
+  uint8_t here;
+
+  for (;;) {
+    while (pc < code_len) {
+      if (seen[pc]) { here = RE_ANCHOR_BOT; goto joined; }
+      seen[pc] = 1;
+      switch (code[pc].op) {
+      case RE_BOT:
+        here = RE_ANCHOR_BOT;
+        goto joined;
+      case RE_BOL:
+        here = RE_ANCHOR_BOL;
+        goto joined;
+      case RE_SAVE:
+      case RE_EOL: case RE_EOT: case RE_EOTNL:
+      case RE_WBOUND: case RE_NWBOUND:
+      case RE_ATOMIC: case RE_ATOMIC_END:
+        pc++;
+        continue;
+      case RE_JMP:
+        pc = code[pc].offset;
+        continue;
+      case RE_CALL:
+        /* The body runs where the call stands, as in first_set_walk(); a body
+           that completes without consuming ends at its RE_RETURN, whose
+           default answers NONE. */
+        pc = code[pc].offset;
+        continue;
+      case RE_SPLIT:
+      case RE_SPLITNG:
+      case RE_COND:  /* a fork to this walk: both bodies are paths */
+        stack[top++] = pc + 1;
+        pc = code[pc].offset;
+        continue;
+      default:
+        return RE_ANCHOR_NONE;
+      }
     }
-    default:
-      return RE_ANCHOR_NONE;
-    }
+    return RE_ANCHOR_NONE;
+
+  joined:
+    if (here < best) best = here;
+    if (top == 0) return best;
+    pc = stack[--top];
   }
-  return RE_ANCHOR_NONE;
+}
+
+/* The anchor of the program, with the room anchor_walk() needs. */
+static uint8_t
+compute_anchor(mrb_state *mrb, const re_inst *code, uint32_t code_len)
+{
+  uint32_t n = code_len + 1;
+  uint32_t pcs[RE_WALK_INLINE];
+  uint8_t marks[RE_WALK_INLINE];
+  uint32_t *heap = NULL;
+  uint32_t *stack = pcs;
+  uint8_t *seen = marks;
+  if (n > RE_WALK_INLINE) {
+    heap = walk_room(mrb, n);
+    if (!heap) return RE_ANCHOR_NONE;
+    stack = heap;
+    seen = (uint8_t*)(heap + n);
+  }
+  memset(seen, 0, n);
+  uint8_t anchor = anchor_walk(code, code_len, 0, seen, stack);
+  mrb_free(mrb, heap);
+  return anchor;
 }
 
 /* TRUE when a path that need not consume runs from pc to goal, so the
@@ -4366,46 +4434,59 @@ anchor_walk(const re_inst *code, uint32_t code_len, uint32_t pc, uint8_t *seen)
    finite, and the answer stays conservative: what a stray path can add is a
    mark on a loop whose body cannot in fact match empty, and a marked loop
    whose iterations all consume never triggers the handling the mark turns
-   on. */
+   on.
+
+   `stack` holds the branch of each fork the walk has still to take, newest
+   first, which is the order following one in a call of its own gave. A pc
+   goes on it only where the walk marked a fork, and a mark is made once,
+   so the caller's code_len entries are room enough for any pattern. */
 static mrb_bool
 epsilon_path(const re_inst *code, uint32_t code_len, uint32_t pc, uint32_t goal,
-             uint32_t *seen, uint32_t mark)
+             uint32_t *seen, uint32_t mark, uint32_t *stack)
 {
-  while (pc != goal) {
-    if (pc >= code_len || seen[pc] == mark) return FALSE;
-    seen[pc] = mark;
-    switch (code[pc].op) {
-    case RE_SAVE:
-    case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
-    case RE_WBOUND: case RE_NWBOUND:
-    case RE_ATOMIC: case RE_ATOMIC_END:
-    case RE_BACKREF:
-    case RE_CALL:
-    case RE_ABSENT_START:
-      pc++;
-      break;
-    case RE_JMP:
-    case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
-    case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
-    /* An absent repeater takes no text where its body matches at the
-       position it began at, so a repetition around one has a body that can
-       match empty and needs the handling this pass turns on. The body of
-       the absent is not on the path: it is a test the scan runs, not text
-       the search passes through. */
-    case RE_ABSENT:
-      pc = code[pc].offset;
-      break;
-    case RE_SPLIT:
-    case RE_SPLITNG:
-    case RE_COND:  /* either body may be the one that runs */
-      if (epsilon_path(code, code_len, code[pc].offset, goal, seen, mark)) return TRUE;
-      pc++;
-      break;
-    default:
-      return FALSE;  /* consumes input */
+  uint32_t top = 0;
+
+  for (;;) {
+    while (pc != goal) {
+      if (pc >= code_len || seen[pc] == mark) goto next;
+      seen[pc] = mark;
+      switch (code[pc].op) {
+      case RE_SAVE:
+      case RE_BOL: case RE_EOL: case RE_BOT: case RE_EOT: case RE_EOTNL:
+      case RE_WBOUND: case RE_NWBOUND:
+      case RE_ATOMIC: case RE_ATOMIC_END:
+      case RE_BACKREF:
+      case RE_CALL:
+      case RE_ABSENT_START:
+        pc++;
+        break;
+      case RE_JMP:
+      case RE_LOOKAHEAD: case RE_NEG_LOOKAHEAD:
+      case RE_LOOKBEHIND: case RE_NEG_LOOKBEHIND:
+      /* An absent repeater takes no text where its body matches at the
+         position it began at, so a repetition around one has a body that can
+         match empty and needs the handling this pass turns on. The body of
+         the absent is not on the path: it is a test the scan runs, not text
+         the search passes through. */
+      case RE_ABSENT:
+        pc = code[pc].offset;
+        break;
+      case RE_SPLIT:
+      case RE_SPLITNG:
+      case RE_COND:  /* either body may be the one that runs */
+        stack[top++] = pc + 1;
+        pc = code[pc].offset;
+        break;
+      default:
+        goto next;  /* consumes input */
+      }
     }
+    return TRUE;
+
+  next:
+    if (top == 0) return FALSE;
+    pc = stack[--top];
   }
-  return TRUE;
 }
 
 /* Find the repetitions whose body can match empty and mark the backward edge
@@ -4421,14 +4502,15 @@ epsilon_path(const re_inst *code, uint32_t code_len, uint32_t pc, uint32_t goal,
 static uint8_t
 mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
 {
-  /* One block holds both arrays. Asking twice puts a raising call between the
-     first allocation and anything that could free it: mrb_calloc() raises
-     when it cannot answer, and this frame is the only owner `delta` has.
-     code_len is capped at RE_MAX_CODE_LEN, so the doubled element count stays
+  /* One block holds all three arrays. Asking three times puts a raising call
+     between the first allocation and anything that could free it: mrb_calloc()
+     raises when it cannot answer, and this frame is the only owner `delta` has.
+     code_len is capped at RE_MAX_CODE_LEN, so the tripled element count stays
      well inside the overflow check mrb_calloc() makes. */
   uint32_t n = code_len + 1;
-  int32_t *delta = (int32_t*)mrb_calloc(mrb, 2 * (size_t)n, sizeof(int32_t));
+  int32_t *delta = (int32_t*)mrb_calloc(mrb, 3 * (size_t)n, sizeof(int32_t));
   uint32_t *seen = (uint32_t*)(delta + n);
+  uint32_t *stack = seen + n;  /* the forks epsilon_path() has yet to take */
   uint32_t mark = 0;
 
   for (uint32_t pc = 0; pc < code_len; pc++) {
@@ -4446,7 +4528,7 @@ mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
     if (in.op != RE_JMP && in.op != RE_SPLIT && in.op != RE_SPLITNG) continue;
     code[pc].a = 0;                /* this pass owns `a` on the edge opcodes */
     if (in.offset > pc) continue;  /* forward edge: alternation, not a loop */
-    if (!epsilon_path(code, code_len, in.offset, pc, seen, ++mark)) continue;
+    if (!epsilon_path(code, code_len, in.offset, pc, seen, ++mark, stack)) continue;
     code[pc].a = 1;
     if (in.op == RE_JMP) {
       /* The head was passed earlier in this scan, so its mark stays. */
@@ -4467,14 +4549,25 @@ mark_empty_loops(mrb_state *mrb, re_inst *code, uint32_t code_len)
 }
 
 static mrb_bool
-compute_first_set(const re_inst *code, uint32_t code_len,
+compute_first_set(mrb_state *mrb, const re_inst *code, uint32_t code_len,
                   const re_charclass *classes, uint8_t *bm)
 {
-  uint8_t seen[4096];
-  if (code_len >= sizeof(seen)) return FALSE;  /* pattern too large */
-  memset(seen, 0, code_len + 1);
-  if (!first_set_walk(code, code_len, classes, 0, bm, seen))
-    return FALSE;
+  uint32_t n = code_len + 1;
+  uint32_t pcs[RE_WALK_INLINE];
+  uint8_t marks[RE_WALK_INLINE];
+  uint32_t *heap = NULL;
+  uint32_t *stack = pcs;
+  uint8_t *seen = marks;
+  if (n > RE_WALK_INLINE) {
+    heap = walk_room(mrb, n);
+    if (!heap) return FALSE;
+    stack = heap;
+    seen = (uint8_t*)(heap + n);
+  }
+  memset(seen, 0, n);
+  mrb_bool narrow = first_set_walk(code, code_len, classes, 0, bm, seen, stack);
+  mrb_free(mrb, heap);
+  if (!narrow) return FALSE;
   /* Check if bitmap is all-ones (no benefit to skip) */
   int set_bits = 0;
   for (int i = 0; i < 16; i++) {
@@ -4939,14 +5032,7 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
      skip_to_line_start(). Under \A the string is never scanned at all, which
      is why a pattern carrying it leaves the prefix and the first-byte set
      below unbuilt: they exist to move a scan along, and there is none. */
-  pat->anchor = RE_ANCHOR_NONE;
-  {
-    uint8_t seen[4096];
-    if (code_len < sizeof(seen)) {
-      memset(seen, 0, code_len + 1);
-      pat->anchor = anchor_walk(pat->code, code_len, 0, seen);
-    }
-  }
+  pat->anchor = compute_anchor(mrb, pat->code, code_len);
 
   /* Extract literal prefix for fast search skip.
      Walk bytecode from the start, skipping zero-width instructions,
@@ -5001,7 +5087,8 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   if (pat->anchor != RE_ANCHOR_BOT) {
     uint8_t bm[16];
     memset(bm, 0, sizeof(bm));
-    pat->has_first_bytes = compute_first_set(pat->code, code_len, pat->classes, bm);
+    pat->has_first_bytes = compute_first_set(mrb, pat->code, code_len,
+                                             pat->classes, bm);
     if (pat->has_first_bytes) {
       memcpy(pat->first_bytes, bm, 16);
       /* A set of up to three bytes is also kept enumerated, so the skip can

--- a/mrbgems/mruby-regexp/src/re_exec.c
+++ b/mrbgems/mruby-regexp/src/re_exec.c
@@ -254,6 +254,22 @@ typedef struct {
   int capa;
 } re_threadlist;
 
+/* A branch of a fork the closure has yet to walk: where it starts and what
+   it starts with. The walk carries the higher-priority branch on and keeps
+   the other one of these (see add_thread()). The position is not in here
+   because a closure stands at one: the walk crosses no instruction that
+   consumes, so every branch it keeps begins where the walk began. */
+typedef struct {
+  uint32_t pc;
+  uint32_t key;
+  int cap_slot;
+} re_pending;
+
+/* Branches the state holds without asking the allocator for room. A pattern
+   whose forks nest no deeper than this spends nothing on them, which is
+   every pattern short of the ones written to nest. */
+#define RE_PEND_INLINE 16
+
 /* All Pike VM state */
 typedef struct {
   mrb_state *mrb;
@@ -276,6 +292,11 @@ typedef struct {
   mrb_bool nomem;         /* the allocator refused the search a buffer it
                              needed: it stops and answers RE_NOMEM */
   int *result_caps;       /* best match (ncap ints) */
+  re_pending *pend;       /* branches a closure left for later: pend_inline
+                             until the nesting outgrows it, the heap after */
+  uint32_t pend_top;      /* entries in use, the newest at the top */
+  uint32_t pend_capa;
+  re_pending pend_inline[RE_PEND_INLINE];
 } pike_state;
 
 /* Hand out a capture slot, growing the pool where it has none left. TRUE is
@@ -366,168 +387,238 @@ re_loop_back(pike_state *s, re_inst inst, uint32_t pc, uint32_t key)
   return key < s->key_max ? key + 1 : key;
 }
 
+/* Room for one more branch, once the ones the state holds are all in use.
+   Answers as pool_alloc() does, and for the same reason: FALSE is the
+   allocator having refused the room, which is the search stopping, and the
+   refusal is recorded on the state since the walk that asked for it hands
+   nothing back. Kept out of pend_push() because a pattern reaching it at all
+   is one written to nest. */
+static mrb_bool
+pend_grow(pike_state *s)
+{
+  uint32_t capa = s->pend_capa * 2;
+  re_pending *p;
+  if (s->pend == s->pend_inline) {
+    p = (re_pending*)mrb_malloc_simple(s->mrb, sizeof(re_pending) * capa);
+    if (p) memcpy(p, s->pend_inline, sizeof(re_pending) * s->pend_capa);
+  }
+  else {
+    p = (re_pending*)mrb_realloc_simple(s->mrb, s->pend,
+                                        sizeof(re_pending) * capa);
+  }
+  if (!p) {
+    s->nomem = TRUE;
+    return FALSE;
+  }
+  s->pend = p;
+  s->pend_capa = capa;
+  return TRUE;
+}
+
+/* Keep a fork's lower-priority branch for the walk to come back to. Inline:
+   this stands where the recursive call it replaced stood, in the closure's
+   own loop, and a call of its own is what the walk is here to stop making. */
+static inline mrb_bool
+pend_push(pike_state *s, uint32_t pc, int cap_slot, uint32_t key)
+{
+  if (s->pend_top == s->pend_capa && !pend_grow(s)) return FALSE;
+  re_pending *e = &s->pend[s->pend_top++];
+  e->pc = pc;
+  e->cap_slot = cap_slot;
+  e->key = key;
+  return TRUE;
+}
+
 /* Add thread following epsilon transitions. `key` is s->gen for the first
    pass over this step's closure and one higher per further pass, and
    visited[pc] holds the key of the pass that last walked pc: a later pass may
    re-walk what an earlier one marked, and no key is ever reused by a later
-   step. */
+   step.
+
+   A fork's branches are walked in priority order: the walk carries the
+   higher-priority one on and keeps the other on the state's own stack,
+   coming back to the newest of them whenever the branch it followed ends.
+   That order is the one walking the higher branch in a call of its own gave,
+   and a closure now costs one C frame however deeply the forks it walks
+   nest: 1,000 nested `(?:...)?` used to need more C stack than a 128 KiB
+   build has, and the 4,095 levels the parse depth limit allows more than
+   256 KiB. */
 static void
 add_thread(pike_state *s, re_threadlist *list,
            uint32_t pc, int cap_slot, const char *sp, uint32_t key)
 {
-  for (;;) {
-    /* Both of these end the walk without an answer to hand back: a cut is
-       this step having been settled by a higher-priority thread, and a
-       refused allocation is the search stopping (see pool_alloc()). */
-    if (s->cut || s->nomem) return;
-    if (pc >= s->pat->code_len) return;
-    if (s->visited[pc] >= key) return;
-    s->visited[pc] = key;
+  s->pend_top = 0;
 
-    re_inst inst = s->pat->code[pc];
-    switch (inst.op) {
-    case RE_JMP:
-      /* A backward jump closes a repetition (e*, e{n,}): it returns to the
-         RE_SPLIT/RE_SPLITNG head, whose offset is the loop's exit. `a` is set
-         only when that body can run empty (see mark_empty_loops()), which is
-         the only case with a final empty iteration to account for. */
-      if (inst.offset <= pc && inst.a) {
-        uint32_t head = inst.offset;
-        if (loop_head_seen(s, head)) {
-          /* The head was walked at this position, so the iteration that just
-             finished consumed nothing. Onigmo stops a repetition on an empty
-             iteration and keeps what that iteration captured, so leave the
-             loop from here rather than dying on the head's mark: this path
-             outranks the exit the head itself queued before the body ran, and
-             claims the exit pc first. */
-          pc = s->pat->code[head].offset;
+  for (;;) {
+    for (;;) {
+      /* Both of these end the walk without an answer to hand back: a cut is
+         this step having been settled by a higher-priority thread, and a
+         refused allocation is the search stopping (see pool_alloc()). */
+      if (s->cut || s->nomem) goto leave;
+      if (pc >= s->pat->code_len) goto next;
+      if (s->visited[pc] >= key) goto next;
+      s->visited[pc] = key;
+
+      re_inst inst = s->pat->code[pc];
+      switch (inst.op) {
+      case RE_JMP:
+        /* A backward jump closes a repetition (e*, e{n,}): it returns to the
+           RE_SPLIT/RE_SPLITNG head, whose offset is the loop's exit. `a` is set
+           only when that body can run empty (see mark_empty_loops()), which is
+           the only case with a final empty iteration to account for. */
+        if (inst.offset <= pc && inst.a) {
+          uint32_t head = inst.offset;
+          if (loop_head_seen(s, head)) {
+            /* The head was walked at this position, so the iteration that just
+               finished consumed nothing. Onigmo stops a repetition on an empty
+               iteration and keeps what that iteration captured, so leave the
+               loop from here rather than dying on the head's mark: this path
+               outranks the exit the head itself queued before the body ran, and
+               claims the exit pc first. */
+            pc = s->pat->code[head].offset;
+            continue;
+          }
+          /* The head is unmarked, so this closure resumed inside the body and
+             the iteration it just finished is a real one. Run the next
+             iteration in a fresh pass, past the marks the resumed tail left. */
+          if (key < s->key_max) key++;
+          pc = head;
           continue;
         }
-        /* The head is unmarked, so this closure resumed inside the body and
-           the iteration it just finished is a real one. Run the next
-           iteration in a fresh pass, past the marks the resumed tail left. */
-        if (key < s->key_max) key++;
-        pc = head;
-        continue;
-      }
-      pc = inst.offset;
-      continue;
-
-    case RE_SPLIT:
-      /* Greedy fork: the fall-through (pc+1) outranks the jump target, the
-         same priority order the backtracking engine uses. Explore the
-         higher-priority branch first so it claims shared pcs (visited[]) and
-         reaches a match before the lower one. Snapshot the captures before
-         pc+1's closure can mutate the shared slot; the jump branch then runs
-         on that snapshot. */
-      {
-        uint32_t back = re_loop_back(s, inst, pc, key);
-        if (back == RE_LOOP_STOP) { pc++; continue; }
-        int cp = 0;
-        if (!s->match_only && !pool_copy(s, cap_slot, &cp)) return;
-        add_thread(s, list, pc + 1, cap_slot, sp, key);
-        if (s->cut || s->nomem) return;
         pc = inst.offset;
-        cap_slot = cp;
-        key = back;
+        continue;
+
+      case RE_SPLIT:
+        /* Greedy fork: the fall-through (pc+1) outranks the jump target, the
+           same priority order the backtracking engine uses. Follow the
+           higher-priority branch first so it claims shared pcs (visited[]) and
+           reaches a match before the lower one. Snapshot the captures before
+           pc+1's closure can mutate the shared slot; the jump branch then runs
+           on that snapshot. */
+        {
+          uint32_t back = re_loop_back(s, inst, pc, key);
+          if (back == RE_LOOP_STOP) { pc++; continue; }
+          int cp = 0;
+          if (!s->match_only && !pool_copy(s, cap_slot, &cp)) goto leave;
+          if (!pend_push(s, inst.offset, cp, back)) goto leave;
+          pc = pc + 1;
+        }
+        continue;
+
+      case RE_SPLITNG:
+        /* Non-greedy fork: the jump target outranks the fall-through. */
+        {
+          uint32_t back = re_loop_back(s, inst, pc, key);
+          if (back == RE_LOOP_STOP) { pc++; continue; }
+          int cp = 0;
+          if (!s->match_only && !pool_copy(s, cap_slot, &cp)) goto leave;
+          if (!pend_push(s, pc + 1, cp, key)) goto leave;
+          pc = inst.offset;
+          key = back;
+        }
+        continue;
+
+      case RE_SAVE:
+        /* No test that the position is a character boundary: it is one. A byte
+           that spells no character is RE_BYTE and matches only where the subject
+           byte stands alone, so no atom stops between two bytes of a character
+           and no position a group is recorded at is inside one. The rule used to
+           be tested here, on the end of group 0 and then on every slot. */
+        if (!s->match_only) {
+          CAP(s, cap_slot)[inst.offset] = (int)(sp - s->str);
+        }
+        pc++;
+        continue;
+
+      case RE_BOL:
+        /* ^ always matches at a line start (string start or just after a \n);
+           Ruby's /m only affects `.`, not the line anchors. \A is RE_BOT. A
+           trailing \n does not open a final line, so ^ does not match at the
+           very end. */
+        if (sp == s->str || (sp != s->str_end && sp[-1] == '\n')) {
+          pc++; continue;
+        }
+        goto next;
+
+      case RE_EOL:
+        /* $ always matches at a line end (string end or just before a \n). */
+        if (sp == s->str_end || *sp == '\n') {
+          pc++; continue;
+        }
+        goto next;
+
+      case RE_BOT:
+        if (sp == s->str) { pc++; continue; }
+        goto next;
+
+      case RE_EOT:
+        if (sp == s->str_end) { pc++; continue; }
+        goto next;
+
+      case RE_EOTNL:
+        if (sp == s->str_end || (sp + 1 == s->str_end && *sp == '\n')) { pc++; continue; }
+        goto next;
+
+      case RE_WBOUND:
+        {
+          mrb_bool before = (sp > s->str) && mrb_re_word_before(s->str, sp, s->str_end, s->binary);
+          mrb_bool after = (sp < s->str_end) && mrb_re_word_at(sp, s->str_end, s->binary);
+          if (before != after) { pc++; continue; }
+        }
+        goto next;
+
+      case RE_NWBOUND:
+        {
+          mrb_bool before = (sp > s->str) && mrb_re_word_before(s->str, sp, s->str_end, s->binary);
+          mrb_bool after = (sp < s->str_end) && mrb_re_word_at(sp, s->str_end, s->binary);
+          if (before == after) { pc++; continue; }
+        }
+        goto next;
+
+      case RE_MATCH:
+        s->matched = TRUE;
+        if (s->result_caps) {
+          memcpy(s->result_caps, CAP(s, cap_slot), sizeof(int) * s->ncap);
+        }
+        /* Leftmost-first: this is the highest-priority thread to reach a match
+           this step (closures run in priority order), so cut every lower one.
+           A surviving higher-priority thread can still match later and override
+           this in a subsequent step, which is the correct greedy/longest case. */
+        s->cut = TRUE;
+        goto leave;
+
+      default:
+        break;
       }
-      continue;
-
-    case RE_SPLITNG:
-      /* Non-greedy fork: the jump target outranks the fall-through. */
-      {
-        uint32_t back = re_loop_back(s, inst, pc, key);
-        if (back == RE_LOOP_STOP) { pc++; continue; }
-        int cp = 0;
-        if (!s->match_only && !pool_copy(s, cap_slot, &cp)) return;
-        add_thread(s, list, inst.offset, cap_slot, sp, back);
-        if (s->cut || s->nomem) return;
-        pc = pc + 1;
-        cap_slot = cp;
-      }
-      continue;
-
-    case RE_SAVE:
-      /* No test that the position is a character boundary: it is one. A byte
-         that spells no character is RE_BYTE and matches only where the subject
-         byte stands alone, so no atom stops between two bytes of a character
-         and no position a group is recorded at is inside one. The rule used to
-         be tested here, on the end of group 0 and then on every slot. */
-      if (!s->match_only) {
-        CAP(s, cap_slot)[inst.offset] = (int)(sp - s->str);
-      }
-      pc++;
-      continue;
-
-    case RE_BOL:
-      /* ^ always matches at a line start (string start or just after a \n);
-         Ruby's /m only affects `.`, not the line anchors. \A is RE_BOT. A
-         trailing \n does not open a final line, so ^ does not match at the
-         very end. */
-      if (sp == s->str || (sp != s->str_end && sp[-1] == '\n')) {
-        pc++; continue;
-      }
-      return;
-
-    case RE_EOL:
-      /* $ always matches at a line end (string end or just before a \n). */
-      if (sp == s->str_end || *sp == '\n') {
-        pc++; continue;
-      }
-      return;
-
-    case RE_BOT:
-      if (sp == s->str) { pc++; continue; }
-      return;
-
-    case RE_EOT:
-      if (sp == s->str_end) { pc++; continue; }
-      return;
-
-    case RE_EOTNL:
-      if (sp == s->str_end || (sp + 1 == s->str_end && *sp == '\n')) { pc++; continue; }
-      return;
-
-    case RE_WBOUND:
-      {
-        mrb_bool before = (sp > s->str) && mrb_re_word_before(s->str, sp, s->str_end, s->binary);
-        mrb_bool after = (sp < s->str_end) && mrb_re_word_at(sp, s->str_end, s->binary);
-        if (before != after) { pc++; continue; }
-      }
-      return;
-
-    case RE_NWBOUND:
-      {
-        mrb_bool before = (sp > s->str) && mrb_re_word_before(s->str, sp, s->str_end, s->binary);
-        mrb_bool after = (sp < s->str_end) && mrb_re_word_at(sp, s->str_end, s->binary);
-        if (before == after) { pc++; continue; }
-      }
-      return;
-
-    case RE_MATCH:
-      s->matched = TRUE;
-      if (s->result_caps) {
-        memcpy(s->result_caps, CAP(s, cap_slot), sizeof(int) * s->ncap);
-      }
-      /* Leftmost-first: this is the highest-priority thread to reach a match
-         this step (closures run in priority order), so cut every lower one.
-         A surviving higher-priority thread can still match later and override
-         this in a subsequent step, which is the correct greedy/longest case. */
-      s->cut = TRUE;
-      return;
-
-    default:
       break;
     }
-    break;
+
+    if (list->count < list->capa) {
+      re_thread *t = &list->threads[list->count++];
+      t->pc = pc;
+      t->cap_slot = cap_slot;
+      t->sp = sp;
+    }
+
+  next:
+    /* The branch the walk followed is finished, whether it left a thread
+       behind or died on an assertion. What a fork kept is walked newest
+       first, which is the order a call of its own gave the higher branch:
+       every branch a fork opened below this one has been walked by now. */
+    if (s->pend_top == 0) return;
+    {
+      re_pending *e = &s->pend[--s->pend_top];
+      pc = e->pc;
+      cap_slot = e->cap_slot;
+      key = e->key;
+    }
   }
 
-  if (list->count < list->capa) {
-    re_thread *t = &list->threads[list->count++];
-    t->pc = pc;
-    t->cap_slot = cap_slot;
-    t->sp = sp;
-  }
+leave:
+  /* A cut and a refusal both end the closure whole, the branches kept for
+     later included: the cut has nothing lower to add and the refusal has
+     nowhere to add it. */
+  s->pend_top = 0;
 }
 
 static int
@@ -569,6 +660,9 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   s.pass_span = RE_PASS_SPAN(pat->loop_depth);
   s.gen = 0;
   s.key_max = s.pass_span - 1;
+  s.pend = s.pend_inline;
+  s.pend_top = 0;
+  s.pend_capa = RE_PEND_INLINE;
 
   /* Everything this search holds is given back by one epilogue below, which
      an allocator that raises would jump past: what had been taken by then
@@ -849,6 +943,7 @@ pike_vm(mrb_state *mrb, const mrb_regexp_pattern *pat,
   }
   mrb_free(mrb, s.cap_pool);
   if (s.result_caps) mrb_free(mrb, s.result_caps);
+  if (s.pend != s.pend_inline) mrb_free(mrb, s.pend);
 
   return ret;
 }

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -341,6 +341,24 @@ assert("Regexp - a pattern whose forks nest deeply matches") do
   assert_equal "b", re.match("b")[0] if nest > 0
 end
 
+assert("Regexp - a pattern forking as often as it is long compiles") do
+  # Nothing bounds how often a pattern forks but its length, which `regexp
+  # too large` puts at 65,535 instructions, and the passes that read a
+  # finished program used to spend a C frame per fork they passed: the marks
+  # on the repetitions that can run empty, and the anchor and first-byte
+  # scans. Each keeps its branches on a stack of its own now, so the patterns
+  # below are a question of heap and not of the stack the build runs on.
+  forks = 2000
+  assert_equal 0, (Regexp.new("a*" * forks) =~ "")
+  assert_equal 0, (Regexp.new("a*" * forks) =~ "aaa")
+  assert_equal 0, (Regexp.new("a?" * forks) =~ "")
+
+  # Past 4096 instructions, which is where the anchor and first-byte scans
+  # used to give up for want of room in the frame they marked from.
+  assert_equal 0, (Regexp.new("(?:x?)" * 3000 + "ab") =~ "xxab")
+  assert_equal 2, (Regexp.new("^" + "(?:x?)" * 3000 + "ab") =~ "\n\nab")
+end
+
 assert("Regexp - an alternation holds as many branches as the pattern writes") do
   # The branches were once collected in an array of 64 and the 64th refused
   # as `too many alternatives`. They are found in the code they were compiled

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -359,6 +359,18 @@ assert("Regexp - a pattern forking as often as it is long compiles") do
   assert_equal 2, (Regexp.new("^" + "(?:x?)" * 3000 + "ab") =~ "\n\nab")
 end
 
+assert("Regexp - a lookbehind body forking as often as it is long is measured") do
+  # A lookbehind is measured by a walk of its body, and a fork in it is two
+  # measures that have to agree, which the walk used to take in a C call
+  # apiece. The width stays inside the 255 bytes a rewind carries; what grows
+  # is the number of forks measured. The measure is the compile's, so a
+  # compile is what this asks for: running such a body keeps a choice point
+  # per fork, which is more than a build that sets MRB_REGEXP_STACK_LIMIT low
+  # grants, and what the widths come to is asked of twenty forks further
+  # down, where the guard for that engine stands.
+  assert_kind_of Regexp, Regexp.new("(?<=" + "(?:a|a)" * 200 + ")b")
+end
+
 assert("Regexp - an alternation holds as many branches as the pattern writes") do
   # The branches were once collected in an array of 64 and the 64th refused
   # as `too many alternatives`. They are found in the code they were compiled

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -320,6 +320,27 @@ assert("Regexp - a pattern nested past the parse depth limit raises") do
   end
 end
 
+assert("Regexp - a pattern whose forks nest deeply matches") do
+  # A step's epsilon closure walks the branches a fork leaves standing, and
+  # what that walk spent on the C stack used to follow how deep the pattern
+  # nests its forks, with nothing above it but MRB_REGEXP_PARSE_DEPTH_LIMIT.
+  # The `?` is what makes every level a fork, the `b` is what makes the
+  # closure cross all of them, and the greedy answer is what says it took the
+  # branch inside as well as the one that skips it.
+  #
+  # Every level here is one the parser holds open at once, the pattern itself
+  # among them, so what the build allows is the ceiling: a build that lowers
+  # the limit is asked a shallower question rather than met with a refusal.
+  nest = Regexp::PARSE_DEPTH_LIMIT - 1
+  nest = 1000 if nest > 1000
+  nest = 0 if nest < 0
+  re = Regexp.new("(?:" * nest + "a" + ")?" * nest + "b")
+  assert_equal "ab", re.match("ab")[0]
+  assert_nil re.match("c")
+  # Where the build left no level at all there is no branch to skip.
+  assert_equal "b", re.match("b")[0] if nest > 0
+end
+
 assert("Regexp - an alternation holds as many branches as the pattern writes") do
   # The branches were once collected in an array of 64 and the 64th refused
   # as `too many alternatives`. They are found in the code they were compiled


### PR DESCRIPTION
## Summary

Five walks over a compiled pattern recursed once per fork they passed, so what
each spent on the C stack followed the pattern rather than the build: the
epsilon closure of a Pike VM step, the three passes that decide what a search
can skip and which repetitions can run empty, and the measure of a lookbehind
body. A program the compiler accepts is bounded by `regexp too large` at 65,535
instructions and by `MRB_REGEXP_PARSE_DEPTH_LIMIT` at 4,096 levels; neither
bound says anything about the stack a build runs on, so a pattern inside both
was a SIGSEGV on a small stack, in the compile or in the search.

Each walk now keeps the branch it has yet to take on a stack of its own and
takes the newest back when the branch it followed ends, which visits what the
recursion visited in the order it did. `mrb_regexp` answers the same thing for
every pattern; what changed is which builds can ask.

This is the third of the same shape: the backtracking engine's state and the
parser's levels already moved off the C stack.

## Changes

Four commits, one per walk that recursed, each carrying the assertions that
ask its walk for an answer:

1. `add_thread()`, the Pike VM's epsilon closure. The stack lives on the search
   state, sixteen entries in the state itself and the heap past that; an entry
   holds no position, since a closure stands at one.
2. `anchor_walk()`, `first_set_walk()` and `epsilon_path()`, the passes over a
   finished program. Each keeps a stack of pcs, taken from the block its marks
   already come in. The marks were an array of 4096 in `mrb_re_compile()`'s
   frame, which also refused both scans to a longer program; they come from the
   scan's own frame now, or from the heap where the program does not fit it.
3. `fixed_len_walk()`, the width of a lookbehind body. A fork there is two
   measures that have to agree, so the frames carry what the walk had taken,
   the first arm's answer, and the pc whose memo slot the answer fills.
4. README.md.

## Behaviour

No pattern answers differently. The refusals keep their wording and their
thresholds: `regexp too large`, `parse depth limit over`, `lookbehind too long`,
`invalid pattern in look-behind`.

Two things a build can now do that it could not:

- Compile and search a pattern that forks more often than its stack has room
  for frames. The table under Testing is the same binary before and after.
- Scan for the anchor and the first bytes of a program past 4096 instructions.
  That number was the size of the array in the frame, not a statement about
  patterns, so such a program used to be searched by proposing every position.
  It is a matter of speed, not of answers.

A stack the allocator refuses is reported the way each walk already reports what
it cannot do: `NoMemoryError` from a search, an unbuilt scan from the anchor and
first-byte passes, and a body of no fixed width from the lookbehind measure.

## Speed

Callgrind Ir, whole process, base against this branch. `compile` and
`lookbehind` build the pattern in the loop; the rest build it once.

| bench (gcc 13.3 -O3)                                 | base          | PR            | delta  |
| ---------------------------------------------------- | ------------- | ------------- | ------ |
| compile `(foo\|bar)+\s*[a-z0-9_]{2,8}(?:baz)?` x2000 | 39,702,903    | 40,475,223    | +1.95% |
| match `/needle/` in 10 KB x2000                      | 12,502,590    | 12,500,930    | −0.01% |
| match `/zebra\|zoo/` in 10 KB x2000                  | 9,247,345     | 9,337,358     | +0.97% |
| match `/(?:a\|b)*c/` on 1 KB x500                    | 788,622,432   | 794,394,550   | +0.73% |
| match `/\d+/` in 10 KB x500                          | 71,870,104    | 71,908,514    | +0.05% |
| `gsub(/o(\w)/)` on 8 KB x200                         | 1,060,150,317 | 1,072,494,532 | +1.16% |
| compile and match a lookbehind of 20 forks x500      | 36,905,598    | 38,752,198    | +5.00% |

The same benches under clang 23.1 -O3:

| bench (clang 23.1 -O3) | base          | PR            | delta  |
| ---------------------- | ------------- | ------------- | ------ |
| compile                | 40,388,738    | 40,053,032    | −0.83% |
| match `/(?:a\|b)*c/`   | 722,076,869   | 700,565,356   | −2.98% |
| gsub                   | 1,088,794,530 | 1,092,475,511 | +0.34% |
| lookbehind             | 37,346,023    | 38,085,815    | +1.98% |

What moved under gcc and not under clang is the inlining of the walks, which
were recursive before and are ordinary loops now. The push a fork makes is
`static inline` in both walks that take one per fork; without that, gcc left it
a call and the fork bench was +8.6% rather than +0.73%.

## Size

`.text` of `bin/mruby`, the seven `ci/gcc-clang` builds, `CC=gcc`, both trees
built into empty directories from the same paths.

| build         | base      | PR        | delta |
| ------------- | --------- | --------- | ----- |
| `full-debug`  | 1,975,846 | 1,978,310 | +2464 |
| `bintest`     | 1,383,750 | 1,384,310 | +560  |
| `cxx_abi`     | 1,417,305 | 1,417,689 | +384  |
| `byte-string` | 1,345,878 | 1,346,342 | +464  |
| `ascii-ctype` | 1,368,118 | 1,368,854 | +736  |
| `no-float`    | 1,309,694 | 1,310,254 | +560  |
| `no-bigint`   | 1,268,390 | 1,268,950 | +560  |

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds green, and every
commit of this branch green on its own with the default config.

The stack each walk needed, the same repro run under `ulimit -s`:

| repro                           | stack   | base | PR  |
| ------------------------------- | ------- | ---- | --- |
| 1,000 nested `(?:...)?` matched | 128 KiB | SEGV | ok  |
| 4,095 nested `(?:...)?` matched | 256 KiB | SEGV | ok  |
| `"a*" * 1500` compiled          | 128 KiB | SEGV | ok  |
| `"a*" * 16000` compiled         | 1 MiB   | SEGV | ok  |
| `"a?" * 1500` compiled          | 128 KiB | SEGV | ok  |
| `(?<=(?:a\|a) x1500)` compiled  | 256 KiB | SEGV | ok  |
| `(?<=(?:a\|a) x3000)` compiled  | 512 KiB | SEGV | ok  |

What the C stack stops holding, the heap takes a fraction of. Below, the
stack a run needs (bisected on `ulimit -s`, so it carries the interpreter's own
40 KiB) and its peak heap under massif, same binaries.

| repro                           | stack base | stack PR | heap base | heap PR | peak sum |
| ------------------------------- | ---------- | -------- | --------- | ------- | -------- |
| `"a?" * 1500` compiled          | 156 KiB    | 40 KiB   | 463,632   | 463,632 | −19%     |
| `"a*" * 1500` compiled          | 160 KiB    | 40 KiB   | 630,016   | 630,016 | −15%     |
| `"a*" * 16000` compiled         | 1292 KiB   | 36 KiB   | 5,238,384 | same    | −20%     |
| 4,000 nested `(?:...)?` matched | 472 KiB    | 40 KiB   | 743,928   | 793,088 | −32%     |
| `(?<=(?:a\|a) x200)` matched    | 84 KiB     | 36 KiB   | 222,320   | 222,320 | −16%     |
| `(?<=(?:a\|a) x3000)` refused   | 648 KiB    | 40 KiB   | 367,800   | 588,992 | −39%     |

A frame the recursion pushed was 81 to 118 bytes; an entry these stacks push is
12 for the closure and 24 for the lookbehind measure, so the sum falls in every
case that goes deep enough to reach the heap at all. Where a walk stays inside
the room it keeps in its own frame the heap does not move, and the seven benches
above need 1 to 4 KiB less stack than the base with no heap change beyond four
bytes per instruction while a pattern compiles.

The same patterns cost, in Ir: `"a*" * 1500` −17.2%, `"a*" * 16000` −17.8%, the
nested match +0.18%, the 200 fork lookbehind +3.32% and the refused one +13.99%
under gcc; under clang the last two are +0.24% and +0.10%, and the compiles are
−17.6%. The lookbehind measure is the one walk gcc does not fold as well as the
recursion it replaced, the same difference the bench table shows.

A differential run over 87,975 cases (generated patterns over four alphabets
and four seeds, a refusal corpus, and long subjects) answers byte for byte what
the base answers. The same corpus under `-fsanitize=address,undefined` reports
nothing.

New assertions cover a thousand nested forks matched, a pattern of 2,000 forks
compiled, a program past 4096 instructions with and without a line anchor, and a
lookbehind body of 200 forks measured. They pass on the base as well: what this
branch changes is the stack such a test needs, which the CI builds have. Each
takes its size from what the build admits rather than from a number of its own:
the nested one from `Regexp::PARSE_DEPTH_LIMIT`, since every level it opens is
one the parser holds, and the lookbehind one asks for the compile and not for a
match, since running a body of that many forks keeps a choice point apiece,
which is more than a build that sets `MRB_REGEXP_STACK_LIMIT` low grants.
`mrbtest` was run against a build set to 48 and one set to a parse depth of 512,
and answers what the base answers there.

## Environment

<details>

```
gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
Homebrew clang version 23.1.0
valgrind-3.27.1
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
Linux 7.0.0-31-generic x86_64
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested and heavily branching regular expressions.
  * Reduced stack-overflow risk when compiling or matching complex expressions.
  * Preserved expected behavior for anchors, lookbehinds, optional patterns, and empty matches.

* **Tests**
  * Added coverage for deeply nested, highly branching, and complex lookbehind expressions.

* **Documentation**
  * Updated regular expression documentation with guidance on stack usage for complex patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->