### PR TITLE
mruby-regexp: keep the backtracking tests inside the stack they ask for

### DIFF
--- a/mrbgems/mruby-regexp/test/backtracking_stack.rb
+++ b/mrbgems/mruby-regexp/test/backtracking_stack.rb
@@ -11,8 +11,13 @@
 #
 # The engine is doing what the build asked there, and the assertions have
 # nothing to say about it. 48 is the limit at which every pattern in these
-# files matches again (at 44 one test is left, at 36 two, at 1 fifty-one),
-# so a test that reaches the engine asks for that much and skips below it.
+# files matches again: with the guard off, a build reading its strings as
+# characters leaves one test at 47, two at 40, three at 36, thirty-nine at 4
+# and eighty-four at 1. A test that reaches the engine asks for that much and
+# skips below it. What stands at the top of that is the search that reaches
+# the step limit, which holds some three entries per character of its run.
+# A test wanting more than this is a test to size down: a lookbehind body of
+# forty branches sits under it at one entry per branch.
 #
 # What asks for it is a test and not a subject: an assertion that reaches no
 # further than the parser, or one whose pattern the Pike VM runs, holds none

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -221,7 +221,6 @@ assert("Regexp.union") do
 
   # no pattern is a pattern that never matches
   assert_equal(/(?!)/, Regexp.union)
-  assert_nil Regexp.union =~ ""
 
   # one pattern: a Regexp is answered as itself, a String is quoted
   re = /a/i
@@ -237,6 +236,14 @@ assert("Regexp.union") do
   assert_raise(TypeError) { Regexp.union(nil) }
   assert_raise(TypeError) { Regexp.union("a", :b) }
   assert_raise(TypeError) { Regexp.union(["a"], "b") }
+end
+
+assert("Regexp.union of no patterns matches nothing") do
+  need_backtracking_stack
+  # What union answers with there is a lookaround, so the search runs on the
+  # backtracking stack rather than the Pike VM, and the assertion's barrier
+  # is what it asks the build for.
+  assert_nil Regexp.union =~ ""
 end
 
 assert("Regexp#inspect") do

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -133,8 +133,8 @@ end
 
 assert("Regexp - {0} erases a call's code but not its reference checks") do
   # The reference a {0}-erased call spelled is still read against the whole
-  # pattern: CRuby refuses each of these, erased or not. No call survives to
-  # run, so no backtracking stack is asked for.
+  # pattern: CRuby refuses each of these, erased or not. Each stops at the
+  # parser, so no search runs and no backtracking stack is asked for.
   assert_raise_with_message(RegexpError,
                             "undefined name <nope> reference: /(?:\\g<nope>){0}/") do
     Regexp.new("(?:\\g<nope>){0}")
@@ -151,8 +151,13 @@ assert("Regexp - {0} erases a call's code but not its reference checks") do
                             "multiplex definition name <a> call: /(?:\\g<a>){0}(?<a>x)(?<a>y)/") do
     Regexp.new("(?:\\g<a>){0}(?<a>x)(?<a>y)")
   end
+end
 
-  # a reference the pattern does define stays fine erased
+assert("Regexp - a {0}-erased call leaves the group it named callable") do
+  need_backtracking_stack
+  # A reference the pattern does define stays fine erased. The group stays
+  # callable whether or not a call reaches it, which is what puts this search
+  # on the backtracking stack: the frame is there to be returned to.
   assert_equal "x", "x".match(Regexp.new("(?:\\g<a>){0}(?<a>x)"))[0]
 end
 

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -807,12 +807,20 @@ assert("Regexp - /i folds an ASCII letter's class whole") do
   assert_true Regexp.new("s", Regexp::IGNORECASE).match?(long_s)
   assert_false Regexp.new("[^s]", Regexp::IGNORECASE).match?(long_s)
   assert_true Regexp.new(long_s, Regexp::IGNORECASE).match?("S")
-  # A backreference compares the same way, so the capture and the repeat need
-  # not hold the same bytes.
-  assert_equal "k#{kelvin}", "k#{kelvin}".match(Regexp.new("(k)\\1", Regexp::IGNORECASE))[0]
   # Without /i none of it folds.
   assert_false Regexp.new("k").match?(kelvin)
   assert_true Regexp.new("[^k]").match?(kelvin)
+end
+
+assert("Regexp - /i folds an ASCII letter's class for a backreference") do
+  need_backtracking_stack
+  # A backreference compares the same way the class above does, so the capture
+  # and the repeat need not hold the same bytes. It is a backreference that
+  # sends this to the backtracking engine, where the assertions above run on
+  # the Pike VM whatever the build's stack limit is.
+  skip unless __ENCODING__ == "UTF-8"
+  kelvin = "K"
+  assert_equal "k#{kelvin}", "k#{kelvin}".match(Regexp.new("(k)\\1", Regexp::IGNORECASE))[0]
 end
 
 assert("Regexp - /i keeps the word class inside ASCII") do
@@ -2909,6 +2917,7 @@ assert("Regexp - a capture inside a lookaround is undone with the lookaround") d
 end
 
 assert("Regexp - lookbehind over a class that can match a multibyte character") do
+  need_backtracking_stack
   # A class consumes exactly one character whatever its members are, so the
   # rewind steps back that many characters rather than assuming a byte each.
   # A build that reads its strings by byte has one byte per character, so it
@@ -2942,6 +2951,7 @@ assert("Regexp - lookbehind over a class that can match a multibyte character") 
 end
 
 assert("Regexp - lookbehind against a binary subject rewinds by bytes") do
+  need_backtracking_stack
   # A binary subject advances one byte at a time, so the same compiled
   # pattern rewinds by its byte count there: two for the literal Ā, and one
   # for a class, which is handed the raw byte as its codepoint. What this

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -390,10 +390,24 @@ assert("Regexp - an alternation holds as many branches as the pattern writes") d
   assert_equal 100, longest_first.match("a" * 100)[0].size
   assert_equal 1, shortest_first.match("a" * 100)[0].size
 
-  # A lookbehind body of that many branches carries a rewind per branch, as
-  # a body of two does: `3`, `11` and `222` stand among the seventy, one,
-  # two and three characters wide.
+  # A lookbehind body counts its branches the same way, seventy of them
+  # compiling where the array of 64 refused the 64th. Compiling asks for no
+  # backtracking stack, so the count stands here rather than with the match
+  # below, which pays an entry per branch.
   alts = (1..70).map { |i| i.to_s(36) * (i % 3 + 1) }
+  assert_kind_of Regexp, Regexp.new("(?<=#{alts.join('|')})!")
+end
+
+assert("Regexp - a lookbehind rewinds once per branch of its body") do
+  need_backtracking_stack
+  # A lookbehind body of many branches carries a rewind per branch, as a body
+  # of two does: `3`, `11` and `222` stand among the forty, one, two and
+  # three characters wide. The branch a rewind is trying stands on the
+  # backtracking stack while it runs, so a body of N branches asks the build
+  # for N entries and the lookaround's barrier for one more: forty of them
+  # match at a limit of 41 and not at 40, which is why the count is one the
+  # guard's stack covers rather than the seventy compiled above.
+  alts = (1..40).map { |i| i.to_s(36) * (i % 3 + 1) }
   behind = Regexp.new("(?<=#{alts.join('|')})!")
   assert_equal 1, behind =~ "3!"
   assert_equal 2, behind =~ "11!"

--- a/mrbgems/mruby-regexp/test/regexp_utf8.rb
+++ b/mrbgems/mruby-regexp/test/regexp_utf8.rb
@@ -139,9 +139,8 @@ assert("Regexp - quantifier on a multibyte literal") do
   # Three and four byte characters take the same path.
   assert_equal 6, "日日".match(/日+/)[0].bytesize
   assert_equal 8, "𝕏𝕏".match(/𝕏+/)[0].bytesize
-  # A quantified literal after another atom, and a non-greedy one.
+  # A quantified literal after another atom.
   assert_equal 5, "aĀĀ".match(/aĀ+/)[0].bytesize
-  assert_equal 2, "ĀĀ".match(/Ā+?/)[0].bytesize
   # Scanning must not split a run into one match per character.
   assert_equal [4, 2], "ĀĀxĀ".scan(/Ā+/).map { |s| s.bytesize }
   # An optional multibyte literal that is absent still matches empty.
@@ -165,7 +164,6 @@ assert("Regexp - quantifier on an escaped multibyte literal") do
   assert_equal 6, Regexp.new("\\日+").match("日日")[0].bytesize
   assert_equal 8, Regexp.new("\\𝕏+").match("𝕏𝕏")[0].bytesize
   assert_equal 5, Regexp.new("a\\Ā+").match("aĀĀ")[0].bytesize
-  assert_equal 2, Regexp.new("\\Ā+?").match("ĀĀ")[0].bytesize
   # Inside [...] the same escape has to read as one codepoint, or the class
   # holds the lead byte and the continuation byte as two wrong members.
   assert_true Regexp.new("[\\Ā]").match?("Ā")
@@ -177,6 +175,17 @@ assert("Regexp - quantifier on an escaped multibyte literal") do
   # same way however the pattern spells them.
   assert_equal 4, Regexp.new("\\xC4\\x80+").match("ĀĀ")[0].bytesize
   assert_equal 4, Regexp.new("\\xC4\\x80\\xC4\\x80").match("ĀĀ")[0].bytesize
+end
+
+assert("Regexp - a non-greedy quantifier on a multibyte literal binds to the character") do
+  need_backtracking_stack
+  # The two spellings above, asked to stop as early as they may. A non-greedy
+  # repeat is what the Pike VM cannot run, so these are the assertions of the
+  # two blocks that stand on the backtracking stack; the rest run at any
+  # stack limit.
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal 2, "ĀĀ".match(/Ā+?/)[0].bytesize
+  assert_equal 2, Regexp.new("\\Ā+?").match("ĀĀ")[0].bytesize
 end
 
 assert("Regexp - quantifier on an invalid multibyte literal") do
@@ -335,17 +344,14 @@ assert("Regexp - a byte that spells no character matches only a byte") do
   assert_nil j.match(Regexp.new("\xc4"))          # literal fast path
   assert_nil ("x" + j).match(Regexp.new("\xc4"))
   assert_nil j.match(Regexp.new("\xc4+"))         # pike VM
-  assert_nil j.match(Regexp.new("(\xc4)\\1?"))    # backtracking engine
   assert_equal j.bytes, j.gsub(Regexp.new("\xc4"), "!").bytes
   # Nothing built on it reaches the character either, where the rule used to be
   # a test on the end of the match and let these through.
   assert_nil j.match(Regexp.new("\xc4."))
   assert_nil j.match(Regexp.new("\xc4(?:\xb5)?"))
-  assert_nil j.match(Regexp.new("(?=\xc4)\xc4\xb5"))
   assert_equal 0, j.match(Regexp.new("\xc4*"))[0].bytesize
   # The bytes that do spell the character are the character, so they match it.
   assert_equal 2, j.match(Regexp.new("\xc4\xb5"))[0].bytesize
-  assert_equal 2, j.match(Regexp.new("(\xc4\xb5)\\1?"))[0].bytesize
   # Read as binary every byte stands alone, so every one of them is a byte the
   # pattern can name.
   if Object.const_defined?(:Encoding)
@@ -359,6 +365,18 @@ assert("Regexp - a byte that spells no character matches only a byte") do
   assert_equal 1, (b + b).b.match(Regexp.new(b))[0].bytesize
   assert_equal 2, (b + b).b.match(Regexp.new(b + "+"))[0].bytesize
   assert_equal 1, ("a" + b).b.match(Regexp.new(b))[0].bytesize
+end
+
+assert("Regexp - the backtracking engine reads such a byte the same way") do
+  need_backtracking_stack
+  # The same question put to the third engine: a backreference or a lookaround
+  # is what sends a pattern there, where the block above stays with the
+  # literal fast path and the Pike VM and runs at any stack limit.
+  skip unless __ENCODING__ == "UTF-8"
+  j = "ĵ"
+  assert_nil j.match(Regexp.new("(\xc4)\\1?"))
+  assert_nil j.match(Regexp.new("(?=\xc4)\xc4\xb5"))
+  assert_equal 2, j.match(Regexp.new("(\xc4\xb5)\\1?"))[0].bytesize
 end
 
 assert("Regexp - a capture spans whole characters") do
@@ -382,9 +400,6 @@ assert("Regexp - a capture spans whole characters") do
   assert_nil Regexp.new("(\xc4).").match(a)
   assert_nil Regexp.new("\xc4(\x80)").match(a)
   assert_nil Regexp.new("((\xc4).)").match(a)
-  assert_nil Regexp.new("(\xc4).\\1?").match(a)      # backtracking engine
-  assert_nil Regexp.new("(?=(\xc4))\xc4\x80").match(a)
-  assert_equal 0, Regexp.new("(?!(\xc4))").match(a).begin(0)
   # A capture that does span whole characters matches, and its offsets are the
   # characters it holds.
   m = Regexp.new("(\xc4\x80)(.)").match(a)
@@ -403,6 +418,18 @@ assert("Regexp - a capture spans whole characters") do
   bm = Regexp.new("(" + b + ")(" + b + ")").match((b + b).b)
   assert_equal [0x81], bm[1].bytes
   assert_equal [0x81], bm[2].bytes
+end
+
+assert("Regexp - a capture the backtracking engine records spans whole characters") do
+  need_backtracking_stack
+  # A group inside a lookaround, and one a backreference reads back, are
+  # recorded by the engine the block above does not reach. The rule is the
+  # same there: no group opens or closes inside a character.
+  skip unless __ENCODING__ == "UTF-8"
+  a = "Āx"  # C4 80 78
+  assert_nil Regexp.new("(\xc4).\\1?").match(a)
+  assert_nil Regexp.new("(?=(\xc4))\xc4\x80").match(a)
+  assert_equal 0, Regexp.new("(?!(\xc4))").match(a).begin(0)
 end
 
 assert("Regexp - a lookbehind branch counts its own width in both units") do
@@ -425,6 +452,7 @@ assert("Regexp - a lookbehind branch counts its own width in both units") do
 end
 
 assert("Regexp - a lookaround holds where its sub-pattern matches") do
+  need_backtracking_stack
   # A lookaround consumes nothing, so where its sub-pattern stopped was not the
   # end of a match and nothing held it to a character. It could therefore
   # answer the opposite of the body it asserts: at the start of "Ā" the pattern
@@ -1075,6 +1103,7 @@ assert('Regexp - a word boundary sits beside any script') do
 end
 
 assert("Regexp - an absent repeater's run stops on a character boundary") do
+  need_backtracking_stack
   skip unless __ENCODING__ == "UTF-8"
 
   # The run may not hold the body's match, so it stops before the first byte

--- a/mrbgems/mruby-regexp/test/unicode_case.rb
+++ b/mrbgems/mruby-regexp/test/unicode_case.rb
@@ -53,8 +53,6 @@ assert("Regexp - Unicode case folding under /i") do
   # U+0103 folds from U+0102, which the range holds.
   assert_equal "ă", "ă".match(/[\u{100}-\u{102}]/i)[0]
   assert_nil "ą".match(/[\u{100}-\u{102}]/i)
-  # Backreferences compare folded too.
-  assert_equal "Āā", "Āā".match(/(Ā)\1/i)[0]
   # Without /i nothing folds.
   assert_nil "ā".match(/Ā/)
   assert_nil "K".match(/k/)
@@ -65,6 +63,15 @@ assert("Regexp - Unicode case folding under /i") do
   # The expansion into several codepoints is what stays out of reach.
   assert_nil "ss".match(/ß/i)
   assert_nil "ff".match(/ﬀ/i)
+end
+
+assert("Regexp - a backreference under /i folds by Unicode") do
+  need_backtracking_stack
+  # A backreference compares folded too, which is the one assertion of the
+  # folding above that runs on the backtracking engine rather than the Pike
+  # VM.
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal "Āā", "Āā".match(/(Ā)\1/i)[0]
 end
 
 assert("Regexp - /i literals share one class per codepoint") do

--- a/mrbgems/mruby-regexp/test/unicode_ctype.rb
+++ b/mrbgems/mruby-regexp/test/unicode_ctype.rb
@@ -65,15 +65,22 @@ assert("Regexp - POSIX brackets classify by Unicode above ASCII") do
   assert_equal "あいう", "123あいう456".match(/[[:^digit:]]+/)[0]
   assert_equal "１２３", "abc１２３def".match(/[[:digit:]]+/)[0]
   assert_equal ["あ", "い"], "あ\u{3000}い".scan(/[[:^space:]]/)
-  # A lookbehind steps back over the whole of the character a bracket admits.
-  assert_equal 1, "あx" =~ /(?<=[[:alpha:]])x/
-  assert_nil "あx" =~ /(?<![[:alpha:]])x/
   # [:xdigit:] and [:ascii:] are sets ASCII defines, so they hold nothing
   # above it on any build and their negations hold everything.
   assert_false "Ａ".match?(/[[:xdigit:]]/)
   assert_true "Ａ".match?(/[[:^xdigit:]]/)
   assert_false "あ".match?(/[[:ascii:]]/)
   assert_true "あ".match?(/[[:^ascii:]]/)
+end
+
+assert("Regexp - a lookbehind steps back over a character a bracket admits") do
+  need_backtracking_stack
+  # The rewind counts the whole of the character, as the forward match above
+  # consumes the whole of it. A lookbehind is what puts this on the
+  # backtracking stack, where the brackets above run on the Pike VM.
+  skip unless __ENCODING__ == "UTF-8"
+  assert_equal 1, "あx" =~ /(?<=[[:alpha:]])x/
+  assert_nil "あx" =~ /(?<![[:alpha:]])x/
 end
 
 assert("Regexp - POSIX brackets combine above ASCII") do


### PR DESCRIPTION
## Summary

`RE_TESTS_NEED_STACK` says what a test reaching the backtracking engine asks of `MRB_REGEXP_STACK_LIMIT`, and it was not saying it: a build setting the limit to that very number crashed mrbtest, and a build reading its strings as characters crashed eleven more tests at a limit of 1.

## Changes

| File                         | What                                                                                                  |
| ---------------------------- | ----------------------------------------------------------------------------------------------------- |
| `test/backtracking_stack.rb` | `RE_TESTS_NEED_STACK` keeps its 48; the comment names what sets it and carries re-measured counts     |
| `test/regexp_syntax.rb`      | the lookbehind branch count is split into a compile and a match of forty branches; three more guarded |
| `test/regexp.rb`             | `Regexp.union` with no patterns is split into an assert of its own under the guard                    |
| `test/regexp_call.rb`        | the call a `{0}` left reachable is split into an assert of its own under the guard                    |
| `test/regexp_utf8.rb`        | six assertions that reach the engine are guarded, three of them split from their Pike VM blocks       |
| `test/unicode_case.rb`       | the backreference under `/i` is split into an assert of its own under the guard                       |
| `test/unicode_ctype.rb`      | the lookbehind over a POSIX bracket is split into an assert of its own under the guard                |

### What the guard promises

`backtracking_stack.rb` reads its number as "the limit at which every pattern in these files matches again", and a build below it skips the tests that ask for the engine rather than reading a `RegexpError` as a failure. What the number does not do is find the assertions for itself, so an assertion added outside the guard is one the number stops describing. Three had been added:

```
RegexpError: Regexp - an alternation holds as many branches as the pattern writes
  => stack limit over (MRB_REGEXP_STACK_LIMIT)
  Total: 2638   OK: 2570   KO: 0   Crash: 1   Skip: 68
```

That is a build at `MRB_REGEXP_STACK_LIMIT=48`, the number the file itself names.

### What each of the three asks for

A lookbehind carries a rewind per branch and each branch stands on the stack while it runs, so a body of N branches asks for N entries and the lookaround's barrier for one more. Measured, forty branches match at a limit of 41 and not at 40; the body in that assertion held seventy, so it wanted 71. The other two failed at a limit of 1: `Regexp.union` with no patterns answers `/(?!)/`, whose lookaround wants 2, and a `{0}`-erased call leaves the group it named callable, whose frame wants 4.

### Why the number stays 48

Raising `RE_TESTS_NEED_STACK` to 71 would make every build under 71 skip the whole set, which is a cost paid by the builds that set the limit low, and it would be paid for a branch count. What that count has to say is said by compiling the pattern, and compiling asks for no backtracking stack, so the seventy-branch lookbehind body is compiled among the other branch counts and the match is made with a body of forty. 48 stays what it was, set by the search that reaches the step limit, which holds some three entries per character of its run.

The two other assertions are split into asserts of their own under `need_backtracking_stack`, which is what the file already says to do with a block that mixes engine and non-engine assertions: the Pike VM and parser assertions keep their blocks and still run at any limit. The comment claiming that no backtracking stack is asked for in the `{0}` block now says what is true of the assertions left in it.

### The same hole in the character tests

Eleven tests crashed at a limit of 1, and eight at 2, in a build that reads its strings as characters. A build reading its strings by byte sees none of them, each either skipping on the encoding or standing in a file only a character build compiles, and no CI build sets the limit at all. What sends a pattern to that engine is a backreference, a call, a lookaround, an atomic group, an absent repeater, a conditional group or a non-greedy or possessive quantifier; four of the eleven blocks are that engine's work throughout and take the guard whole, and the seven others hand what reaches the engine to an assert of its own and keep running their Pike VM assertions at any limit. The least obvious of them is `Ā+?`: a non-greedy quantifier is the one spelling in the two blocks about a quantifier on a multibyte literal that the Pike VM cannot run.

## Testing

`mrbtest` built at each limit. The default gembox reads its strings by byte, the full-core gembox reads them as characters:

| `MRB_REGEXP_STACK_LIMIT` | gembox    | Total | OK   | KO  | Crash | Skip |
| ------------------------ | --------- | ----- | ---- | --- | ----- | ---- |
| 1                        | default   | 2642  | 2498 | 0   | 0     | 144  |
| 2                        | default   | 2642  | 2498 | 0   | 0     | 144  |
| 47                       | default   | 2642  | 2498 | 0   | 0     | 144  |
| 48                       | default   | 2642  | 2571 | 0   | 0     | 71   |
| 2048 (default)           | default   | 2642  | 2571 | 0   | 0     | 71   |
| 1                        | full-core | 2888  | 2785 | 0   | 0     | 103  |
| 2                        | full-core | 2888  | 2785 | 0   | 0     | 103  |
| 4                        | full-core | 2888  | 2785 | 0   | 0     | 103  |
| 47                       | full-core | 2888  | 2785 | 0   | 0     | 103  |
| 48                       | full-core | 2888  | 2869 | 0   | 0     | 19   |
| 2048 (default)           | full-core | 2888  | 2869 | 0   | 0     | 19   |

The same full-core gembox with `MRB_USE_ASCII_CTYPE`, where the `/i` refusals stand in for the folding tests: 2874 tests, `KO 0` and `Crash 0` at 1, 48 and 2048.

The counts in the guard's comment come from the full-core builds with the guard turned into a no-op: no test fails at 48, one at 47, two at 40, three at 36, thirty-nine at 4 and eighty-four at 1.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds: `Total 2623-2888`, `KO 0`, `Crash 0`, `Warning 0`. No CI build sets `MRB_REGEXP_STACK_LIMIT`, which is why the stale threshold went unnoticed.

This is a test-only change: no engine source is touched.

## Environment

<details>
<summary>Host, toolchain and the compile line of each build</summary>

|            |                                             |
| ---------- | ------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                          |
| Kernel     | Linux 7.0.0-31-generic x86_64               |
| CPU        | AMD Ryzen 9 5950X (16 cores)                |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils   | GNU ld 2.47.20260726                        |
| CRuby      | ruby 4.0.6 (2026-07-14) +PRISM x86_64-linux |

The sweeps build the default and full-core gemboxes with the limit on the command line; the seven CI builds are `build_config/ci/gcc-clang.rb` unchanged. `-MMD -c`, `-I` and `-o` dropped:

```console
# default gembox, MRB_REGEXP_STACK_LIMIT=48
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REGEXP_STACK_LIMIT=48 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"

# ci/gcc-clang no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-regexp/src/re_exec.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regular expression coverage for lookbehind, backreferences, lookarounds, Unicode case folding, multibyte characters, and non-greedy quantifiers.
  * Improved test handling across different execution and stack-limit configurations.
  * Added dedicated coverage for empty regular-expression unions and callable groups after pattern erasure.
  * Clarified test documentation around stack requirements, branch limits, and backtracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->