### PR TITLE
amalgam: fold mruby-compiler into the one translation unit

### DIFF
--- a/doc/guides/amalgamation.md
+++ b/doc/guides/amalgamation.md
@@ -121,8 +121,8 @@ MRUBY_CONFIG=build_config/amalgam.rb rake amalgam
 
 Typical sizes depend on included gems:
 
-- `mruby.h`: 200-500 KB
-- `mruby.c`: 2-4 MB
+- `mruby.h`: 270-800 KB
+- `mruby.c`: 1.4-6.9 MB
 
 ## Technical Details
 
@@ -141,7 +141,7 @@ Typical sizes depend on included gems:
 
 ### The `MRB_AMALGAMATION` Define
 
-Both generated `.c` files define `MRB_AMALGAMATION` ahead of everything else.
+The generated `mruby.c` defines `MRB_AMALGAMATION` ahead of everything else.
 It marks a translation unit that holds the whole runtime rather than one
 source file, so that a source asking the compiler for work proportional to
 the translation unit can keep the request scoped the way a per-file build

--- a/lib/mruby/amalgam.rb
+++ b/lib/mruby/amalgam.rb
@@ -37,16 +37,6 @@ module MRuby
       mruby/boxing_nan.h
     ].freeze
 
-    # Gems emitted as their own translation unit (mruby_compiler.c)
-    # instead of being merged into mruby.c. mruby-compiler's sources
-    # define file-scope static functions and operand-fetch macros that
-    # mirror the core VM's (cdump.c, codedump.c, dump.c, mrc_opcode.h vs
-    # mruby/opcode.h), so they cannot share a translation unit with the
-    # core sources.
-    SEPARATE_TU_GEMS = %w[
-      mruby-compiler
-    ].freeze
-
     # Core sources in recommended order
     CORE_SOURCE_ORDER = %w[
       allocf.c
@@ -89,9 +79,8 @@ module MRuby
       @processed_guards = {}
       @processed_headers = []  # Track header paths for include transformation
       @xmacro_cache = {}
-      @inline_mruby = true     # inline mruby core headers (false in the compiler TU)
       # Pre-collect gem header names for include transformation
-      build_gem_header_map(main_library_gems)
+      build_gem_header_map(library_gems)
     end
 
     # Resolve an include to the gem header file providing it. Basename
@@ -104,15 +93,22 @@ module MRuby
         (quote_type == '"' ? @gem_header_basenames[File.basename(header)] : nil)
     end
 
-    # Include dirs a gem contributes from inside its own tree: its include/
-    # dir plus any gem-local cc.include_paths, e.g. mruby-compiler's vendored
-    # lib/prism/include. Paths outside the gem dir (build dirs, other gems)
-    # are not gem-local headers and are left alone.
+    # Include dirs holding a gem's own headers: its include/ dir, the
+    # gem-local ones its mrbgem.rake adds (mruby-compiler's vendored
+    # lib/prism/include) and the ones it writes under the build tree for the
+    # headers it generates (mruby-compiler's prism/ast.h and
+    # prism/diagnostic.h, built from the templates). Only the paths the gem
+    # itself adds count: the build's own include dirs carry the core headers,
+    # which belong to the amalgamated mruby.h, not to a gem. Another gem's
+    # include dir, added here as a dependency, is left to that gem's own
+    # entry.
     def gem_include_dirs(gem)
       gem_root = File.expand_path(gem.dir)
-      dirs = ["#{gem.dir}/include"] + gem.cc.include_paths
+      build_root = File.expand_path(@build.build_root)
+      own_paths = gem.cc.include_paths - @build.cc.include_paths
+      dirs = ["#{gem.dir}/include"] + own_paths
       dirs.map { |d| File.expand_path(d) }
-        .select { |d| d.start_with?("#{gem_root}/") }
+        .select { |d| d.start_with?("#{gem_root}/") || d.start_with?("#{build_root}/") }
         .select { |d| File.directory?(d) }
         .uniq
     end
@@ -121,9 +117,7 @@ module MRuby
     # it: @gem_header_map keys paths relative to each include dir
     # ("prism/ast.h"), @gem_header_basenames keys bare basenames ("io_hal.h")
     # for quoted includes. *.inc files are included for X-macro tables like
-    # mruby-compiler's mrc_presym.inc. Built per output file: mruby.h and
-    # mruby.c see the main gems' headers, mruby_compiler.c sees only the
-    # separate-TU gems' (including their vendored include dirs).
+    # mruby-compiler's mrc_presym.inc.
     def build_gem_header_map(gems)
       @gem_header_map = {}
       @gem_header_basenames = {}
@@ -178,24 +172,6 @@ module MRuby
       end
     end
 
-    # mruby_compiler.c: mruby-compiler (and its vendored prism) as a
-    # separate translation unit. Compiled against the shared mruby.h;
-    # the mrc_*/prism headers stay private to this file.
-    def generate_compiler_source(output_path)
-      FileUtils.mkdir_p(File.dirname(output_path))
-      _pp "GEN", output_path.relative_path
-
-      gems = separate_tu_gems
-      @inline_mruby = false  # mruby core headers live in the shared mruby.h
-      build_gem_header_map(gems)
-
-      File.open(output_path, "w:binary") do |f|
-        write_compiler_preamble(f, gems)
-        write_compiler_headers(f, gems)
-        write_compiler_sources(f, gems)
-      end
-    end
-
     private
 
     def include_dir
@@ -213,16 +189,6 @@ module MRuby
     # Filter out binary gems (they have main() functions)
     def library_gems
       @build.gems.reject { |gem| gem.name.start_with?("mruby-bin-") }
-    end
-
-    # Gems merged into mruby.c
-    def main_library_gems
-      library_gems.reject { |gem| SEPARATE_TU_GEMS.include?(gem.name) }
-    end
-
-    # Gems emitted as mruby_compiler.c
-    def separate_tu_gems
-      library_gems.select { |gem| SEPARATE_TU_GEMS.include?(gem.name) }
     end
 
     # ========== Header Generation ==========
@@ -274,7 +240,7 @@ module MRuby
           f.puts "#endif"
         end
       end
-      write_gem_cc_defines(f, main_library_gems)
+      write_gem_cc_defines(f, library_gems)
     end
 
     # The revision the amalgam was generated from, ahead of the version.h that
@@ -370,7 +336,7 @@ module MRuby
     end
 
     def write_gem_headers(f)
-      main_library_gems.each do |gem|
+      library_gems.each do |gem|
         roots = gem_header_roots(gem)
         next if roots.empty?
 
@@ -481,82 +447,6 @@ module MRuby
       f.puts content
     end
 
-    # ========== Compiler TU Generation ==========
-
-    def write_compiler_preamble(f, gems)
-      f.puts <<~PREAMBLE
-        /*
-        ** mruby amalgamated compiler source (mruby-compiler + prism)
-        ** Generated from mruby source files
-        **
-        ** This file is auto-generated. Do not edit directly.
-        ** Compile together with the amalgamated mruby.c.
-        */
-
-        #ifndef MRB_AMALGAMATION
-        #define MRB_AMALGAMATION 1
-        #endif
-      PREAMBLE
-
-      write_gem_cc_defines(f, gems)
-      f.puts %(\n#include "mruby.h"\n)
-
-      # mruby/internal.h is not part of the public mruby.h; compiler
-      # sources (mruby_compat.c) use its declarations, so inline it here
-      # the same way mruby.c does, unless a gem header has already put it in
-      # mruby.h, which this file includes.
-      internal_path = "#{include_dir}/mruby/internal.h"
-      if File.exist?(internal_path) && !internal_header_in_public?
-        content = File.read(internal_path, mode: "rb")
-        content = strip_include_guard(content, extract_include_guard(content))
-        content = transform_source_includes(content)
-        f.puts "\n/* mruby/internal.h */"
-        f.puts content
-      end
-      f.puts
-    end
-
-    def write_compiler_headers(f, gems)
-      f.puts "/* ======== Compiler headers ======== */"
-      gems.each do |gem|
-        roots = gem_header_roots(gem)
-        next if roots.empty?
-
-        paths = roots.flat_map { |root| Dir.glob("#{root}/**/*.h") }
-        order_gem_headers(paths, roots).each do |path|
-          rel_path = header_rel_path(path, roots)
-          # X-macro tables are inlined at each include site instead
-          next if gem_xmacro_path(rel_path, '"')
-          write_header_content(f, "#{gem.name}: #{rel_path}", path)
-          @processed_headers << rel_path unless @processed_headers.include?(rel_path)
-        end
-      end
-    end
-
-    def write_compiler_sources(f, gems)
-      f.puts "\n/* ======== Compiler sources ======== */"
-      gems.each do |gem|
-        sources = gem_source_files(gem)
-        sources.each_with_index do |path, idx|
-          rel_path = path.sub("#{File.expand_path(gem.dir)}/", "")
-          write_source_content(f, "#{gem.name}: #{rel_path}", path)
-          write_macro_cleanup(f, "#{gem.name}/#{File.basename(path)}") if idx < sources.size - 1
-        end
-
-        gem_mrblib = "#{gem.build_dir}/gem_mrblib.c"
-        if File.exist?(gem_mrblib)
-          write_source_content(f, "#{gem.name}: gem_mrblib.c", gem_mrblib)
-        end
-
-        gem_init = "#{gem.build_dir}/gem_init.c"
-        if File.exist?(gem_init)
-          write_source_content(f, "#{gem.name}: gem_init.c", gem_init)
-        end
-
-        write_macro_cleanup(f, gem.name)
-      end
-    end
-
     # ========== Source Generation ==========
 
     def write_source_preamble(f)
@@ -589,11 +479,32 @@ module MRuby
     def internal_header_in_public?
       return @internal_in_public unless @internal_in_public.nil?
 
-      @internal_in_public = main_library_gems.any? do |gem|
+      @internal_in_public = library_gems.any? do |gem|
         gem_include = "#{gem.dir}/include"
         next false unless File.directory?(gem_include)
         Dir.glob("#{gem_include}/**/*.h").any? do |path|
           File.read(path, mode: "rb") =~ /^\s*#\s*include\s*[<"]mruby\/internal\.h[>"]/
+        end
+      end
+    end
+
+    # The include guard mruby/opcode.h and mruby-compiler's mrc_opcode.h
+    # share, a TU normally seeing only one of the two.
+    OPCODE_GUARD = "MRUBY_OPCODE_H"
+
+    # Whether a gem header claiming that guard reaches mruby.h, as
+    # mruby-compiler's mrc_opcode.h does. It declares the same enum and the
+    # same operand-read macros as mruby/opcode.h; what differs is the six
+    # operand-fetch macros, and an include of either header re-points those.
+    # Read from the gem headers for the same reason as above.
+    def opcode_header_in_public?
+      return @opcode_in_public unless @opcode_in_public.nil?
+
+      @opcode_in_public = library_gems.any? do |gem|
+        gem_header_roots(gem).any? do |root|
+          Dir.glob("#{root}/**/*.h").any? do |path|
+            extract_include_guard(File.read(path, mode: "rb")) == OPCODE_GUARD
+          end
         end
       end
     end
@@ -654,11 +565,15 @@ module MRuby
         f.puts content
       end
 
-      # mruby/opcode.h is deliberately kept out of the shared mruby.h: its
-      # operand-fetch macros (FETCH_*) conflict with mruby-compiler's
-      # mrc_opcode.h variants, so each translation unit inlines its own.
+      # mruby/opcode.h is not among the headers mruby.h is built from: its
+      # operand-fetch macros (FETCH_*) are one of two variants, so an
+      # include site re-points them rather than the file carrying either.
+      # Where a gem header has already put the same include guard in
+      # mruby.h, emitting this one too would redeclare the opcode enum.
       opcode_path = "#{include_dir}/mruby/opcode.h"
-      if File.exist?(opcode_path)
+      if opcode_header_in_public?
+        f.puts "\n/* mruby/opcode.h - already in mruby.h */"
+      elsif File.exist?(opcode_path)
         content = File.read(opcode_path, mode: "rb")
         content = strip_include_guard(content, extract_include_guard(content))
         content = transform_source_includes(content)
@@ -704,6 +619,7 @@ module MRuby
       push
       pop
       peek
+      NUMERIC_SHIFT_WIDTH_MAX
     ].freeze
 
     # File-local names defined in a C source: static functions and tables,
@@ -758,11 +674,17 @@ module MRuby
       collisions.sort.each { |sym| f.puts "#undef #{sym}" }
     end
 
+    # gem_init.c and gem_mrblib.c are written after every other source of the
+    # gem, so the obj walk below leaves them to that step rather than pulling
+    # them in with the rest of the generated sources.
+    GEM_INIT_SOURCES = %w[gem_init.c gem_mrblib.c].freeze
+
     # C sources of a gem: the conventional src/ and core/ trees, the first
     # matching ports/<name>/ dir (same fallback chain as the normal build,
     # see Gem::Specification#setup), plus any sources registered only
-    # through custom obj file tasks (e.g. mruby-compiler's vendored
-    # lib/prism), recovered from each obj's file-task prerequisite.
+    # through custom obj file tasks (mruby-compiler's vendored lib/prism and
+    # the prism sources it generates under the build tree), recovered from
+    # each obj's file-task prerequisite.
     def gem_source_files(gem)
       source_dirs = ["#{gem.dir}/src", "#{gem.dir}/core"].select { |d| File.directory?(d) }
       @build.effective_ports.each do |port|
@@ -778,30 +700,43 @@ module MRuby
       sources = source_dirs.flat_map { |d| Dir.glob("#{d}/**/*.c") }.sort
         .map { |s| File.expand_path(s) }
       gem_prefix = "#{File.expand_path(gem.dir)}/"
+      build_prefix = "#{File.expand_path(@build.build_root)}/"
       gem.objs.flatten.each do |obj|
         next unless Rake::Task.task_defined?(obj)
         src = Rake::Task[obj].prerequisites.first
         next unless src && src.end_with?(".c") && File.exist?(src)
         src = File.expand_path(src)
-        # Only gem-local sources; build-generated ones are handled separately
-        next unless src.start_with?(gem_prefix)
+        # The gem's own sources, wherever they sit: in its tree, or under the
+        # build tree where it writes the ones it generates (mruby-compiler's
+        # prism/src/node.c and friends, built from the templates).
+        next unless src.start_with?(gem_prefix) || src.start_with?(build_prefix)
+        next if GEM_INIT_SOURCES.include?(File.basename(src))
         sources << src unless sources.include?(src)
       end
       sources
     end
 
+    # The name a source is written under in the amalgam: relative to the gem
+    # for its own tree, to the build root for what it generates. An absolute
+    # path would name the machine that generated the file.
+    def source_label(gem, path)
+      [File.expand_path(gem.dir), File.expand_path(@build.build_root)].each do |root|
+        return path.sub("#{root}/", "") if path.start_with?("#{root}/")
+      end
+      File.basename(path)
+    end
+
     def write_gem_sources(f)
       f.puts "\n/* ======== Gem sources ======== */"
 
-      main_library_gems.each do |gem|
+      library_gems.each do |gem|
         sources = gem_source_files(gem)
 
         # Include C sources if the gem has any
         unless sources.empty?
           renamed = write_static_renames(f, gem, sources)
           sources.each_with_index do |path, idx|
-            rel_path = path.sub("#{File.expand_path(gem.dir)}/", "")
-            write_source_content(f, "#{gem.name}: #{rel_path}", path)
+            write_source_content(f, "#{gem.name}: #{source_label(gem, path)}", path)
             # Clear macros between source files to avoid conflicts
             # (e.g., mrb_stat macro in file.c vs function in file_test.c)
             write_macro_cleanup(f, "#{gem.name}/#{File.basename(path)}") if idx < sources.size - 1
@@ -869,8 +804,8 @@ module MRuby
     # guard (a TU normally sees only one of them) but their operand-fetch
     # macros differ: mrc code reserves `c` for the mrc_ccontext parameter
     # and fetches the third operand into `cc`. In an amalgamated TU both
-    # kinds of consumer can appear (e.g. mruby_compat.c uses the core
-    # variant inside the compiler TU), so an include of either header
+    # kinds of consumer appear (the VM reads its operands one way, the
+    # compiler's code generator the other), so an include of either header
     # re-points the differing macros to that header's variant.
     OPCODE_FETCH_MACROS = {
       "mruby/opcode.h" => <<~MACROS,
@@ -989,13 +924,8 @@ module MRuby
           # Keep original whitespace, comment out the include
           "#{prefix}// #{include_stmt} - in amalgam"
         elsif inline && mruby_header?(header)
-          if @inline_mruby
-            # Recursively inline this header
-            "#{prefix}#{inline_header(header)}"
-          else
-            # Compiler TU: mruby core headers live in the shared mruby.h
-            "#{prefix}// #{include_stmt} - in amalgam header"
-          end
+          # Recursively inline this header
+          "#{prefix}#{inline_header(header)}"
         elsif (gem_path = gem_header_path(header, quote_type))
           # Gem-local header (e.g. mruby-compiler's mrc_common.h or its
           # vendored prism.h). Inline it at the first include site; later

--- a/mrbgems/mruby-compiler/src/parser_util.c
+++ b/mrbgems/mruby-compiler/src/parser_util.c
@@ -9,5 +9,6 @@ mrc_sym_name_len(mrc_ccontext *c, mrc_sym sym, mrc_int *lenp)
     *lenp = constant->length;
     return (const char*)constant->start;
   }
+  *lenp = 0;
   return NULL;
 }

--- a/mrbgems/mruby-io/include/io_hal.h
+++ b/mrbgems/mruby-io/include/io_hal.h
@@ -38,6 +38,27 @@ MRB_BEGIN_DECL
  * Platform-independent type definitions
  */
 
+/* A host that names struct stat's time fields with macros (st_atime for
+   st_atim.tv_sec, as glibc does) would rewrite the same names below, whose
+   own are plain members.  A source of this gem includes <sys/stat.h> after
+   this header and never sees them defined here, but the amalgamated build
+   puts every header in one translation unit, where another gem's header
+   (mruby-compiler's prism) has pulled <sys/stat.h> in first.  Set them
+   aside across the struct and put them back, so that reading the system's
+   fields by their documented names still works afterwards. */
+#ifdef st_atime
+# define MRB_IO_STAT_TIME_MACROS_SET_ASIDE
+# if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER)
+#  pragma push_macro("st_atime")
+#  pragma push_macro("st_mtime")
+#  pragma push_macro("st_ctime")
+#  define MRB_IO_STAT_TIME_MACROS_RESTORABLE
+# endif
+# undef st_atime
+# undef st_mtime
+# undef st_ctime
+#endif
+
 /* File status structure - platform-independent representation */
 typedef struct mrb_io_stat {
   mrb_int st_dev;       /* Device ID */
@@ -54,6 +75,16 @@ typedef struct mrb_io_stat {
   mrb_int  st_blksize;   /* Block size for filesystem I/O */
   mrb_int  st_blocks;    /* Number of 512B blocks allocated */
 } mrb_io_stat;
+
+#ifdef MRB_IO_STAT_TIME_MACROS_SET_ASIDE
+# ifdef MRB_IO_STAT_TIME_MACROS_RESTORABLE
+#  pragma pop_macro("st_ctime")
+#  pragma pop_macro("st_mtime")
+#  pragma pop_macro("st_atime")
+#  undef MRB_IO_STAT_TIME_MACROS_RESTORABLE
+# endif
+# undef MRB_IO_STAT_TIME_MACROS_SET_ASIDE
+#endif
 
 /* Timeval structure for select() */
 typedef struct mrb_io_timeval {

--- a/mrbgems/mruby-io/src/io.c
+++ b/mrbgems/mruby-io/src/io.c
@@ -660,7 +660,7 @@ fptr_finalize(mrb_state *mrb, struct mrb_io *fptr, int quiet)
     do {
       pid = mrb_hal_io_waitpid(mrb, fptr->pid, &status, 0);
     } while (pid == -1 && errno == EINTR);
-    if (!quiet && pid == fptr->pid) {
+    if (!quiet && pid > 0 && pid == fptr->pid) {
       io_set_process_status(mrb, pid, status);
     }
     fptr->pid = 0;

--- a/tasks/amalgam.rake
+++ b/tasks/amalgam.rake
@@ -25,23 +25,10 @@ MRuby.each_target do
     amalgam.generate_source(t.name)
   end
 
-  # mruby-compiler (and its vendored prism) cannot share a translation
-  # unit with the core sources; it gets its own amalgamated file
-  amalgam_files = [header_file, source_file]
-  if gems.any? { |g| MRuby::Amalgam::SEPARATE_TU_GEMS.include?(g.name) }
-    compiler_file = "#{amalgam_dir}/mruby_compiler.c"
-    file compiler_file => source_deps do |t|
-      amalgam = MRuby::Amalgam.new(self)
-      amalgam.generate_compiler_source(t.name)
-    end
-    amalgam_files << compiler_file
-  end
-
   desc "Generate amalgamated mruby.h and mruby.c in #{amalgam_dir}"
-  task :amalgam => amalgam_files do
+  task :amalgam => [header_file, source_file] do
     puts "Amalgamation complete:"
     puts "  Header: #{header_file}"
     puts "  Source: #{source_file}"
-    puts "  Compiler source: #{amalgam_files[2]}" if amalgam_files.size > 2
   end
 end


### PR DESCRIPTION
## Summary

The amalgamation cannot be compiled at all when the build has `mruby-compiler` in it: the second output file names two prism headers that were never inlined, `mruby.h` cannot be included after `<sys/stat.h>`, and neither of those is what the split into a second file was written for.

## Changes

| File                                       | What                                                                                                                                                                                                                                                                                                                                                                            |
| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-io/include/io_hal.h`        | set `st_atime` / `st_mtime` / `st_ctime` aside across `mrb_io_stat` and put them back afterwards                                                                                                                                                                                                                                                                                |
| `mrbgems/mruby-io/src/io.c`                | `fptr_finalize()` reads a spawned child's `status` only where the wait reaped it                                                                                                                                                                                                                                                                                                |
| `mrbgems/mruby-compiler/src/parser_util.c` | `mrc_sym_name_len()` writes 0 through `lenp` where it finds no name                                                                                                                                                                                                                                                                                                             |
| `lib/mruby/amalgam.rb`                     | remove `SEPARATE_TU_GEMS`, `generate_compiler_source()`, `write_compiler_preamble()`, `write_compiler_headers()`, `write_compiler_sources()`, `main_library_gems()`, `separate_tu_gems()` and the `@inline_mruby` switch; add `opcode_header_in_public?()` and `source_label()`; let `gem_include_dirs()` and `gem_source_files()` reach what a gem writes under the build tree |
| `tasks/amalgam.rake`                       | one output file fewer                                                                                                                                                                                                                                                                                                                                                           |
| `doc/guides/amalgamation.md`               | name the one generated `.c` file where it named two                                                                                                                                                                                                                                                                                                                             |

### `mruby_compiler.c` on master does not compile

`prism/ast.h` and `prism/diagnostic.h`, and the sources `node.c`, `diagnostic.c`, `prettyprint.c`, `serialize.c` and `token_type.c` beside them, are written by prism's templates into `#{build_root}/prism/`, outside the gem's own tree. `gem_include_dirs()` kept only include dirs under the gem dir and `gem_source_files()` only sources under it, so neither the headers nor the sources reached the output:

```console
$ rake amalgam
$ cc -O0 -Wall -Wundef -c build/host/amalgam/mruby_compiler.c
build/host/amalgam/mruby_compiler.c:1500:10: fatal error: prism/diagnostic.h: No such file or directory
```

Handing the compiler those include dirs does not get past it. The two `#include` lines sit ahead of the amalgam's own copy of `prism/util/pm_string.h` and `prism/util/pm_constant_pool.h` (the `#define` that would suppress a second copy comes later in the file), so the disk copies are read first and `pm_constant_id_list_t`, `pm_constant_pool_find()` and the rest are declared twice.

`gem_include_dirs()` now takes the include dirs the gem itself adds: its own, and the ones under the build tree where it writes what it generates. The build's own include dirs are left out, since their headers are the core's and belong to the amalgamated `mruby.h`; a dependency gem's include dir is still left to that gem's own entry. `gem_source_files()` accepts a source under the build root as well, minus `gem_init.c` and `gem_mrblib.c`, which are written after every other source of the gem and stay with that step. A source is named in the output relative to whichever root it sits under, so a generated one is not labelled by an absolute path naming the machine that ran the build.

### `mruby.h` cannot be included after `<sys/stat.h>`

glibc names `struct stat`'s time fields with macros (`st_atime` expands to `st_atim.tv_sec`), and `mrb_io_stat` spells its own members the same way. A source of mruby-io never sees the collision, because it includes `io_hal.h` before `<sys/stat.h>`; a consumer of the amalgamation that includes the system header first does:

```console
$ cc -O0 -I build/host/amalgam -c app.c
In file included from app.c:4:
build/host/amalgam/mruby.h:10720:12: error: expected ':', ',', ';', '}' or '__attribute__' before '.' token
10720 |   mrb_int  st_atime;     /* Last access time */
      |            ^~~~~~~~
```

The three macros are undone across the struct and, where the compiler has `push_macro`, put back afterwards, so that reading the system's fields by their documented names still works. `file.c` and the POSIX port keep the `#undef` each does for its own body.

### A status the caller reads where the wait did not write it

`fptr_finalize()` waits on a spawned child and reads `status` where the pid it got back is the one it asked about. A failed wait leaves that pid at -1 without writing `status`, and nothing rules out an `fptr->pid` of -1 reaching the comparison; the Windows port also returns 0 for a wait that timed out, and leaves `status` alone when it does. The read is guarded on `pid > 0` now.

GCC sees the path only where `io_hal.c` and `io.c` share a translation unit, and reports `status` as `-Wmaybe-uninitialized` on the merged file. The per-file build, where the port is an external symbol, assumes the write and says nothing: `io.c` at `-O3 -Wall`, with the flags the CI config passes it, is silent on master.

### A length the caller reads and the callee may not have written

`mrc_sym_name_len()` writes `*lenp` only where the constant pool has an entry for the symbol, and six of its callers in `dump.c` ignore the return value and read the length regardless: the size pass adds `len + 1` per symbol, the filename table adds `sizeof(uint16_t) + filename_len`, and the writers copy `str_len` bytes each. `mrb_sym_name_len()`, which this mirrors, writes 0 through `lenp` before returning `NULL` for a symbol it cannot name. The six reads sit in a different translation unit from the function, so GCC sees them only once the two share one, and reports them as `-Wmaybe-uninitialized` on the merged file.

### The opcode enum, declared twice

`mruby/opcode.h` and the gem's `mrc_opcode.h` share the include guard `MRUBY_OPCODE_H`, a translation unit normally seeing only one of them, and the amalgam strips the guard from each header it emits. With the gem merged, `mruby.h` carries `mrc_opcode.h` and `mruby.c` emitted `mruby/opcode.h` on top of it, which is 119 of the errors below. The second one is now skipped where a gem header has already claimed that guard, the way `mruby/internal.h` is already skipped. What differs between the two headers is the six operand-fetch macros, and an include site re-points those either way.

That leaves `NUMERIC_SHIFT_WIDTH_MAX`, which the VM and the code generator each define over their own integer width; it joins the macros a source is not meant to hand on.

### What the split was said to be for

The comment on `SEPARATE_TU_GEMS` named the gem's file-scope statics and its operand-fetch macros. The statics are not the obstacle: `write_static_renames()` already renames them apart. Merging the gem back with nothing else changed, and the two prism include dirs handed to the compiler so it gets past the missing header, gives 214 errors from exactly the two families above:

```console
$ cc -O0 -Wall -Wundef -I build/prism/include -I mrbgems/mruby-compiler/lib/prism/include \
     -c build/host/amalgam/mruby.c
  119  redeclaration of enumerator 'OP_ADD', 'OP_ALIAS', ...
   74  redeclaration or conflicting type, 'PM_STRING_CONSTANT', 'pm_constant_pool_find', ...
    8  'mrb_io_stat' has no member named 'st_atime' / 'st_mtime' / 'st_ctime'
   13  the rest, downstream of those
```

## Behaviour

`rake amalgam` writes `mruby.h` and `mruby.c`, and nothing else. `doc/guides/amalgamation.md` describes two output files, which is right again, and the sentence #7502 added about the `MRB_AMALGAMATION` define now names the one `.c` file there is.

With #7502 in master, GCC compiles the merged file at `-O2` in 20s to a 2.8MB object and clang in 21s. Master's own `mruby.c` compiles at `-O2` as well, but its `mruby_compiler.c` does not compile at any optimisation level, so nothing has ever linked from master's output when the build has `mruby-compiler` in it.

## Size

`bin/mruby` `.text` from `build_config/ci/gcc-clang.rb`, `CC=gcc CXX=g++ LD=gcc`, against master at `fdf857e6e`:

| Build              | master    | This PR   | Delta |
| ------------------ | --------- | --------- | ----- |
| `bintest`          | 1,384,326 | 1,384,310 | -16   |
| `ascii-ctype`      | 1,368,870 | 1,368,854 | -16   |
| `byte-string`      | 1,346,358 | 1,346,342 | -16   |
| `cxx_abi`          | 1,417,705 | 1,417,689 | -16   |
| `no-float`         | 1,310,270 | 1,310,254 | -16   |
| `no-bigint`        | 1,268,966 | 1,268,950 | -16   |
| `full-debug` (-O0) | 1,978,310 | 1,978,326 | +16   |

Two objects move across all seven builds, and nothing else does. `parser_util.o` takes the added store: `.text` 41 to 43 at `-O3`, 96 to 107 at `-O0`. `io.o` takes the added guard: 20,094 to 20,078 at `-O3`, 25,030 to 25,036 at `-O0`. The six optimised binaries end up 16 smaller and `full-debug` 16 larger, both after the padding each already had.

`dump.o` (8,917), `codedump.o` (21,500) and `mruby_compat.o` (16,589) are unchanged, since none of them inlines `mrc_sym_name_len()`. The `io_hal.h` change costs nothing at all: every other object of mruby-io keeps a byte-identical `.text` (`gem_init.o` 313, `ports/posix/io_hal.o` 2,517, `src/file.o` 7,321, `src/file_test.o` 2,874, `src/mruby_io_gem.o` 89), as does every other allocatable section of them.

The amalgam itself writes more, because it now writes what it was dropping. Sources as `rake amalgam` emits them, and the `.text` of the object `gcc -O3` makes of each, on the default config:

| Default config             | master           | This PR   | Delta      |
| -------------------------- | ---------------- | --------- | ---------- |
| `mruby.h`                  | 425,628          | 784,601   | +358,973   |
| `mruby.c`                  | 3,905,718        | 6,702,247 | +2,796,529 |
| `mruby_compiler.c`         | 1,939,315        | none      | -1,939,315 |
| Sources, total             | 6,270,661        | 7,486,848 | +1,216,187 |
| `mruby.o` `.text`          | 955,145          | 1,511,785 | +556,640   |
| `mruby_compiler.o` `.text` | does not compile | none      |            |

Of the 1,216,187 source bytes it grows by, 1,031,786 is the five generated prism sources master never emitted, and the rest is mruby-compiler's headers reaching `mruby.h` as every other gem's do. The 556,640 of `.text` is the same thing after compilation: master's 955,145 is an mruby with no compiler in it, and it never gets one, because `mruby_compiler.c` stops at `prism/diagnostic.h`. Master reaches no linkable object here at all.

A `full-core` gembox build, which is what the CI configs carry, moves by the same amount, since what arrives is the same compiler either way:

| `full-core` gembox         | master           | This PR   | Delta      |
| -------------------------- | ---------------- | --------- | ---------- |
| `mruby.h`                  | 443,417          | 802,390   | +358,973   |
| `mruby.c`                  | 4,076,674        | 6,873,960 | +2,797,286 |
| `mruby_compiler.c`         | 1,939,315        | none      | -1,939,315 |
| Sources, total             | 6,459,406        | 7,676,350 | +1,216,944 |
| `mruby.o` `.text`          | 1,047,145        | 1,602,649 | +555,504   |
| `mruby_compiler.o` `.text` | does not compile | none      |            |

On `minimal`, which has no `mruby-compiler` to fold in, nothing moves:

| `minimal` config    | master    | This PR   | Delta |
| ------------------- | --------- | --------- | ----- |
| `mruby.h`           | 267,722   | 267,722   | 0     |
| `mruby.c`           | 1,420,140 | 1,420,209 | +69   |
| `mruby.o` `.text`   | 361,928   | 361,928   | 0     |
| `mruby.o` `.rodata` | 29,956    | 29,956    | 0     |

The 69 source bytes are the revision stamp and the one added `#undef NUMERIC_SHIFT_WIDTH_MAX`.

## Testing

Generated and compiled from the host config, then linked against an embedder that parses Ruby at run time, reads a file's three timestamps through mruby-io, and reads `struct stat`'s own `st_mtime` afterwards, which is what the `push_macro` half is for:

```console
$ rake amalgam
$ cc -O0 -Wall -Wundef -c build/host/amalgam/mruby.c -o mruby.o     # 0 errors, 0 warnings
$ cc -O0 -I build/host/amalgam -c app.c -o app.o
$ cc app.o mruby.o -o app -lm
$ ./app
[[:a, 1], ["b", 2], [610, "Integer"], [3, 6, 9], [2, 3], [65, 66, 67], [3, 2, 1], 4950, true, 1, true]
[true, true, true]
stat mtime ok: 1
```

A `full-core` gembox build links and runs the same embedder to the same three lines, at `-O3`. `MRUBY_CONFIG=minimal rake amalgam` generates and compiles clean as well, and its output is byte-identical to master's apart from those 69 bytes.

`-O0` with `-Wall -Wundef` is clean. At `-O2`, with the `-std=gnu99` the toolchain passes its own sources, what is left is:

- GCC, one: `-Wstringop-overflow=` on `__builtin_memcpy` in prism's `pm_buffer_append()`, inlined into `pm_parse_stream_read()`, which only a single translation unit reaches. prism is a submodule and the line is upstream's.
- clang, three: `-Wtypedef-redefinition` on `mempool`, `mrb_mempool` and `mrb_parser_foreach_top_variable_func`, a repeat C11 allows and C99 does not. Master's own output already carries the first two; the third arrives with the compiler gem. At clang's default C17 there are none.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, under both `gcc` and `clang`, is green on all seven builds: 0 KO and 0 Crash throughout, and bintest 146 OK / 1 Skip.

| Build         | Total | OK    | Skip |
| ------------- | ----- | ----- | ---- |
| `full-debug`  | 2,879 | 2,869 | 10   |
| `bintest`     | 2,879 | 2,860 | 19   |
| `cxx_abi`     | 2,879 | 2,860 | 19   |
| `byte-string` | 2,795 | 2,728 | 67   |
| `ascii-ctype` | 2,867 | 2,846 | 21   |
| `no-float`    | 2,614 | 2,518 | 96   |
| `no-bigint`   | 2,831 | 2,799 | 32   |

`rake -m test` on the default config gives 2,568 OK / 0 KO / 0 Crash / 67 Skip and bintest 129 OK / 0 KO / 1 Skip.

## Environment

<details>

|            |                                                           |
| ---------- | --------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                        |
| Kernel     | 7.0.0-31-generic                                          |
| CPU        | AMD Ryzen 9 5950X (16C/32T)                               |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), clang 23.1.0 |
| binutils   | GNU ld 2.47.20260726                                      |
| CRuby      | 4.0.6 (2026-07-14 revision 03b6d3f889)                    |
| rake       | 13.3.1                                                    |

`SRC` is the source tree, `BUILD` the build directory.

`build_config/default.rb`, build `host`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

`build_config/ci/gcc-clang.rb`, the seven builds under `gcc`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

and the same seven under `CC=clang CXX=clang++ LD=clang`:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The amalgamation was compiled by hand, outside any build config, with the lines shown in the sections above.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Amalgamated builds now consolidate compiler components into a single generated source file.

* **Bug Fixes**
  * Improved compatibility with system headers that define file-statistic macros.
  * Corrected symbol lookup length reporting when a symbol is not found.
  * Process finalization now records status only for the expected child process.

* **Documentation**
  * Updated amalgamation size ranges and clarified generated-source definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->