### PR TITLE
mruby-regexp: drive the classes a pattern nests from a level stack too

### DIFF
--- a/mrbgems/mruby-regexp/README.md
+++ b/mrbgems/mruby-regexp/README.md
@@ -386,10 +386,12 @@ bytes, plus one String header:
 | 128            | 4 KiB                    |
 | 32             | 1 KiB                    |
 
-A build that cannot make the allocation raises `NoMemoryError`. A nested
-character class is the one construct still read by recursion, at about 500
-bytes of C stack a level, which the class table bounds at 256 levels whatever
-the limit.
+A build that cannot make the allocation raises `NoMemoryError`. A class written
+inside a class is a level on a stack of its own, held the same way, and the
+class table bounds those as well: a level open holds an entry in it, and the
+257th is `too many character classes`. The shallower of the two answers, so at
+the default limit a class nests 256 deep and at a limit of 256 or less it nests
+as deep as the limit.
 
 The passes that read the finished program keep their branches on stacks of
 their own as well: the anchor and first-byte scans, the marks on the

--- a/mrbgems/mruby-regexp/include/re_internal.h
+++ b/mrbgems/mruby-regexp/include/re_internal.h
@@ -384,7 +384,7 @@ typedef struct mrb_regexp_pattern {
    a group of any kind, a lookaround, an atomic group, an inline option
    toggle, which encloses the rest of the group it stands in and so is a level
    of its own, and a character class nested in another (see open_level() and
-   parse_nested_class() in re_compile.c). A pattern past this is `parse depth
+   parse_class_levels() in re_compile.c). A pattern past this is `parse depth
    limit over`, which is CRuby's message for the same refusal.
 
    The default is Onigmo's ONIG_MAX_PARSE_DEPTH, so a pattern is refused
@@ -392,9 +392,10 @@ typedef struct mrb_regexp_pattern {
    guards: the parser keeps the levels it has open on the heap, 32 bytes
    each, so a pattern nested past what the machine holds is refused by the
    allocator, at whatever depth that is, and no build has a stack to size
-   this from. One value holds for every build. (A nested character class is
-   still read by recursion, at about 500 bytes of C stack a level, which the
-   class table bounds at 256 levels.)
+   this from. One value holds for every build. (A nested character class is a
+   level on a stack of its own, and the class table bounds those at 256 as
+   well, so a build at the default limit meets the table there and one that
+   sets this at or below 256 meets this.)
 
    The floor is 1, a build that takes no nesting at all; the ceiling is where
    the limit stops being one, a million levels being 32 MiB of them. */

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -67,6 +67,42 @@ typedef struct {
    frame's worth of C stack once, not per level. */
 #define RE_LEVELS_INLINE 8
 
+/* What ended the operand of a character class parse_class_operand() was
+   reading. The ']' and the '&&' are consumed there; the '[' is left standing,
+   since what follows it is read as a level of its own. */
+enum {
+  RE_CLASS_END,    /* the ']' that closes the class */
+  RE_CLASS_MORE,   /* the '&&' that stands before the next operand */
+  RE_CLASS_NEST    /* the '[' of a class written inside this one */
+};
+
+/* One character class the parse has open: the class a '[' began, the operand
+   of it being read, and what its ']' closes with. A class written inside a
+   class is one of these too; see parse_class_expr(). */
+typedef struct {
+  uint16_t id;       /* the class the body is read into: the operands come to
+                        an intersection here, and this is what joins the level
+                        below once the class closes */
+  uint16_t cur_id;   /* the class the operand being read goes into: `id` for
+                        the first, there being nothing yet to intersect it
+                        with, and one of its own after each `&&` */
+  mrb_bool negated;  /* the '[^' of a nest opened the level, so what joins the
+                        level below is the complement of what it holds. The
+                        outermost class carries its own negation in the class
+                        (RE_NCLASS) instead */
+  mrb_bool first;    /* the operand opens the class and nothing has been read
+                        into it, where a ']' is a member rather than the
+                        close; only the first operand does, so [a&&]a] is the
+                        empty class followed by the two characters `a]` */
+  uint8_t cross[RE_CLASS_BITMAP_SIZE];  /* the ASCII members the class holds
+                        in its own right, as against the ones an ASCII-only
+                        set brought, narrowed by each operand in step; see
+                        close_class_operand() */
+  re_charclass ascii_set;  /* the operand's ASCII-only sets, held beside the
+                        class until the operand ends; see compile_charclass()
+                        for what is held there and why */
+} re_class_level;
+
 /* Compiler state.
 
    Everything the compile allocates and the finished pattern goes on owning
@@ -1382,7 +1418,7 @@ reject_set_as_range_start(re_compiler *c)
   }
 }
 
-static void parse_class_expr(re_compiler *c, uint16_t id, uint8_t *cross);
+static void parse_class_expr(re_compiler *c, re_class_level *lv);
 
 /* Everything an ASCII-only set brought joins the class it was written in. */
 static void
@@ -1392,22 +1428,33 @@ class_join_ascii_set(re_charclass *cc, const re_charclass *ascii_set)
   if (ascii_set->utf8_any) cc->utf8_any = TRUE;
 }
 
-/* One nested class, from its '[' through its ']', joined to class `id`.
+/* Set a level up to read a class body into `id`; see re_class_level. */
+static void
+init_class_level(re_class_level *lv, uint16_t id, mrb_bool negated)
+{
+  memset(lv, 0, sizeof(*lv));
+  lv->id = lv->cur_id = id;
+  lv->negated = negated;
+  lv->first = TRUE;
+}
+
+/* The ']' of a nested class: `lv` joins the operand `outer` is reading, and
+   the class it was read into goes back.
 
    It is read into a class of its own rather than into the same one, because
    what it names is a set: a `&&` inside it takes the intersection of what is
    written there and of nothing around it, so [x[a&&b]] holds `x` and whatever
-   `a` and `b` have in common. A class that is not negated then joins this one
-   as a union, which is the same set reading [xab] gives, and a negated one
+   `a` and `b` have in common. A class that is not negated then joins the outer
+   one as a union, which is the same set reading [xab] gives, and a negated one
    joins it as the complement of what it holds, a set being able to join a
    union only once it is written out as members. The class goes back
    afterwards, so a pattern's nests cost one id at a time rather than one each.
 
    The ASCII members a nest holds only through an ASCII-only set of its own go
-   to the caller's `ascii_set` rather than into the class, which is how the
-   fold at the end can still tell a `\w` written in a nest from one written
-   here. A complement is a set of members like any other, so all of one goes
-   into the class.
+   to the outer level's `ascii_set` rather than into the class, which is how
+   the fold at the end can still tell a `\w` written in a nest from one written
+   beside it. A complement is a set of members like any other, so all of one
+   goes into the class.
 
    Neither is closed under folding here. /i closes the union once at the end,
    which is where the counterparts of what a complement let in are picked up:
@@ -1415,7 +1462,35 @@ class_join_ascii_set(re_charclass *cc, const re_charclass *ascii_set)
    well, so the class accepts what it was written to reject. CRuby reads it
    the same way, and reads [[^[:upper:]]x] under /i as [[:^upper:]x]. */
 static void
-parse_nested_class(re_compiler *c, uint16_t id, re_charclass *ascii_set)
+close_nested_class(re_compiler *c, re_class_level *outer, const re_class_level *lv)
+{
+  re_charclass *sub = &c->pat->classes[lv->id];
+  if (lv->negated) {
+    class_complement(c, sub);
+  }
+  else {
+    for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) {
+      outer->ascii_set.bitmap[i] |= sub->bitmap[i] & ~lv->cross[i];
+      sub->bitmap[i] &= lv->cross[i];
+    }
+  }
+  class_union(c, &c->pat->classes[outer->cur_id], sub);
+  drop_class(c, lv->id);
+
+  /* A nested class names a set, and CRuby opens no range on one: the '-'
+     after it is a member, where the '-' after a POSIX bracket or a shorthand
+     is the error reject_set_as_range_start() reports. So [[a]-z] holds `a`,
+     `-` and `z`, and [[:alpha:]-z] raises. */
+  if (peek(c) == '-') {
+    next_char(c);
+    class_set_bit(&c->pat->classes[outer->cur_id], '-');
+  }
+}
+
+/* One nested class, from the '[' the operand loop stopped at through the ']'
+   that closes it. */
+static void
+parse_nested_class(re_compiler *c, re_class_level *outer)
 {
   if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
     compile_error(c, "parse depth limit over");
@@ -1428,21 +1503,10 @@ parse_nested_class(re_compiler *c, uint16_t id, re_charclass *ascii_set)
   }
   /* The table can move here, so nothing above holds a pointer into it across
      this call; the class is named by id throughout. */
-  uint8_t sub_cross[RE_CLASS_BITMAP_SIZE];
-  uint16_t sub_id = add_class(c);
-  parse_class_expr(c, sub_id, sub_cross);
-  re_charclass *sub = &c->pat->classes[sub_id];
-  if (negated) {
-    class_complement(c, sub);
-  }
-  else {
-    for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) {
-      ascii_set->bitmap[i] |= sub->bitmap[i] & ~sub_cross[i];
-      sub->bitmap[i] &= sub_cross[i];
-    }
-  }
-  class_union(c, &c->pat->classes[id], sub);
-  drop_class(c, sub_id);
+  re_class_level lv;
+  init_class_level(&lv, add_class(c), negated);
+  parse_class_expr(c, &lv);
+  close_nested_class(c, outer, &lv);
   c->depth--;
 }
 
@@ -1454,25 +1518,28 @@ at_intersection(const char *p, const char *end)
   return p + 1 < end && p[0] == '&' && p[1] == '&';
 }
 
-/* Read one operand of a class into class `id`: the members written between
-   the `&&` before it and the `&&` or `]` after it. TRUE where a `&&` ended
-   it, which is consumed. `first` says the operand opens the class, where a
-   ']' is a member rather than the end; only the first one does, so [a&&]a]
-   is the empty class followed by the two characters `a]`. `ascii_set` is the
-   operand's own; see compile_charclass() for what is held there and why. */
-static mrb_bool
-parse_class_operand(re_compiler *c, uint16_t id, re_charclass *ascii_set, mrb_bool first)
-{
-  re_charclass *cc = &c->pat->classes[id];
+/* Read the operand `lv` has open: the members written between the `&&` before
+   it and the `&&`, the ']' or the nested '[' after it, which is what the
+   return says; see RE_CLASS_END. The members go into the class the level is
+   reading into, and the ASCII-only sets among them into the level's own
+   `ascii_set`; see compile_charclass() for what is held there and why.
 
-  while (peek(c) != ']' || first) {
+   A nest is reported rather than read here, and the operand is read on from
+   here once the nest has closed. */
+static int
+parse_class_operand(re_compiler *c, re_class_level *lv)
+{
+  re_charclass *cc = &c->pat->classes[lv->cur_id];
+  re_charclass *ascii_set = &lv->ascii_set;
+
+  while (peek(c) != ']' || lv->first) {
     if (peek(c) < 0) compile_error(c, "premature end of char-class");
-    first = FALSE;
+    lv->first = FALSE;
 
     if (at_intersection(c->p, c->src_end)) {
       next_char(c);
       next_char(c);
-      return TRUE;
+      return RE_CLASS_MORE;
     }
 
     /* A '[' inside a class opens something in CRuby rather than standing for
@@ -1486,19 +1553,7 @@ parse_class_operand(re_compiler *c, uint16_t id, re_charclass *ascii_set, mrb_bo
     if (peek(c) == '[' && c->p + 1 < c->src_end) {
       if (c->p[1] == '.') compile_error(c, "POSIX collating element is not supported");
       if (c->p[1] == '=') compile_error(c, "POSIX equivalence class is not supported");
-      if (c->p[1] != ':') {
-        parse_nested_class(c, id, ascii_set);
-        cc = &c->pat->classes[id];  /* a negated nest moves the table */
-        /* A nested class names a set, and CRuby opens no range on one: the
-           '-' after it is a member, where the '-' after a POSIX bracket or a
-           shorthand is the error reject_set_as_range_start() reports. So
-           [[a]-z] holds `a`, `-` and `z`, and [[:alpha:]-z] raises. */
-        if (peek(c) == '-') {
-          next_char(c);
-          class_set_bit(cc, '-');
-        }
-        continue;
-      }
+      if (c->p[1] != ':') return RE_CLASS_NEST;
     }
 
     /* POSIX bracket class: [:name:] or negated [:^name:] inside [...]. */
@@ -1630,47 +1685,63 @@ parse_class_operand(re_compiler *c, uint16_t id, re_charclass *ascii_set, mrb_bo
     }
   }
   next_char(c);  /* skip ']' */
-  return FALSE;
+  return RE_CLASS_END;
 }
 
-/* Read a class body into class `id`, from just after its '[' (and its '^')
-   through its ']': the intersection of the operands `&&` separates, each of
-   them the union of what is written in it.
+/* The operand ends: what it holds joins the class the level is reading into.
 
-   `cross` receives the ASCII members the class holds in its own right, which
-   is what the caller needs to tell them from the ones an ASCII-only set is
-   the whole reason for; compile_charclass() says what the difference decides.
-   An operand's ASCII-only sets join it before the intersection is taken,
-   since the intersection is of what the operands hold and not of how they
-   were written, and `cross` is narrowed by each operand in step: a member
-   both sides put there in their own right is one this class holds in its
-   own right. */
+   The ASCII-only sets join before the intersection is taken, since the
+   intersection is of what the operands hold and not of how they were written,
+   and `cross` is narrowed by each operand in step: a member both sides put
+   there in their own right is one the class holds in its own right. */
 static void
-parse_class_expr(re_compiler *c, uint16_t id, uint8_t *cross)
+close_class_operand(re_compiler *c, re_class_level *lv)
 {
-  /* Only the bitmap and utf8_any are ever written to an ASCII-only set. */
-  re_charclass ascii_set;
-  memset(&ascii_set, 0, sizeof(ascii_set));
+  re_charclass *cc = &c->pat->classes[lv->cur_id];
 
-  mrb_bool more = parse_class_operand(c, id, &ascii_set, TRUE);
-  {
-    re_charclass *cc = &c->pat->classes[id];
-    for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) cross[i] = cc->bitmap[i];
-    class_join_ascii_set(cc, &ascii_set);
+  if (lv->cur_id == lv->id) {
+    for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) lv->cross[i] = cc->bitmap[i];
+    class_join_ascii_set(cc, &lv->ascii_set);
+    return;
   }
+  for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) lv->cross[i] &= cc->bitmap[i];
+  class_join_ascii_set(cc, &lv->ascii_set);
+  class_intersect(c, lv->id, lv->cur_id);
+  drop_class(c, lv->cur_id);
+  lv->cur_id = lv->id;
+}
 
-  while (more) {
-    /* The operand is read beside this class rather than into it, there being
-       no way back from a union to the members it was made of. */
-    uint16_t sub_id = add_class(c);
-    re_charclass sub_ascii;
-    memset(&sub_ascii, 0, sizeof(sub_ascii));
-    more = parse_class_operand(c, sub_id, &sub_ascii, FALSE);
-    re_charclass *sub = &c->pat->classes[sub_id];
-    for (int i = 0; i < RE_CLASS_BITMAP_SIZE; i++) cross[i] &= sub->bitmap[i];
-    class_join_ascii_set(sub, &sub_ascii);
-    class_intersect(c, id, sub_id);
-    drop_class(c, sub_id);
+/* The `&&` opens the next operand, which is read beside the class rather than
+   into it, there being no way back from a union to the members it was made
+   of. Only the bitmap and utf8_any are ever written to an ASCII-only set. */
+static void
+open_class_operand(re_compiler *c, re_class_level *lv)
+{
+  lv->cur_id = add_class(c);
+  memset(&lv->ascii_set, 0, sizeof(lv->ascii_set));
+}
+
+/* Read a class body into `lv`, from just after its '[' (and its '^') through
+   its ']': the intersection of the operands `&&` separates, each of them the
+   union of what is written in it.
+
+   `lv->cross` is left holding the ASCII members the class holds in its own
+   right, which is what the caller needs to tell them from the ones an
+   ASCII-only set is the whole reason for; compile_charclass() says what the
+   difference decides. */
+static void
+parse_class_expr(re_compiler *c, re_class_level *lv)
+{
+  for (;;) {
+    int ended = parse_class_operand(c, lv);
+
+    if (ended == RE_CLASS_NEST) {
+      parse_nested_class(c, lv);
+      continue;
+    }
+    close_class_operand(c, lv);
+    if (ended == RE_CLASS_END) return;
+    open_class_operand(c, lv);
   }
 }
 
@@ -1694,8 +1765,10 @@ compile_charclass(re_compiler *c)
      the sets already holds both cases of every letter in it, so for a class
      that is a union this adds nothing, and an intersection is where it tells:
      the letters left in [b-z&&\w] are cased like any others. */
-  uint8_t cross[RE_CLASS_BITMAP_SIZE];
-  parse_class_expr(c, id, cross);
+  re_class_level lv;
+  init_class_level(&lv, id, FALSE);
+  parse_class_expr(c, &lv);
+  uint8_t *cross = lv.cross;
   re_charclass *cc = &c->pat->classes[id];
 
   /* Close the class under case folding for /i. This runs once the class is

--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -78,7 +78,9 @@ enum {
 
 /* One character class the parse has open: the class a '[' began, the operand
    of it being read, and what its ']' closes with. A class written inside a
-   class is one of these too; see parse_class_expr(). */
+   class is one of these too, so what a pattern nests is a stack the parse
+   keeps of its own rather than frames on the C stack, as the levels the
+   pattern itself nests are; see parse_class_levels(). */
 typedef struct {
   uint16_t id;       /* the class the body is read into: the operands come to
                         an intersection here, and this is what joins the level
@@ -102,6 +104,13 @@ typedef struct {
                         class until the operand ends; see compile_charclass()
                         for what is held there and why */
 } re_class_level;
+
+/* Class levels the compiler keeps inline before it spills to the heap: a
+   class takes one and a class written inside it the other, which is as deep
+   as a written pattern goes. What the array costs is one frame's worth of C
+   stack once, not per level, and a class deeper than this pays an allocation
+   rather than the stack it used to descend. */
+#define RE_CLASS_LEVELS_INLINE 2
 
 /* Compiler state.
 
@@ -172,6 +181,17 @@ typedef struct {
   uint32_t level_capa;
   mrb_value level_store;    /* nil while the levels are inline */
   re_level levels_inline[RE_LEVELS_INLINE];
+  /* The character classes the parse has open, innermost last; see
+     re_class_level. They are held as the levels above are, and are the same
+     answer to the same question: a class written inside a class is a level
+     rather than a descent, so no pattern's classes reach the C stack. The
+     stack is empty between one class and the next, so a pattern pays for the
+     deepest class it writes and not for the sum of them. */
+  re_class_level *class_levels;
+  uint32_t class_level_count;
+  uint32_t class_level_capa;
+  mrb_value class_level_store;  /* nil while the class levels are inline */
+  re_class_level class_levels_inline[RE_CLASS_LEVELS_INLINE];
   /* The alternation that finished last, as the span it covers and how many
      branches it has. The lookbehind arm reads it to tell a body that *is*
      an alternation from one that merely holds one: only the first may give
@@ -1418,8 +1438,6 @@ reject_set_as_range_start(re_compiler *c)
   }
 }
 
-static void parse_class_expr(re_compiler *c, re_class_level *lv);
-
 /* Everything an ASCII-only set brought joins the class it was written in. */
 static void
 class_join_ascii_set(re_charclass *cc, const re_charclass *ascii_set)
@@ -1428,18 +1446,38 @@ class_join_ascii_set(re_charclass *cc, const re_charclass *ascii_set)
   if (ascii_set->utf8_any) cc->utf8_any = TRUE;
 }
 
-/* Set a level up to read a class body into `id`; see re_class_level. */
-static void
-init_class_level(re_class_level *lv, uint16_t id, mrb_bool negated)
+/* Open a level for a class body to be read into; see re_class_level. */
+static re_class_level*
+open_class_level(re_compiler *c, uint16_t id, mrb_bool negated)
 {
+  if (c->class_level_count == c->class_level_capa) {
+    /* Outgrown: the levels move to a String the GC arena holds for the
+       compile, as the levels the pattern nests do (see open_level()), and
+       double from there. */
+    uint32_t capa = c->class_level_capa * 2;
+    size_t bytes = sizeof(re_class_level) * capa;
+    if (mrb_nil_p(c->class_level_store)) {
+      c->class_level_store = mrb_str_new(c->mrb, NULL, bytes);
+      memcpy(RSTRING_PTR(c->class_level_store), c->class_levels,
+             sizeof(re_class_level) * c->class_level_count);
+    }
+    else {
+      mrb_str_resize(c->mrb, c->class_level_store, (mrb_int)bytes);
+    }
+    c->class_levels = (re_class_level*)RSTRING_PTR(c->class_level_store);
+    c->class_level_capa = capa;
+  }
+  re_class_level *lv = &c->class_levels[c->class_level_count++];
   memset(lv, 0, sizeof(*lv));
   lv->id = lv->cur_id = id;
   lv->negated = negated;
   lv->first = TRUE;
+  return lv;
 }
 
-/* The ']' of a nested class: `lv` joins the operand `outer` is reading, and
-   the class it was read into goes back.
+/* The ']' of a nested class: the level closes, what it holds joins the
+   operand the level below has open, and the class it was read into goes
+   back.
 
    It is read into a class of its own rather than into the same one, because
    what it names is a set: a `&&` inside it takes the intersection of what is
@@ -1462,8 +1500,10 @@ init_class_level(re_class_level *lv, uint16_t id, mrb_bool negated)
    well, so the class accepts what it was written to reject. CRuby reads it
    the same way, and reads [[^[:upper:]]x] under /i as [[:^upper:]x]. */
 static void
-close_nested_class(re_compiler *c, re_class_level *outer, const re_class_level *lv)
+close_nested_class(re_compiler *c)
 {
+  re_class_level *lv = &c->class_levels[c->class_level_count - 1];
+  re_class_level *outer = lv - 1;
   re_charclass *sub = &c->pat->classes[lv->id];
   if (lv->negated) {
     class_complement(c, sub);
@@ -1476,6 +1516,8 @@ close_nested_class(re_compiler *c, re_class_level *outer, const re_class_level *
   }
   class_union(c, &c->pat->classes[outer->cur_id], sub);
   drop_class(c, lv->id);
+  c->class_level_count--;
+  c->depth--;
 
   /* A nested class names a set, and CRuby opens no range on one: the '-'
      after it is a member, where the '-' after a POSIX bracket or a shorthand
@@ -1485,29 +1527,6 @@ close_nested_class(re_compiler *c, re_class_level *outer, const re_class_level *
     next_char(c);
     class_set_bit(&c->pat->classes[outer->cur_id], '-');
   }
-}
-
-/* One nested class, from the '[' the operand loop stopped at through the ']'
-   that closes it. */
-static void
-parse_nested_class(re_compiler *c, re_class_level *outer)
-{
-  if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
-    compile_error(c, "parse depth limit over");
-  }
-  next_char(c);  /* '[' */
-  mrb_bool negated = FALSE;
-  if (peek(c) == '^') {
-    next_char(c);
-    negated = TRUE;
-  }
-  /* The table can move here, so nothing above holds a pointer into it across
-     this call; the class is named by id throughout. */
-  re_class_level lv;
-  init_class_level(&lv, add_class(c), negated);
-  parse_class_expr(c, &lv);
-  close_nested_class(c, outer, &lv);
-  c->depth--;
 }
 
 /* TRUE where the two characters are the `&&` that separates one operand of a
@@ -1524,11 +1543,15 @@ at_intersection(const char *p, const char *end)
    reading into, and the ASCII-only sets among them into the level's own
    `ascii_set`; see compile_charclass() for what is held there and why.
 
-   A nest is reported rather than read here, and the operand is read on from
-   here once the nest has closed. */
+   A nest is reported rather than read here, so a class inside a class costs
+   the level parse_class_levels() pushes and no C frame; the operand is read
+   on from here once that level has closed. */
 static int
 parse_class_operand(re_compiler *c, re_class_level *lv)
 {
+  /* Nothing an operand holds adds a class, and a nest is reported before one
+     is opened, so the table cannot move under this pointer while the operand
+     is read. */
   re_charclass *cc = &c->pat->classes[lv->cur_id];
   re_charclass *ascii_set = &lv->ascii_set;
 
@@ -1721,27 +1744,66 @@ open_class_operand(re_compiler *c, re_class_level *lv)
   memset(&lv->ascii_set, 0, sizeof(lv->ascii_set));
 }
 
-/* Read a class body into `lv`, from just after its '[' (and its '^') through
-   its ']': the intersection of the operands `&&` separates, each of them the
-   union of what is written in it.
+/* Read a class body into class `id`, from just after its '[' (and its '^')
+   through its ']': the intersection of the operands `&&` separates, each of
+   them the union of what is written in it, and each of them able to hold a
+   class written inside this one.
 
-   `lv->cross` is left holding the ASCII members the class holds in its own
-   right, which is what the caller needs to tell them from the ones an
-   ASCII-only set is the whole reason for; compile_charclass() says what the
-   difference decides. */
+   A nest opens a level here rather than a C frame, as a '(' opens one in
+   compile_levels(): the operand loop reports the '[' it stopped at, what
+   follows is read by the same loop one level in, and the ']' pops the level
+   into the operand the level below has open. So the classes a pattern nests
+   cost the levels and no stack, at any depth, on any build.
+
+   Two things bound the depth and the shallower answers: the class table,
+   every open level holding an entry in it until it closes, and
+   MRB_REGEXP_PARSE_DEPTH_LIMIT, which a nest counts against beside the
+   levels the pattern has open. At the default limit the table is the one a
+   pattern meets, at RE_MAX_CLASSES; a build that sets the limit at or below
+   that meets the limit here first.
+
+   `cross` receives the ASCII members the class holds in its own right, which
+   is what the caller needs to tell them from the ones an ASCII-only set is
+   the whole reason for; compile_charclass() says what the difference
+   decides. */
 static void
-parse_class_expr(re_compiler *c, re_class_level *lv)
+parse_class_levels(re_compiler *c, uint16_t id, uint8_t *cross)
 {
+  open_class_level(c, id, FALSE);
+
   for (;;) {
+    /* A push can move the levels, so the one being read is taken afresh. */
+    re_class_level *lv = &c->class_levels[c->class_level_count - 1];
     int ended = parse_class_operand(c, lv);
 
     if (ended == RE_CLASS_NEST) {
-      parse_nested_class(c, lv);
+      /* The limit is met at the level that crosses it, as open_level() meets
+         it, rather than at the bottom of a descent. */
+      if (++c->depth > (uint32_t)MRB_REGEXP_PARSE_DEPTH_LIMIT) {
+        compile_error(c, "parse depth limit over");
+      }
+      next_char(c);  /* '[' */
+      mrb_bool negated = FALSE;
+      if (peek(c) == '^') {
+        next_char(c);
+        negated = TRUE;
+      }
+      open_class_level(c, add_class(c), negated);
       continue;
     }
+
     close_class_operand(c, lv);
-    if (ended == RE_CLASS_END) return;
-    open_class_operand(c, lv);
+    if (ended == RE_CLASS_MORE) {
+      open_class_operand(c, lv);
+      continue;
+    }
+    if (c->class_level_count > 1) {
+      close_nested_class(c);
+      continue;
+    }
+    memcpy(cross, lv->cross, RE_CLASS_BITMAP_SIZE);
+    c->class_level_count--;
+    return;
   }
 }
 
@@ -1765,14 +1827,12 @@ compile_charclass(re_compiler *c)
      the sets already holds both cases of every letter in it, so for a class
      that is a union this adds nothing, and an intersection is where it tells:
      the letters left in [b-z&&\w] are cased like any others. */
-  re_class_level lv;
-  init_class_level(&lv, id, FALSE);
-  parse_class_expr(c, &lv);
-  uint8_t *cross = lv.cross;
+  uint8_t cross[RE_CLASS_BITMAP_SIZE];
+  parse_class_levels(c, id, cross);
   re_charclass *cc = &c->pat->classes[id];
 
   /* Close the class under case folding for /i. This runs once the class is
-     complete, so it covers every form parse_class_expr() reads in: POSIX
+     complete, so it covers every form parse_class_levels() reads in: POSIX
      brackets, ranges, single literals and the nested classes whose union the
      class is. Negation is applied at match time against the same class
      (RE_NCLASS), so closing the positive set is also what keeps [^a-c] and
@@ -4195,7 +4255,7 @@ skip_uninterpreted(const char *src, const char *end, uint32_t *class_depth, int 
     }
     /* A '[' that opens no bracket opens a class of its own, whose ']' closes
        that one and not this. Counting the levels is what keeps this pass
-       reading the same span as parse_nested_class(): with a flag, the ']' of
+       reading the same span as the class levels do: with a flag, the ']' of
        [[a]b#c] would end the class here and leave `#c]` a comment under /x
        where the parser has it as members. */
     if (ch != '[') return src + 1;
@@ -5150,6 +5210,9 @@ mrb_re_compile(mrb_state *mrb, mrb_regexp_pattern *pat,
   c.level_store = mrb_nil_value();
   c.levels = c.levels_inline;
   c.level_capa = RE_LEVELS_INLINE;
+  c.class_level_store = mrb_nil_value();
+  c.class_levels = c.class_levels_inline;
+  c.class_level_capa = RE_CLASS_LEVELS_INLINE;
 
   /* Both things the pre-pass removes, a (?#...) group and a `#` comment,
      are spelled with a '#', so a pattern without one is parsed as written.

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -3491,6 +3491,57 @@ assert("Regexp - a '-' after a nested class is a member") do
   end
 end
 
+assert("Regexp - what bounds the classes a pattern nests is a table, not a stack") do
+  # A class written inside a class is a level on the parser's own stack, as a
+  # group is, so how deep one may nest is a matter of what the compiler holds
+  # a level in and not of the C stack the build gets. Two things bound it and
+  # the shallower answers: every level open holds an entry in the class table
+  # while it is open, 256 of which there are, and every level but the
+  # outermost counts against MRB_REGEXP_PARSE_DEPTH_LIMIT beside the levels
+  # the pattern itself has open, of which there is one here. So a build at
+  # the default limit nests 256 classes and is told `too many character
+  # classes` at the 257th, and a build that sets the limit at or below that
+  # meets its own limit there instead.
+  deep = 256
+  refusal = "too many character classes"
+  if Regexp::PARSE_DEPTH_LIMIT <= deep
+    deep = Regexp::PARSE_DEPTH_LIMIT
+    refusal = "parse depth limit over"
+  end
+
+  # a union at every level, and the complement of what the innermost holds
+  union = Regexp.new("[" * deep + "a-c" + "]" * deep)
+  assert_equal "b", "xb"[union]
+  assert_nil union =~ "d"
+  neg = Regexp.new("[" * (deep - 1) + "[^a-c]" + "]" * (deep - 1))
+  assert_equal "d", "ad"[neg]
+  assert_nil neg =~ "b"
+
+  # An operand after a `&&` is read beside the class rather than into it, and
+  # the intersection of the two is taken through a third, so a class holding
+  # one takes two entries of the table beyond the levels it has open and
+  # nests two levels fewer.
+  wide = deep < 3 ? 1 : deep - 2
+  isect = Regexp.new("[" * wide + "a-c&&b-d" + "]" * wide)
+  assert_equal "c", "ac"[isect]
+  assert_nil isect =~ "a"
+
+  # The stack is empty again between one class and the next, so a pattern
+  # holding two of them nests in the second as it nested in the first. What a
+  # class leaves behind in the table is the one entry the pattern matches
+  # against; the entries its levels held go back as they close. That entry is
+  # why the pair nests one shy of what a lone class nests.
+  half = deep < 3 ? 1 : deep - 1
+  pair = Regexp.new("[" * half + "a" + "]" * half + "[" * half + "b" + "]" * half)
+  assert_equal "ab", "ab"[pair]
+  assert_nil pair =~ "ba"
+
+  over = "[" * (deep + 1) + "a" + "]" * (deep + 1)
+  assert_raise_with_message(RegexpError, "#{refusal}: /#{over}/") do
+    Regexp.new(over)
+  end
+end
+
 assert("Regexp - free-spacing mode reads a nested class as members") do
   # The comment pass has to step over a class as one span, and a class nests:
   # with a flag rather than a count the ']' of [[a]b#c] would end the class


### PR DESCRIPTION
## Summary

A character class written inside a character class is the one construct the parser still read by descending, so that nesting spent C stack where every other nesting had stopped spending it: 255 nested classes wanted 168 KiB of stack, and 255 nested groups compiled in the 40 KiB a trivial pattern needs.

## Changes

| File                                         | What                                                                                                                                                                                                                                                                   |
| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-regexp/src/re_compile.c`      | add `re_class_level`, `open_class_level()`, `open_class_operand()`, `close_class_operand()`, `close_nested_class()` and `parse_class_levels()`; `parse_class_operand()` reports what ended the operand it read; remove `parse_class_expr()` and `parse_nested_class()` |
| `mrbgems/mruby-regexp/include/re_internal.h` | say what a nested class costs now, beside `MRB_REGEXP_PARSE_DEPTH_LIMIT`                                                                                                                                                                                               |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | assert what bounds the nesting, at the bound                                                                                                                                                                                                                           |
| `mrbgems/mruby-regexp/README.md`             | the same in the parse depth section                                                                                                                                                                                                                                    |

### The construct that still recursed

`parse_class_operand()` read a nested class by calling `parse_nested_class()`, which called `parse_class_expr()`, which called the operand loop again. Every level of nesting cost that set of frames:

| compiler           | `parse_class_expr` | `parse_class_operand` | per level |
| ------------------ | -----------------: | --------------------: | --------: |
| gcc 13.3.0 `-O3`   |                288 |                   224 |       512 |
| clang 23.1.0 `-O3` |                312 |                   120 |       432 |

by `-fstack-usage`, `parse_nested_class()` inlined into its caller in both. 255 levels at 512 bytes is 130,560, which is where a 128 KiB stack runs out:

```console
$ (ulimit -s 128; mruby -e 'p Regexp.new("(?:" * 255 + "a" + ")" * 255).class')
Regexp
$ (ulimit -s 128; mruby -e 'p Regexp.new("[" * 255 + "a" + "]" * 255).class')
Segmentation fault (core dumped)
```

The levels a pattern nests, groups and lookarounds and the rest, are a stack the parser keeps of its own, so that the depth a pattern may reach does not depend on the stack the build gets. This was the footnote on that sentence: a build with a 128 KiB stack that takes patterns from outside got a crash from one construct and an error from the other eight.

### What a level holds

A nest opens a level here too. `parse_class_operand()` returns at the `[` it stops at rather than reading what follows, `parse_class_levels()` pushes a level for the nest, the same loop reads it, and its `]` pops the level into the operand the level below has open, which is where the union, the complement and the `-` that may follow a nest are done.

A level carries what the two functions used to hold in their frames: the class the body is read into, the class the operand being read goes into, the operand's ASCII-only set, the ASCII members the class holds in its own right, and whether the nest was written `[^`. That is 72 bytes on a 64-bit build. Two stand in the compiler's own frame, which is as deep as a written pattern nests, and past them the levels move to a String the GC arena holds for the compile, as the pattern's levels do. The deepest nesting a pattern can reach spends 18 KiB of heap while it compiles and nothing after it.

What the frames cost is gone: `mrb_re_compile()` grows by the two inline levels and the three fields that address them, 176 bytes once, and no function of the class parser has a frame that repeats.

### What does not move

`RE_MAX_CLASSES` bounds the entries a pattern's class table holds at 256, and a level open holds one until it closes, so 256 classes nest and the 257th is `too many character classes`, on any stack, before this change and after it. An operand after a `&&` is read beside the class and the intersection taken through a third, so a class holding one nests two levels fewer.

`MRB_REGEXP_PARSE_DEPTH_LIMIT` counts a nested class as it did, against the same counter the groups use: 4095 groups around one class compile and 4096 around one do not. The shallower of the two bounds is what a pattern meets, which for a stock build is the table: a build that sets the limit at or below 256 nests classes as deep as its limit and is told `parse depth limit over` past it, and one that sets it above 256 is told `too many character classes`. Verified by building at 3, 4, 256 and 257 and asking; the base answers the same at each.

## Behaviour

No pattern compiles differently, and none is refused that was not refused before. What changes is that the refusals no longer depend on the stack:

```console
$ (ulimit -s 128; mruby -e 'p Regexp.new("[" * 255 + "a" + "]" * 255).class')
Regexp
$ mruby -e 'p Regexp.new("[" * 257 + "a" + "]" * 257).class'
-e:1:in initialize: too many character classes: /[[[...]]]/ (RegexpError)
```

A pattern that nests classes now reaches the depth every other construct reaches, on the stack a pattern of three characters needs. What each one asks for, and what the crash was, is under Testing.

## Speed

Compiling is where this stands, so it is what was measured, by callgrind Ir with the interpreter's own startup subtracted (an empty script, 3,419,301 Ir):

```ruby
PATS = [
  "[a-z0-9_]+", "[^\\s]", "[[:alpha:]]", "[\\w&&[^_]]",
  "x[abc]y", "[[a]b]", "[[a][b]]", "[[^a]b]", "[a-c[d-f]]",
]
2000.times { PATS.each { |p| Regexp.new(p) } }
```

| what the loop compiles             |      master |     this PR |  ratio | per compile |
| ---------------------------------- | ----------: | ----------: | -----: | ----------: |
| the nine patterns above            | 208,955,666 | 210,951,650 | 1.010x |     +111 Ir |
| six patterns with no class in them | 138,275,651 | 138,531,632 | 1.002x |      +21 Ir |

The second row is `["abc", "a(b)c", "a|b", "(?:ab)+", "^a.*b$", "a{2,3}"]`, which opens no class at all: what it pays is the zeroing of a compiler struct 176 bytes larger. The first row pays that and the level a class pushes. Matching is untouched.

Keeping fewer levels inline makes that worse rather than better: with one, the nine patterns cost 218,216,720 Ir, since four of them nest a class and each then takes an allocation the frame would have answered for.

## Size

`.text` of `bin/mruby`, `size -A`, the seven `build_config/ci/gcc-clang.rb` builds, empty build dirs, `CC=gcc CXX=g++ LD=gcc`:

| build                |    master |   this PR |  delta |
| -------------------- | --------: | --------: | -----: |
| `bintest`            | 1,384,262 | 1,385,254 |   +992 |
| `ascii-ctype`        | 1,368,806 | 1,370,838 | +2,032 |
| `byte-string`        | 1,346,294 | 1,348,230 | +1,936 |
| `cxx_abi`            | 1,417,881 | 1,419,033 | +1,152 |
| `no-float`           | 1,310,702 | 1,311,694 |   +992 |
| `no-bigint`          | 1,268,774 | 1,269,766 |   +992 |
| `full-debug` (`-O0`) | 1,978,310 | 1,979,062 |   +752 |

All of it is `re_compile.o`: its `.text` moves +992 under the defines of `bintest`, +2,032 under those of `ascii-ctype` and +1,936 under those of `byte-string`, which is the whole of each binary's delta. What the two larger ones are is inlining: the class parser is one loop now and gcc inlines the operand reader into it where it did not inline the recursion.

## Testing

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds green, KO 0 and Crash 0 over 147 / 2,627 / 2,806 / 2,844 / 2,878 / 2,892 / 2,892 assertions, and every commit of this branch green on its own.

The same repro under `ulimit -s`, base and this PR:

| repro                                     | stack   | base | PR            |
| ----------------------------------------- | ------- | ---- | ------------- |
| 64 nested classes compiled                | 64 KiB  | SEGV | ok            |
| 128 nested classes compiled               | 96 KiB  | SEGV | ok            |
| 255 nested classes compiled               | 128 KiB | SEGV | ok            |
| 256 nested classes compiled               | 128 KiB | SEGV | ok            |
| 253 nested, the innermost negated         | 128 KiB | SEGV | ok            |
| 254 nested, the innermost an intersection | 128 KiB | SEGV | ok            |
| 200 nested classes matched                | 128 KiB | SEGV | ok            |
| 100 groups around 200 nested classes      | 128 KiB | SEGV | ok            |
| 257 nested classes refused                | 128 KiB | SEGV | `RegexpError` |

The last row is the refusal this change does not move: the class table runs out at the 257th either way, and the base crashed on the way to saying so.

The stack each one asks for, bisected on `ulimit -s` over a 4 KiB grid, beside the peak of what the run holds under massif (`--stacks=yes --time-unit=B`, heap and heap-plus-stacks):

| repro              | stack base | stack PR | heap base | heap PR | peak sum |
| ------------------ | ---------: | -------: | --------: | ------: | -------: |
| `a[b]c` compiled   |     40 KiB |   40 KiB |   145,944 | 145,944 |     same |
| 64 nested classes  |     68 KiB |   36 KiB |   141,456 | 147,256 |   −13.3% |
| 128 nested classes |    100 KiB |   40 KiB |   141,456 | 151,232 |   −26.1% |
| 255 nested classes |    168 KiB |   36 KiB |   147,888 | 167,168 |   −39.2% |
| 256 nested classes |    164 KiB |   40 KiB |   147,936 | 167,216 |   −39.3% |
| 255 nested groups  |     36 KiB |   40 KiB |   147,256 | 147,256 |     same |

The bisection carries the interpreter's own floor and moves ±4 KiB from run to run: `mruby -e 'p 1'` runs on 32 KiB and `Regexp.new("a[b]c")` on 40, which is where the whole PR column sits. What the base column holds above that floor is 502 bytes a level, which is the 512 `-fstack-usage` reports; the heap takes 72 bytes a level in its place, so the sum of the two falls by a third at the depth the class table allows. A class that nests two deep or less allocates nothing at all, which is why the first row does not move.

- A differential over 81 class patterns times three flag sets, and over deep nestings and intersections, against a `master` binary built the same way: 255 lines of match sets and error messages, identical.
- The same for the depth limit where the two kinds of level meet: 4,090 groups around 10 classes, 4,095 around 1, 4,096 around 1, 4,094 around 2, 4,000 around 100. Identical.
- `rake -m test` on builds setting `MRB_REGEXP_PARSE_DEPTH_LIMIT` to 4, 256 and 257, where the new assertion takes its depth from the limit rather than from the table: green on all three. At 3 the suite loses eight assertions whose patterns are written four levels deep, on the base as well as here.
- The assertions the new test makes answer the same in CRuby 4.0.6.

## Environment

<details>

| what       | version                                                  |
| ---------- | -------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                       |
| kernel     | Linux 7.0.0-31-generic x86_64                            |
| CPU        | AMD Ryzen 9 5950X                                        |
| C compiler | gcc 13.3.0 (`cxx_abi` is `gcc -x c++`; g++ 13.3.0 links) |
| binutils   | GNU ld 2.47.20260726                                     |
| valgrind   | callgrind, Ir                                            |
| CRuby      | 4.0.6                                                    |

The compile line each build gives `re_compile.c`, less `-MMD -c`, the include paths and `-o`:

```console
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The Speed and Behaviour figures are from a `full-core` gembox with `MRB_UTF8_STRING`, gcc 13.3.0 `-O3`, the same defines as the `bintest` line above less `MRB_GC_FIXED_ARENA` and `MRB_USE_DEBUG_HOOK`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deeply nested regular-expression character classes.
  * Nested classes now follow the applicable parse-depth and character-class limits, with clear errors when either limit is exceeded.
  * Improved support for unions, negated classes, intersections, and sequential nested classes at supported limits.

* **Documentation**
  * Updated regular-expression documentation to clarify nesting limits and the resulting error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->