### PR TITLE
hash.c: give the comparison behind a pattern match's `**rest` a value to start from

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -2169,7 +2169,7 @@ mrb_hash_except_keys(mrb_state *mrb, mrb_value hash)
   H_EACH(h, entry) {
     mrb_bool found = FALSE;
     for (mrb_int i = 0; i < klen && i < RARRAY_LEN(keys); i++) {
-      mrb_bool eq;
+      mrb_bool eq = FALSE;
       H_CHECK_MODIFIED(mrb, h) {eq = mrb_equal(mrb, entry->key, RARRAY_PTR(keys)[i]);}
       if (eq) {
         found = TRUE;


### PR DESCRIPTION
## Summary

`mrb_hash_except_keys()` backs `Hash#__except`, which the code generator emits for the `**rest` of a pattern match. It reads `eq` outside the `H_CHECK_MODIFIED` block that writes it, and the block is a `for` loop, so nothing tells the compiler its body runs. gcc reports the read as `-Wmaybe-uninitialized` at `-O1`.

## Changes

| File         | What                                          |
| ------------ | --------------------------------------------- |
| `src/hash.c` | `mrb_hash_except_keys()` starts `eq` at FALSE |

`H_CHECK_MODIFIED` is a loop that runs its body once and validates afterwards:

```c
#define H_CHECK_MODIFIED(mrb, h)                                              \
  for (struct h_check_modified h_checker__ = h_check_modified_init(mrb, h);   \
       h_checker__.tbl;                                                       \
       h_check_modified_validate(mrb, &h_checker__, h), h_checker__.tbl = NULL)
```

`h_checker__.tbl` is `h->hsh.ht`, and `H_EACH` reaches the body only where the table it walks has entries, so the assignment does happen. gcc sees that much at `-O2` and says nothing there; at `-O1` it does not:

```console
$ gcc -O1 -std=gnu99 -Wall -I include -I build/host/include -c src/hash.c
src/hash.c:2174:10: warning: 'eq' may be used uninitialized [-Wmaybe-uninitialized]
 2174 |       if (eq) {
      |          ^
src/hash.c:2172:16: note: 'eq' was declared here
 2172 |       mrb_bool eq;
      |                ^~
```

FALSE is what a comparison that did not happen should read as: the key was not found among the ones to leave out, so the entry is kept, which is what a `**rest` does with a key the pattern did not name.

## Behaviour

None. A pattern match's `**rest` binds what it bound before; the only path the initialiser could change is one the loop shape rules out.

## Size

`bin/mruby` `.text` from `build_config/ci/gcc-clang.rb`, `CC=gcc CXX=g++ LD=gcc`, against master at `2452fe969`:

| Build              | master    | This PR   | Delta |
| ------------------ | --------- | --------- | ----- |
| `bintest`          | 1,384,310 | 1,384,310 | 0     |
| `ascii-ctype`      | 1,368,854 | 1,368,854 | 0     |
| `byte-string`      | 1,346,342 | 1,346,342 | 0     |
| `cxx_abi`          | 1,417,689 | 1,417,689 | 0     |
| `no-float`         | 1,310,254 | 1,310,254 | 0     |
| `no-bigint`        | 1,268,950 | 1,268,950 | 0     |
| `full-debug` (-O0) | 1,978,326 | 1,978,342 | +16   |

One object moves, and only where the store is not optimised away. `hash.o` `.text` is 24,576 either way at `-O3`, and 24,952 to 24,956 at `-O0`; the binary takes 16 there after the padding it already had. Every other object of the six optimised builds keeps a byte-identical `.text`.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake test`, under `gcc` and again under `clang`, is green on all seven builds, with the same numbers under both compilers:

| Build         | Total | OK    | KO  | Crash | Skip |
| ------------- | ----- | ----- | --- | ----- | ---- |
| `full-debug`  | 2,888 | 2,878 | 0   | 0     | 10   |
| `bintest`     | 2,888 | 2,869 | 0   | 0     | 19   |
| `cxx_abi`     | 2,888 | 2,869 | 0   | 0     | 19   |
| `byte-string` | 2,802 | 2,731 | 0   | 0     | 71   |
| `ascii-ctype` | 2,874 | 2,853 | 0   | 0     | 21   |
| `no-float`    | 2,623 | 2,527 | 0   | 0     | 96   |
| `no-bigint`   | 2,840 | 2,808 | 0   | 0     | 32   |

`bintest` adds 146 OK / 0 KO / 1 Skip out of 147 under both. `rake -m test` on the default config gives 2,572 OK / 0 KO / 0 Crash / 0 Warning / 72 Skip out of 2,644, and `MRUBY_CONFIG=minimal rake all` succeeds.

`src/hash.c` compiled on its own at `-O0`, `-O1`, `-O2` and `-O3` with `-std=gnu99 -Wall -Wundef` reports nothing at any of them now.

## Environment

<details>

|            |                                                           |
| ---------- | --------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                        |
| Kernel     | 7.0.0-31-generic                                          |
| CPU        | AMD Ryzen 9 5950X (16C/32T)                               |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), clang 23.1.0 |
| binutils   | GNU ld 2.47.20260726                                      |
| CRuby      | 4.0.6 (2026-07-14 revision 03b6d3f889)                    |
| rake       | 13.3.1                                                    |

`SRC` is the source tree, `BUILD` the build directory.

`build_config/default.rb`, build `host`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

`build_config/ci/gcc-clang.rb`, the seven builds under `gcc`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

and the same seven under `CC=clang CXX=clang++ LD=clang`:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`src/hash.c` was compiled on its own with the line shown in the section above.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hash key exclusion reliability by ensuring consistent behavior when a modification check interrupts processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
