### PR TITLE
vm.c: drop the VM's `flatten` from a GCC amalgamation

### DIFF
--- a/doc/guides/amalgamation.md
+++ b/doc/guides/amalgamation.md
@@ -139,6 +139,27 @@ Typical sizes depend on included gems:
 - Local includes (`.cstub` files) are automatically inlined
 - Generated files (`mrblib.c`, `gem_init.c`) are included
 
+### The `MRB_AMALGAMATION` Define
+
+Both generated `.c` files define `MRB_AMALGAMATION` ahead of everything else.
+It marks a translation unit that holds the whole runtime rather than one
+source file, so that a source asking the compiler for work proportional to
+the translation unit can keep the request scoped the way a per-file build
+scopes it.
+
+The VM uses it for exactly that. `mrb_vm_exec()` carries
+`__attribute__((flatten))`, which inlines every call it makes, recursively,
+as deep as the translation unit allows. A per-file build stops it at the VM's
+own static opcode handlers, which is what the attribute is for. With the whole
+runtime in one translation unit it instead reaches the cycle that allocation,
+collection and exception raising form with each other, and the descent never
+converges. GCC exhausts memory in its inliner before emitting a single
+function, so under GCC the amalgamation drops the attribute and
+`mrb_vm_exec()` is optimized like any other function there.
+
+Clang keeps the descent bounded, compiles the same file in seconds, and runs
+faster with the attribute than without it, so it keeps it.
+
 ### Build Configuration Defines
 
 The defines the build compiles with are written at the top of `mruby.h`,

--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -492,6 +492,10 @@ module MRuby
         ** This file is auto-generated. Do not edit directly.
         ** Compile together with the amalgamated mruby.c.
         */
+
+        #ifndef MRB_AMALGAMATION
+        #define MRB_AMALGAMATION 1
+        #endif
       PREAMBLE
 
       write_gem_cc_defines(f, gems)
@@ -563,6 +567,14 @@ module MRuby
         **
         ** This file is auto-generated. Do not edit directly.
         */
+
+        /* Marks a translation unit that holds the whole runtime rather than
+        ** one source file. Sources that ask the compiler for whole-callgraph
+        ** work (src/vm.c and __attribute__((flatten))) read this to keep the
+        ** request scoped the way a per-file build scopes it. */
+        #ifndef MRB_AMALGAMATION
+        #define MRB_AMALGAMATION 1
+        #endif
 
         #include "mruby.h"
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -2144,7 +2144,16 @@ catch_handler_find(const mrb_irep *irep, const mrb_code *pc, uint32_t filter)
 #define VM_SENDB_SYM  3  /* fallback sendb: goto L_SENDB_SYM */
 #define VM_RETURN_NIL 4  /* nil irep: return nil via L_OP_RETURN */
 
-#if defined(__GNUC__) || defined(__clang__)
+/* `flatten` inlines every call mrb_vm_exec makes, recursively, as deep as the
+   translation unit allows. A per-file build stops it at this file's static
+   opcode handlers, which is what the attribute is for. The amalgamation puts
+   the whole runtime in one translation unit, so the descent reaches the cycle
+   that allocation, collection and exception raising form with each other
+   (mrb_realloc -> mrb_realloc_simple -> mrb_full_gc -> sweep -> mrb_realloc,
+   and mrb_realloc -> mrb_raise_nomemory -> mrb_exc_raise -> allocation) and
+   never converges. GCC exhausts memory in ipa-inline there; Clang keeps the
+   descent bounded and stays faster with the attribute, so only GCC drops it. */
+#if defined(__clang__) || (defined(__GNUC__) && !defined(MRB_AMALGAMATION))
 #define MRB_FLATTEN __attribute__((flatten))
 #else
 #define MRB_FLATTEN


### PR DESCRIPTION
## Summary

`gcc -O2` on the generated `mruby.c` never finishes. `__attribute__((flatten))` on `mrb_vm_exec()` asks for one thing in a per-file build and another when the whole runtime is a single translation unit, and GCC's inliner does not come back from the second. The amalgamation now drops the attribute under GCC and keeps it under Clang, which handles it and is faster with it.

## Changes

| File                         | What                                                                                |
| ---------------------------- | ----------------------------------------------------------------------------------- |
| `lib/mruby/amalgam.rb`       | `mruby.c` and `mruby_compiler.c` define `MRB_AMALGAMATION` ahead of everything else |
| `src/vm.c`                   | `MRB_FLATTEN` reads it, and expands to nothing when GCC compiles an amalgamation    |
| `doc/guides/amalgamation.md` | new "The `MRB_AMALGAMATION` Define" section                                         |

### The descent has nothing to stop it

`flatten` inlines every call `mrb_vm_exec()` makes, recursively, as deep as the translation unit allows. A per-file build stops at `vm.c`'s own static opcode handlers, which is what the attribute is for. The amalgamation puts the whole runtime in one translation unit, so the same instruction descends into the cycle that allocation, collection and exception raising form with each other:

```
mrb_realloc -> mrb_realloc_simple -> mrb_full_gc -> sweep -> mrb_realloc
mrb_realloc -> mrb_raise_nomemory -> mrb_exc_raise -> allocation
```

Those functions live in `gc.c` and `error.c`, and the raise path reaches on into `backtrace.c`, so a per-file build never sees the cycle at all. `-Q` shows GCC dying inside the interprocedural `inline` pass, before it emits a single function:

```console
<icf> {heap 20M} <devirt> {heap 20M} <cp> {heap 20M} <sra> {heap 20M} <fnsummary> {heap 20M} <inline>virtual memory exhausted: Cannot allocate memory
```

The optimized build command `doc/guides/amalgamation.md` documents is exactly the one that fails.

### Why the guard is GCC only

Clang keeps the descent bounded. It compiles the same file in 13 seconds, and the VM it builds is faster with the attribute than without it, so it keeps it. Same amalgamation, same bytecode, `clang -O2`, min of 10 runs:

| benchmark          | with `flatten` | without `flatten` |
| ------------------ | -------------: | ----------------: |
| `bm_fib`           |         2.42 s |            2.70 s |
| `bm_so_lists`      |         0.28 s |            0.34 s |
| `bm_hash_access`   |         0.62 s |            0.66 s |
| `bm_so_mandelbrot` |         0.94 s |            1.02 s |

`mrb_vm_exec` is 75,844 bytes with the attribute and 53,379 bytes without.

## Behaviour

`gcc -O2 -DNDEBUG -c mruby.c` on the generated file, under `ulimit -v 24000000` so a runaway inliner cannot take the machine with it:

| compiler   | master                        | this PR        |
| ---------- | ----------------------------- | -------------- |
| gcc 9.5.0  | 24 GB cap exhausted at 30.3 s | 10.3 s, 366 MB |
| gcc 10.5.0 | 24 GB cap exhausted at 47.2 s | 12.5 s, 341 MB |
| gcc 11.5.0 | 24 GB cap exhausted at 60.4 s | 12.0 s, 344 MB |
| gcc 12.4.0 | 24 GB cap exhausted at 71.8 s | 15.3 s, 347 MB |
| gcc 13.3.0 | 24 GB cap exhausted at 70.3 s | 13.8 s, 353 MB |
| gcc 14.2.0 | 24 GB cap exhausted at 86.0 s | 14.8 s, 355 MB |

`-O1` fails the same way on all six; `-O0` completes on all six, before and after. Without the cap, GCC keeps allocating until the kernel kills it.

Clang is unaffected: `clang -O2` compiles the generated `mruby.c` in 12.7 s before and 13.0 s after, at a 216 MB peak either way, and the object's `.text` is byte-identical across the change.

The resulting `mruby.c` links and runs: `bm_fib` built from the `gcc -O2` amalgamation prints `24157817`.

## Size

`bin/mruby` `.text` from `size -A`, `build_config/ci/gcc-clang.rb`, `CC=gcc CXX=g++ LD=gcc`, empty build directories, base `2f677e233`:

| build              |    master |   this PR | delta |
| ------------------ | --------: | --------: | ----: |
| `bintest`          | 1,383,750 | 1,383,750 |     0 |
| `ascii-ctype`      | 1,368,118 | 1,368,118 |     0 |
| `byte-string`      | 1,345,878 | 1,345,878 |     0 |
| `cxx_abi`          | 1,417,305 | 1,417,305 |     0 |
| `no-float`         | 1,309,694 | 1,309,694 |     0 |
| `no-bigint`        | 1,268,390 | 1,268,390 |     0 |
| `full-debug` (-O0) | 1,975,846 | 1,975,846 |     0 |

The default `host` build is 1,292,382 both sides. `MRB_AMALGAMATION` is never defined in a per-file build, so nothing there sees a different preprocessing result: `src/vm.o`'s `.text` is byte-identical (87,633 bytes, `mrb_vm_exec` 65,433), and only `.debug_info` and `.debug_line` move, by the nine comment lines this adds above the guard.

## Testing

- `rake all test`: 2632 tests, 0 KO, 0 crash, 0 warning; bintest 130, 0 KO.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all seven builds green, 0 KO and 0 crash in each; bintest 147, 0 KO.
- Amalgamation generated with the default configuration, compiled at `-O2` by gcc 9, 10, 11, 12, 13 and 14 and by clang, linked against a `mrb_load_irep` driver, and run.
- Nothing in `.github/workflows/`, `test/` or `bintest/` compiles the amalgamation, so this has no CI coverage before or after; the runs above are local.

## Noted, not addressed

`mruby_compiler.c` cannot be compiled on its own, on master as well as here: prism headers are only partly inlined, so `prism/diagnostic.h` is not found, and supplying the include paths then produces a `PM_STRING_CONSTANT` redeclaration. That is a separate defect in the generator and is untouched by this change.

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Ubuntu 24.04.4, Linux 7.0.0-31-generic x86_64      |
| CPU        | AMD Ryzen 9 5950X, 62 GiB RAM                      |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| also built | gcc 9.5.0, 10.5.0, 11.5.0, 12.4.0, 14.2.0          |
| clang      | Homebrew clang 23.1.0                              |
| binutils   | GNU ld 2.47.20260726                               |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Amalgamation compile line used for every measurement above, with the amalgam directory's `-I` dropped:

```console
gcc -O2 -DNDEBUG -c mruby.c
```

Compile lines of `src/vm.c` from `rake --verbose` in each build, with the `-I`, `-MMD -c`, `-o` and `-ffile-prefix-map` arguments dropped:

```console
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/vm.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
host:        gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/vm.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of amalgamated builds with GCC by preventing excessive compiler resource usage during optimization.
  * Preserved optimized compilation behavior for supported Clang builds.

* **Documentation**
  * Added technical guidance explaining amalgamated builds and compiler-specific optimization behavior.
  * Documented how generated runtime sources identify amalgamated translation units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->