### PR TITLE
mruby-compiler: fix the operand order of a hash-value pattern

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3189,6 +3189,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             genop_3(s, OP_SEND, val_reg, new_sym(s, MRC_OPSYM_2(aref)), 1);
 
             if (assoc->value) {
+              push(); /* keep the value below cursp() for the sub-pattern */
               codegen_pattern(s, (mrc_node *)assoc->value, val_reg, fail_pos, -1);
             }
             else {

--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -152,6 +152,25 @@ assert("Regexp#=== - Symbol argument") do
   assert_equal "has digits", result
 end
 
+assert("Regexp#=== - value pattern in a hash value") do
+  # a pattern in value position is the receiver of #===, and the hash value its
+  # argument; the operands used to come out the other way around, which a
+  # regexp cannot survive
+  case {a: "value"}
+  in {a: /\Avalue\z/}
+    assert_true true
+  else
+    flunk "the regexp did not match the hash value"
+  end
+
+  case {a: "other"}
+  in {a: /\Avalue\z/}
+    flunk "the regexp matched a value it does not describe"
+  else
+    assert_true true
+  end
+end
+
 assert("Regexp - match operand rejects other types") do
   assert_raise(TypeError) { /a/.match(1) }
   assert_raise(TypeError) { /a/.match?(1) }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1343,6 +1343,56 @@ assert('pattern matching - hash patterns') do
   end
 end
 
+assert('pattern matching - value patterns as a hash value') do
+  # a value pattern is the receiver of `===`, the hash value its argument
+  case {a: 1}
+  in {a: Integer}
+    assert_true true
+  else
+    flunk "Integer did not match the value 1"
+  end
+
+  case {a: "s"}
+  in {a: Integer}
+    flunk "Integer matched the value \"s\""
+  else
+    assert_true true
+  end
+
+  # a range is asymmetric the same way
+  case {a: 1}
+  in {a: 0..2}
+    assert_true true
+  else
+    flunk "0..2 did not match the value 1"
+  end
+
+  # binding after a class pattern
+  case {a: 1, b: {c: 2}}
+  in {a: Integer => x, b: {c: Integer => y}}
+    assert_equal 1, x
+    assert_equal 2, y
+  else
+    flunk "nested class patterns did not match"
+  end
+
+  # the same pattern nested inside an array pattern
+  case [{a: 1}]
+  in [{a: Integer}]
+    assert_true true
+  else
+    flunk "class pattern in a nested hash did not match"
+  end
+
+  # the value keeps its register for the patterns that follow
+  case {a: 1, b: 2}
+  in {a: Integer, b: Integer => y}
+    assert_equal 2, y
+  else
+    flunk "two class patterns in one hash did not match"
+  end
+end
+
 assert('pattern matching - guard clauses') do
   # if guard
   result = case 10


### PR DESCRIPTION
## Summary

A class, range or regexp pattern in a hash-value position matched nothing: `case {a: 1}; in {a: Integer}` fell through to `else`. The hash-pattern value loop compiled the sub-pattern with its target at `cursp()` rather than below it, so the `===` send went out with its operands swapped.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-compiler/src/codegen.c` | `codegen_pattern()`: one `push()` before the hash value's sub-pattern |
| `test/t/syntax.rb` | `pattern matching - class pattern as a hash value` becomes `- value patterns as a hash value`, covering the asymmetric patterns |
| `mrbgems/mruby-regexp/test/regexp.rb` | `Regexp#=== - value pattern in a hash value`, the regexp half of the same check |

### The target has to stay below `cursp()`

A value pattern compiles to `pattern === value`: `codegen()` lands the pattern in the receiver slot at `cursp()`, and the target is moved into the argument slot above it. Every sub-pattern site keeps the target below `cursp()`, the array-pattern and find-pattern paths by passing `cursp() - 1`, except the hash-pattern value loop, which sets `s->sp = val_reg` for the `[]` send and then calls `codegen_pattern()` with `target == cursp()`. `mrbc -v` on `case {a: 1}; in {a: Integer}` shows the result:

```console
    2 045 LOADI_0	R5	(0)
    2 047 SEND		R4	:[]	n=1     ; R4 = vals[0] -> 1
    2 051 GETCONST	R5	Integer
    2 054 SEND		R4	:===	n=1     ; 1 === Integer -> false
```

With the `push()` the value is copied up into the argument slot and the constant becomes the receiver:

```console
    2 045 LOADI_0	R5	(0)
    2 047 SEND		R4	:[]	n=1     ; R4 = vals[0] -> 1
    2 051 GETCONST	R5	Integer
    2 054 MOVE		R6	R4
    2 057 SEND		R5	:===	n=1     ; Integer === 1 -> true
```

The loop already resets `s->sp` to `loop_sp` at the end of every iteration, so the extra push needs no matching pop. The frame grows by one register, `nregs` 7 to 8 in the disassembly above.

## Behaviour

Patterns whose `===` is symmetric enough for the cases that matter kept working, which is why the existing hash-pattern tests passed. The asymmetric ones matched nothing, at any nesting depth arrived at through a hash value.

| Pattern | Before | After | CRuby 4.0.6 |
| --- | --- | --- | --- |
| `case {a: 1}; in {a: Integer}` | no match | match | match |
| `case {a: 1}; in {a: 0..2}` | no match | match | match |
| `case {a: "s"}; in {a: /s/}` | no match | match | match |
| `case [{a: 1}]; in [{a: Integer}]` | no match | match | match |
| `case {a: 1}; in {a: 1}` | match | match | match |
| `x = 1; case {a: 1}; in {a: ^x}` | match | match | match |
| `case {a: [1]}; in {a: [Integer]}` | match | match | match |
| `case [1]; in [Integer]` | match | match | match |
| `case 1; in Integer` | match | match | match |

## Testing

The core assert block gains a class pattern, a range, the binding form `Integer => x`, a hash nested in an array pattern, and two class patterns in one hash. `Regexp` is not part of mruby core, so the regexp case goes to the gem that provides it, next to the other `Regexp#===` blocks. Reverting the `push()` alone turns both red:

```
Fail: Regexp#=== - value pattern in a hash value (mrbgems: mruby-regexp)
 - Assertion[1] the regexp did not match the hash value.
Fail: pattern matching - value patterns as a hash value (core)
 - Assertion[1] Integer did not match the value 1.
 - Assertion[3] 0..2 did not match the value 1.
 - Assertion[4] nested class patterns did not match.
 - Assertion[5] class pattern in a nested hash did not match.
 - Assertion[6] two class patterns in one hash did not match.
```

- `rake -m test`: 2647 core assertions, 130 bintest, 0 KO, 0 Crash.
- `MRUBY_CONFIG=ci/gcc-clang rake -m test`: all 7 builds, 0 KO, 0 Crash.
- Every example in the table above was run against both mruby and CRuby 4.0.6.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X, 16C/32T |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `codegen.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hash pattern matching so value patterns are evaluated against the correct matched values.
  - Improved support for class, range, nested, and regular expression patterns used as hash values.
  - Corrected matching and non-matching behavior in `case/in` expressions.

- **Tests**
  - Added coverage for hash value patterns, bindings, nested patterns, multiple patterns, and regular expression matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->