### PR TITLE
mruby-sprintf: read the width of mrb_int off an integer, not off sprintf

### DIFF
--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -227,18 +227,21 @@ assert('sprintf - a width near mrb_int is refused, not wrapped') do
   # 2147483647 is the width that wrapped.  Where mrb_int is 32-bit it is past
   # what a String can hold and has to be refused; where mrb_int is wider it is
   # an ordinary request and the answer is a 2GB string, which is not something
-  # to allocate in a test.  `%c` costs one pass either way and says which
-  # build this is, so it is asked first and the rest follow only where the
-  # width does not fit.
+  # to allocate in a test.  Asking sprintf which build this is would build that
+  # string to find out, so the width is read off an integer instead: 2**31 is
+  # an object of its own where mrb_int stops below it, and where the build has
+  # no wider integer at all it cannot be reached.  Spelling it as a literal
+  # would take the whole file down on the builds this guards, so it is raised.
   narrow =
     begin
-      sprintf("ab%2147483647c", 65)
-      false
-    rescue ArgumentError
+      n = 2 ** 31
+      !n.equal?(2 ** 31)
+    rescue RangeError
       true
     end
   skip "mrb_int holds a width of 2147483647" unless narrow
 
+  assert_raise(ArgumentError) { sprintf("ab%2147483647c", 65) }
   assert_raise(ArgumentError) { sprintf("ab%2147483647d", 0) }
   assert_raise(ArgumentError) { sprintf("ab%2147483647s", "x") }
   assert_raise(ArgumentError) { sprintf("ab%.2147483647d", 0) }


### PR DESCRIPTION
## Summary

Follow-up to 2452fe969. The width test there learns whether this build refuses
a width of `2147483647` by asking `sprintf` for one, which on a build whose
`mrb_int` holds it is answered with the 2GB string rather than an exception.
The guard exists so that string is never built, but the probe builds it before
the skip. Reading the width of `mrb_int` off an integer instead answers the
same question for nothing.

## Changes

One test file, `mrbgems/mruby-sprintf/test/sprintf.rb`.

- The probe becomes `2 ** 31`: where `mrb_int` stops below it the value is an
  object of its own, or the build has no such integer and raises `RangeError`;
  where `mrb_int` holds it both sides are the same immediate. It is spelled as
  an expression rather than a literal because a literal too wide for `mrb_int`
  takes the whole test file down on the builds this guard selects for.
- `%c` is no longer needed as the probe, so it joins the four assertions it
  used to stand in front of.

No C changed, so there is no `.text` delta to report.

## Behaviour

Unchanged where it counts. The same builds run the assertions and the same
builds skip:

| build                          | before                    | after |
| ------------------------------ | ------------------------- | ----- |
| `MRB_INT32`                    | runs                      | runs  |
| `MRB_INT32` + `mruby-bigint`   | runs                      | runs  |
| `MRB_INT32` + `MRB_NO_FLOAT`   | runs                      | runs  |
| default width                  | skips, after a 2GB string | skips |
| default width + `mruby-bigint` | skips, after a 2GB string | skips |
| default width + `MRB_NO_FLOAT` | skips, after a 2GB string | skips |

## Speed

The probe was the whole cost of this test on a build that skips it. Measured
on the host below, `sprintf("ab%2147483647c", 65)` returns 2147483649 bytes:

```
Maximum resident set size: 2099412 kB
Elapsed (wall clock) time: 0:01.13
```

Peak resident for the whole `mrbtest` binary, before and after:

| build                          | before | after  |
| ------------------------------ | ------ | ------ |
| default width                  | 2.1 GB | 6.2 MB |
| default width + `mruby-bigint` | 2.1 GB | 6.1 MB |
| default width + `MRB_NO_FLOAT` | 2.1 GB | 5.8 MB |

Every test binary in CI whose `mrb_int` holds the width paid that once, which
is every job except the i686 and armhf ones.

## Testing

Six builds, `MRB_INT32` and the default width crossed with plain,
`mruby-bigint` and `MRB_NO_FLOAT`. Each was run twice, once against master and
once with the `CHECK()` of 9f82c532c reverted to its `blen+(l) >= bsiz` form, to
confirm the assertions still discriminate:

| build                          | master        | pre-fix `CHECK()`   |
| ------------------------------ | ------------- | ------------------- |
| `MRB_INT32`                    | KO 0          | SIGSEGV, no summary |
| `MRB_INT32` + `mruby-bigint`   | KO 0          | SIGSEGV, no summary |
| `MRB_INT32` + `MRB_NO_FLOAT`   | KO 0          | SIGSEGV, no summary |
| default width                  | KO 0, skipped | KO 0, skipped       |
| default width + `mruby-bigint` | KO 0, skipped | KO 0, skipped       |
| default width + `MRB_NO_FLOAT` | KO 0, skipped | KO 0, skipped       |

All five assertions in the block reach `CHECK()` on a narrow build and die on
the pre-fix macro, including the two 2452fe969 added: `%.2147483647d` for the
precision path and `%2147483626f` for the one `fmt_float` reaches through
`need`.

<details>
<summary>Build configuration</summary>

```ruby
MRuby::Build.new('int32') do |conf|
  toolchain :gcc
  conf.gembox 'stdlib'
  conf.gem :core => 'mruby-sprintf'
  conf.gem :core => 'mruby-bin-mruby'
  conf.gem :core => 'mruby-bin-mrbc'
  conf.compilers.each { |c| c.defines << 'MRB_INT32' }
  conf.enable_test
end
```

The other five are the same with `MRB_INT32` dropped, `mruby-bigint` added, or
`MRB_NO_FLOAT` defined. Built and run with:

```
MRUBY_CONFIG=... MRUBY_BUILD_DIR=... CC=gcc rake -m test:build
/usr/bin/time -f '%M kB, %e s' build/<name>/bin/mrbtest
```

`prek run --files mrbgems/mruby-sprintf/test/sprintf.rb` passes.

</details>

## Environment

<details>

```
Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic x86_64
gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
```

`MRB_INT32` on an LP64 host stands in for the ILP32 runners: it is what makes
`mrb_int` 32-bit, and `INT_MAX` is then the same bound `get_num()` already
applies, so `2147483647` is a width that wraps there exactly as it does on
i686.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated oversized-width formatting tests to reliably handle builds with narrower integer ranges.
  * Added direct validation that excessively large widths are rejected where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->ふ