### PR TITLE
amalgam: compile the merged file without warnings under clang

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -37,6 +37,17 @@ void mrb_ci_svar_set(mrb_state *mrb, struct mrb_context *c, mrb_callinfo *ci, st
    recording itself runs inside marking and cannot allocate. */
 void mrb_svars_reserve(mrb_state *mrb, struct mrb_context *c);
 
+#ifdef MRUBY_COMPILE_H
+/* Walk the top-level local variables of a parsed program, which is how
+   `eval` carries the caller's variables into the block it compiles.
+   Written by mruby-compiler and called by mruby-eval, so the typedef its
+   callback is spelled with is declared here rather than in each of them:
+   the amalgamation puts both in one translation unit, where a second copy
+   of a typedef is a redefinition. */
+typedef mrb_bool mrb_parser_foreach_top_variable_func(mrb_state *mrb, mrb_sym sym, void *user);
+void mrb_parser_foreach_top_variable(mrb_state *mrb, struct mrb_parser_state *p, mrb_parser_foreach_top_variable_func *func, void *user);
+#endif
+
 #ifdef MRUBY_CLASS_H
 struct RClass *mrb_vm_define_class(mrb_state*, mrb_value, mrb_value, mrb_sym);
 struct RClass *mrb_vm_define_module(mrb_state*, mrb_value, mrb_sym);

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -493,6 +493,7 @@ uint32_t mrb_utf8_decode(const char *p, const char *e, mrb_int *lenp);
 mrb_int mrb_utf8_strlen(const char *str, mrb_int byte_len);
 #endif
 
+#ifdef HAVE_MRUBY_REGEXP_GEM
 /* Whether more than one byte can spell one character in what this build
    reads. The three functions below answer what a given run of bytes spells,
    which is what a reader wants; this is for the few places that have to know
@@ -548,6 +549,8 @@ mrb_enc_decode(const char *p, const char *e, mrb_int *lenp)
   return (uint8_t)*p;
 #endif
 }
+#endif  /* HAVE_MRUBY_REGEXP_GEM */
+
 /* What a case conversion makes of each character. `capitalize` asks two things
    of one string, title case at the front and lower case behind it, and `swap`
    asks per character, so a mode is what a method does rather than one case. */

--- a/include/mruby/mempool.h
+++ b/include/mruby/mempool.h
@@ -4,6 +4,9 @@
 ** See Copyright Notice in mruby.h
 */
 
+#ifndef MRUBY_MEMPOOL_H
+#define MRUBY_MEMPOOL_H
+
 /* memory pool implementation */
 typedef struct mempool mempool;
 MRB_API struct mempool* mempool_open(void);
@@ -17,3 +20,5 @@ typedef struct mempool mrb_mempool;
 #define mrb_mempool_close(m) mempool_close(m)
 #define mrb_mempool_alloc(m, size) mempool_alloc((m),(size))
 #define mrb_mempool_realloc(m, ptr, oldlen, newlen) mempool_realloc((m),(ptr),(oldlen),(newlen))
+
+#endif  /* MRUBY_MEMPOOL_H */

--- a/mrbgems/mruby-compiler/src/mruby_compat.c
+++ b/mrbgems/mruby-compiler/src/mruby_compat.c
@@ -24,8 +24,6 @@
 
 int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
 
-typedef mrb_bool mrb_parser_foreach_top_variable_func(mrb_state *mrb, mrb_sym sym, void *user);
-
 static void
 copy_context_to_mrc(mrc_ccontext *dst, const mrb_ccontext *src)
 {

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -14,10 +14,6 @@ mrb_bool mrb_binding_p(mrb_state *mrb, mrb_value binding);
 const struct RProc * mrb_binding_extract_proc(mrb_state *mrb, mrb_value binding);
 struct REnv * mrb_binding_extract_env(mrb_state *mrb, mrb_value binding);
 
-/* provided by mruby-compiler */
-typedef mrb_bool mrb_parser_foreach_top_variable_func(mrb_state *mrb, mrb_sym sym, void *user);
-void mrb_parser_foreach_top_variable(mrb_state *mrb, struct mrb_parser_state *p, mrb_parser_foreach_top_variable_func *func, void *user);
-
 static struct RProc*
 create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value binding, const char *file, mrb_int line)
 {


### PR DESCRIPTION
## Summary

#7503 left the merged file compiling clean at `-O0`, and named what clang still reported at `-O2 -std=gnu99`: three `-Wtypedef-redefinition`. On `minimal` there are five, the other two being `-Wunused-function`. Each is a declaration a per-file build had no reason to report on, and none of them has to stay the way it is for the amalgamation's sake. This removes them all.

## Changes

| File                                        | What                                                                                                                                                                                                                  |
| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `include/mruby/mempool.h`                   | add the include guard `MRUBY_MEMPOOL_H`                                                                                                                                                                               |
| `include/mruby/internal.h`                  | declare `mrb_parser_foreach_top_variable()` and the typedef its callback is spelled with under `#ifdef MRUBY_COMPILE_H`; put `MRB_ENC_MULTIBYTE_P` and the three `mrb_enc_*()` readers behind `HAVE_MRUBY_REGEXP_GEM` |
| `mrbgems/mruby-eval/src/eval.c`             | drop its own copy of that typedef and prototype                                                                                                                                                                       |
| `mrbgems/mruby-compiler/src/mruby_compat.c` | drop its own copy of that typedef                                                                                                                                                                                     |

### A header the amalgamation had no way to deduplicate

`lib/mruby/amalgam.rb` writes a header once per include guard, and inlines a header without one at every site it is reached from, since a guardless header is an X macro table whose expansion depends on what the include site has defined. `mruby/mempool.h` has no guard and is not a table: `mruby/compile.h` includes it, and `HEADER_ORDER` names it in its own right, so `mruby.h` carries both of its typedefs twice.

```console
$ clang -O2 -std=gnu99 -Wall -Wundef -I build/host/amalgam -c build/host/amalgam/mruby.c
build/host/amalgam/mruby.h:8229:24: warning: redefinition of typedef 'mempool' is a C11 feature [-Wtypedef-redefinition]
build/host/amalgam/mruby.h:8236:24: warning: redefinition of typedef 'mrb_mempool' is a C11 feature [-Wtypedef-redefinition]
```

`mruby/mempool.h` and `mruby/ops.h` were the two headers under `include/` without a guard, and `ops.h` is one of the tables the rule is written for.

### A typedef each of two gems wrote for itself

`mrb_parser_foreach_top_variable()` is written by mruby-compiler and called by mruby-eval, and each of them carried its own copy of the typedef the callback parameter is spelled with. Two translation units never saw both, so nothing said anything until they became one.

It is declared once now, in `mruby/internal.h`, behind `#ifdef MRUBY_COMPILE_H` the way the array and class declarations around it are gated, so it appears only where `struct mrb_parser_state` has been declared. Both callers already include `mruby/compile.h` ahead of `mruby/internal.h`.

### Three readers with no caller in the file they land in

`MRB_ENC_MULTIBYTE_P`, `mrb_enc_charlen()`, `mrb_enc_char_head()` and `mrb_enc_decode()` are read by mruby-regexp alone, in `re_internal.h` and `re_compile.c`. A build without that gem compiles the three `static inline` bodies for nobody, which costs nothing in a per-file build because clang leaves a function defined in a header alone. The amalgamation writes `mruby/internal.h` into `mruby.c` itself, where they are functions defined in the file being compiled:

```console
$ MRUBY_CONFIG=minimal rake amalgam
$ clang -O2 -std=gnu99 -Wall -Wundef -I build/minimal/amalgam -c build/minimal/amalgam/mruby.c
build/minimal/amalgam/mruby.c:535:1: warning: unused function 'mrb_enc_charlen' [-Wunused-function]
build/minimal/amalgam/mruby.c:546:1: warning: unused function 'mrb_enc_char_head' [-Wunused-function]
build/minimal/amalgam/mruby.c:557:1: warning: unused function 'mrb_enc_decode' [-Wunused-function]
```

They stand behind `HAVE_MRUBY_REGEXP_GEM` now, which is the gate the case tables further down `mruby/internal.h` already use.

## Behaviour

`rake amalgam` writes the same two files, and clang has nothing to say about what it writes. Warnings on `mruby.c` at `-std=gnu99 -Wall -Wundef`, against master at `b4661c33d`:

| Config      | Compiler | master, `-O0` / `-O1` / `-O2` / `-O3` | This PR, `-O0` / `-O1` / `-O2` / `-O3` |
| ----------- | -------- | ------------------------------------- | -------------------------------------- |
| `minimal`   | gcc      | 0 / 1 / 0 / 0                         | 0 / 1 / 0 / 0                          |
| `minimal`   | clang    | 5 / 5 / 5 / 5                         | 0 / 0 / 0 / 0                          |
| `default`   | gcc      | 0 / 1 / 1 / 1                         | 0 / 1 / 1 / 1                          |
| `default`   | clang    | 3 / 3 / 3 / 3                         | 0 / 0 / 0 / 0                          |
| `full-core` | gcc      | 0 / 1 / 1 / 1                         | 0 / 1 / 1 / 1                          |
| `full-core` | clang    | 3 / 3 / 3 / 3                         | 0 / 0 / 0 / 0                          |

gcc says nothing about a redundant typedef under `-std=gnu99` alone, since it allows one as an extension. Under `-Wpedantic` it names the same sites clang does, and none of them after this: 2 to 0 on `minimal`, 3 to 0 on the other two.

What gcc still counts belongs to neither family, and neither one is this PR's to fix:

- gcc at `-O2` and `-O3`, on `default` and `full-core`: `-Wstringop-overflow=` on `__builtin_memcpy`, from prism's `pm_buffer_append()` inlined into `pm_parse_stream_read()`. `length` there is a `size_t` that `fgets` never leaves at 0, which gcc cannot prove. It reaches the compiler only where every prism source shares one translation unit, so `prism.c` on its own is silent. prism is a submodule and the line is upstream's.
- gcc at `-O1`, on every config: `-Wmaybe-uninitialized` on `eq` in `mrb_hash_except_keys()`. That one reproduces on a plain build of `src/hash.c`, has nothing to do with the amalgamation, and goes separately in #7505.

## Size

`bin/mruby` `.text` from `build_config/ci/gcc-clang.rb`, `CC=gcc CXX=g++ LD=gcc`, against master at `b4661c33d`:

| Build              | master    | This PR   | Delta |
| ------------------ | --------- | --------- | ----- |
| `bintest`          | 1,384,310 | 1,384,310 | 0     |
| `ascii-ctype`      | 1,368,854 | 1,368,854 | 0     |
| `byte-string`      | 1,346,342 | 1,346,342 | 0     |
| `cxx_abi`          | 1,417,689 | 1,417,689 | 0     |
| `no-float`         | 1,310,254 | 1,310,254 | 0     |
| `no-bigint`        | 1,268,950 | 1,268,950 | 0     |
| `full-debug` (-O0) | 1,978,326 | 1,978,326 | 0     |

Nothing here is code. The guard and the two gates decide which declarations a translation unit sees, and the declarations they leave out had no caller in the builds that lose them.

## Testing

Each of the three commits builds and tests on its own: `rake -m test` on the default config gives 2,571 OK / 0 KO / 0 Crash / 0 Warning / 71 Skip out of 2,642 at every one of them, and `MRUBY_CONFIG=minimal rake all` succeeds at every one of them.

`MRUBY_CONFIG=ci/gcc-clang rake test`, under `gcc` and again under `clang`, is green on all seven builds, with the same numbers under both compilers:

| Build         | Total | OK    | KO  | Crash | Skip |
| ------------- | ----- | ----- | --- | ----- | ---- |
| `full-debug`  | 2,888 | 2,878 | 0   | 0     | 10   |
| `bintest`     | 2,888 | 2,869 | 0   | 0     | 19   |
| `cxx_abi`     | 2,888 | 2,869 | 0   | 0     | 19   |
| `byte-string` | 2,802 | 2,731 | 0   | 0     | 71   |
| `ascii-ctype` | 2,874 | 2,853 | 0   | 0     | 21   |
| `no-float`    | 2,623 | 2,527 | 0   | 0     | 96   |
| `no-bigint`   | 2,840 | 2,808 | 0   | 0     | 32   |

`bintest` adds 146 OK / 0 KO / 1 Skip out of 147 under both.

The amalgamation itself was generated on `minimal`, the default config and a `full-core` gembox, and each output compiled by hand with `gcc` and `clang` at `-O0`, `-O1`, `-O2` and `-O3`, with `-std=gnu99 -Wall -Wundef`, which is where the counts above come from.

## Environment

<details>

|            |                                                           |
| ---------- | --------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                        |
| Kernel     | 7.0.0-31-generic                                          |
| CPU        | AMD Ryzen 9 5950X (16C/32T)                               |
| C compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), clang 23.1.0 |
| binutils   | GNU ld 2.47.20260726                                      |
| CRuby      | 4.0.6 (2026-07-14 revision 03b6d3f889)                    |
| rake       | 13.3.1                                                    |

`SRC` is the source tree, `BUILD` the build directory.

`build_config/default.rb`, build `host`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

`build_config/ci/gcc-clang.rb`, the seven builds under `gcc`:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="SRC=." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

and the same seven under `CC=clang CXX=clang++ LD=clang`:

```console
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -g3 -O0 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
clang -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
clang -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-compilation-dir="." -ffile-prefix-map="BUILD=build" -DMRBGEM_MRUBY_IO_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The amalgamation was compiled by hand, outside any build config, with the lines shown in the sections above.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public interface for inspecting top-level local variables during parsing, supporting compiler and evaluation integrations.

- **Refactor**
  - Consolidated shared parser declarations across compilation and evaluation components.
  - Limited encoding helpers to builds that include regular-expression support.
  - Improved header protection to prevent duplicate inclusion and support more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->