### PR TITLE
mruby-compiler: answer defined? with "expression" where CRuby does

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -6270,6 +6270,18 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       case PM_NIL_NODE: case PM_TRUE_NODE: case PM_FALSE_NODE:
       case PM_RANGE_NODE: case PM_LAMBDA_NODE: case PM_DEFINED_NODE:
       case PM_SOURCE_FILE_NODE: case PM_SOURCE_LINE_NODE: case PM_SOURCE_ENCODING_NODE:
+      /* control flow, jumps and definitions: CRuby answers "expression" for
+         every one of these without looking inside them */
+      case PM_AND_NODE: case PM_OR_NODE:
+      case PM_IF_NODE: case PM_UNLESS_NODE:
+      case PM_CASE_NODE: case PM_CASE_MATCH_NODE:
+      case PM_WHILE_NODE: case PM_UNTIL_NODE: case PM_FOR_NODE:
+      case PM_BEGIN_NODE:
+      case PM_RETURN_NODE: case PM_BREAK_NODE: case PM_NEXT_NODE:
+      case PM_REDO_NODE: case PM_RETRY_NODE:
+      case PM_DEF_NODE: case PM_CLASS_NODE: case PM_MODULE_NODE:
+      case PM_SINGLETON_CLASS_NODE:
+      case PM_MATCH_PREDICATE_NODE: case PM_MATCH_REQUIRED_NODE:
         type = "expression";
         break;
       case PM_SELF_NODE:

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -6358,13 +6358,22 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         helper = MRC_SYM_2(defined_super_q);
         break;
       case PM_CALL_NODE:
+      {
+        pm_call_node_t *call = (pm_call_node_t *)value;
+        /* CRuby answers "expression" for a call carrying a literal block,
+           without asking whether the method is there; a block passed as
+           `&arg` keeps the call an ordinary one */
+        if (call->block != NULL && nint(call->block) == PM_BLOCK_NODE) {
+          type = "expression";
+        }
         /* a bare method call on self (no explicit receiver, so no operand to
            evaluate); a call with a receiver would need to evaluate it */
-        if (((pm_call_node_t *)value)->receiver == NULL) {
+        else if (call->receiver == NULL) {
           helper = MRC_SYM_2(defined_method_q);
-          arg = ((pm_call_node_t *)value)->name;
+          arg = call->name;
         }
         break;
+      }
       default:
         break;
       }

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -6259,7 +6259,18 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       int helper = 0;             /* runtime helper symbol, 0 = none */
       pm_constant_id_t arg = 0;   /* symbol operand for the helper, 0 = none */
       pm_constant_id_t arg2 = 0;  /* second symbol operand (A::B), 0 = none */
-      switch (nint(cast->value)) {
+      /* parentheses around a single expression are transparent here, so
+         `defined?((x))` answers what `defined?(x)` does; parentheses holding
+         no statement or several fall through to the "expression" cases */
+      mrc_node *value = cast->value;
+      while (nint(value) == PM_PARENTHESES_NODE) {
+        mrc_node *body = (mrc_node *)((pm_parentheses_node_t *)value)->body;
+        if (body == NULL || nint(body) != PM_STATEMENTS_NODE) break;
+        pm_node_list_t *stmts = &((pm_statements_node_t *)body)->body;
+        if (stmts->size != 1) break;
+        value = (mrc_node *)stmts->nodes[0];
+      }
+      switch (nint(value)) {
       case PM_INTEGER_NODE: case PM_FLOAT_NODE:
       case PM_RATIONAL_NODE: case PM_IMAGINARY_NODE:
       case PM_STRING_NODE: case PM_INTERPOLATED_STRING_NODE:
@@ -6276,7 +6287,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       case PM_IF_NODE: case PM_UNLESS_NODE:
       case PM_CASE_NODE: case PM_CASE_MATCH_NODE:
       case PM_WHILE_NODE: case PM_UNTIL_NODE: case PM_FOR_NODE:
-      case PM_BEGIN_NODE:
+      case PM_BEGIN_NODE: case PM_PARENTHESES_NODE:
       case PM_RETURN_NODE: case PM_BREAK_NODE: case PM_NEXT_NODE:
       case PM_REDO_NODE: case PM_RETRY_NODE:
       case PM_DEF_NODE: case PM_CLASS_NODE: case PM_MODULE_NODE:
@@ -6314,17 +6325,17 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         break;
       case PM_INSTANCE_VARIABLE_READ_NODE:
         helper = MRC_SYM_2(defined_ivar_q);
-        arg = ((pm_instance_variable_read_node_t *)cast->value)->name;
+        arg = ((pm_instance_variable_read_node_t *)value)->name;
         break;
       case PM_CONSTANT_READ_NODE:
         helper = MRC_SYM_2(defined_const_q);
-        arg = ((pm_constant_read_node_t *)cast->value)->name;
+        arg = ((pm_constant_read_node_t *)value)->name;
         break;
       case PM_CONSTANT_PATH_NODE:
         /* only A::B where A is a plain constant; nested/toplevel/expression
            parents are left to fall through to nil */
         {
-          pm_constant_path_node_t *cp = (pm_constant_path_node_t *)cast->value;
+          pm_constant_path_node_t *cp = (pm_constant_path_node_t *)value;
           if (cp->parent && nint(cp->parent) == PM_CONSTANT_READ_NODE) {
             helper = MRC_SYM_2(defined_const_path_q);
             arg = ((pm_constant_read_node_t *)cp->parent)->name;
@@ -6334,11 +6345,11 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         break;
       case PM_GLOBAL_VARIABLE_READ_NODE:
         helper = MRC_SYM_2(defined_gvar_q);
-        arg = ((pm_global_variable_read_node_t *)cast->value)->name;
+        arg = ((pm_global_variable_read_node_t *)value)->name;
         break;
       case PM_CLASS_VARIABLE_READ_NODE:
         helper = MRC_SYM_2(defined_cvar_q);
-        arg = ((pm_class_variable_read_node_t *)cast->value)->name;
+        arg = ((pm_class_variable_read_node_t *)value)->name;
         break;
       case PM_YIELD_NODE:
         helper = MRC_SYM_2(defined_yield_q);
@@ -6349,9 +6360,9 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       case PM_CALL_NODE:
         /* a bare method call on self (no explicit receiver, so no operand to
            evaluate); a call with a receiver would need to evaluate it */
-        if (((pm_call_node_t *)cast->value)->receiver == NULL) {
+        if (((pm_call_node_t *)value)->receiver == NULL) {
           helper = MRC_SYM_2(defined_method_q);
-          arg = ((pm_call_node_t *)cast->value)->name;
+          arg = ((pm_call_node_t *)value)->name;
         }
         break;
       default:

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1632,6 +1632,46 @@ assert('defined? on constant paths (A::B)') do
   assert_equal 'constant', defined?(Float::INFINITY) if Object.const_defined?(:Float)
 end
 
+assert('defined? on control flow, jumps and definitions') do
+  lv = 1
+
+  # logical operators
+  assert_equal 'expression', defined?(lv && lv)
+  assert_equal 'expression', defined?(lv || lv)
+  assert_equal 'expression', defined?(lv and lv)
+  assert_equal 'expression', defined?(lv or lv)
+
+  # control flow
+  assert_equal 'expression', defined?(if lv then 1 else 2 end)
+  assert_equal 'expression', defined?(unless lv then 1 end)
+  assert_equal 'expression', defined?(lv ? 1 : 2)
+  assert_equal 'expression', defined?(case lv; when 1 then 2; end)
+  assert_equal 'expression', defined?(case lv; in Integer then 1; end)
+  assert_equal 'expression', defined?(lv in Integer)
+  assert_equal 'expression', defined?(lv => Integer)
+  assert_equal 'expression', defined?(while false do end)
+  assert_equal 'expression', defined?(until true do end)
+  assert_equal 'expression', defined?(for i in [1] do end)
+  assert_equal 'expression', defined?(begin; 1; end)
+  assert_equal 'expression', defined?(if (lv == 1)..(lv == 2) then 1 end)
+
+  # jumps, which `defined?` reports on without needing a place to jump to
+  assert_equal 'expression', defined?(return)
+  assert_equal 'expression', defined?(break)
+  assert_equal 'expression', defined?(next)
+  assert_equal 'expression', defined?(redo)
+  assert_equal 'expression', defined?(retry)
+
+  # definitions, which stay undefined because the operand is not evaluated
+  assert_equal 'expression', defined?(def defined_never_defined; end)
+  assert_false respond_to?(:defined_never_defined, true)
+  assert_equal 'expression', defined?(class DefinedNeverClass; end)
+  assert_equal 'expression', defined?(module DefinedNeverModule; end)
+  assert_false Object.const_defined?(:DefinedNeverClass)
+  assert_false Object.const_defined?(:DefinedNeverModule)
+  assert_equal 'expression', defined?(class << self; end)
+end
+
 # NOTE: `&nil` block-forbidding parameters live in syntax_block_forbid.rb,
 # which the build excludes when compiling with mruby-compiler-prism (the
 # Prism parser does not accept `&nil` yet).

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1672,6 +1672,20 @@ assert('defined? on control flow, jumps and definitions') do
   assert_equal 'expression', defined?(class << self; end)
 end
 
+assert('defined? sees through parentheses around one expression') do
+  lv = 1
+  @defined_paren_iv = 1
+
+  assert_equal 'local-variable', defined?((lv))
+  assert_equal 'local-variable', defined?(((lv)))
+  assert_equal 'instance-variable', defined?((@defined_paren_iv))
+  assert_equal 'constant', defined?((Object))
+  assert_nil defined?((no_such_method_at_all))
+
+  # parentheses holding several statements are an expression of their own
+  assert_equal 'expression', defined?((1; 2))
+end
+
 # NOTE: `&nil` block-forbidding parameters live in syntax_block_forbid.rb,
 # which the build excludes when compiling with mruby-compiler-prism (the
 # Prism parser does not accept `&nil` yet).

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1686,6 +1686,19 @@ assert('defined? sees through parentheses around one expression') do
   assert_equal 'expression', defined?((1; 2))
 end
 
+assert('defined? on a call carrying a block') do
+  # a literal block makes the whole call an expression, whether or not the
+  # method is there and whatever the call is written on
+  assert_equal 'expression', defined?(loop { break })
+  assert_equal 'expression', defined?(no_such_method_at_all { })
+  assert_equal 'expression', defined?([1, 2].map { |e| e })
+  assert_equal 'expression', defined?(nil&.no_such_method_at_all { })
+
+  # a block passed as `&arg` leaves an ordinary call behind
+  assert_equal 'method', defined?(assert(&:to_s))
+  assert_nil defined?(no_such_method_at_all(&:to_s))
+end
+
 # NOTE: `&nil` block-forbidding parameters live in syntax_block_forbid.rb,
 # which the build excludes when compiling with mruby-compiler-prism (the
 # Prism parser does not accept `&nil` yet).


### PR DESCRIPTION
## Summary

`defined?` decides an operand's answer from its node type and falls through to nil for anything it does not name. A family of operands sat in that gap and answered nil where CRuby answers "expression".

## Changes

| File                                   | What                                                                                                                                                                                                                          |
| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | the `PM_DEFINED_NODE` operand switch names the control flow, jump and definition node types, sees through parentheses around a single statement, and decides a call carrying a literal block before asking about the receiver |
| `test/t/syntax.rb`                     | three assert blocks, one per group                                                                                                                                                                                            |

This is the first of four steps toward a CRuby-compatible `defined?`. It widens the node-type decision alone: no runtime helper and no VM instruction is touched, and the operand is still never evaluated. The three that follow cover constant paths of any depth, recursive checking of a call's arguments, and calls through an explicit receiver.

### Control flow, jumps and definitions

Name those node types alongside the literals that already answer "expression". None of them needs the operand evaluated, so the rule that `defined?` leaves its operand alone still holds: the definition forms report "expression" without defining anything, which the tests check by asking for the method and the constants afterwards.

Only the node types Prism can hand `defined?` are named. A flip-flop is one it cannot: `defined?((a)..(b))` parses as a range, and the flip-flop reading is reserved for a condition, which an operand never is. A statements node is another, since the parentheses walk below descends into the single statement rather than stopping at the list.

### Parentheses around one expression

`defined?((lv))` reached the operand switch as a node of its own and matched nothing. While the operand is a parentheses node whose body holds exactly one statement, descend into that statement, so `defined?((lv))` answers what `defined?(lv)` does. Parentheses holding no statement or several are an expression in their own right and stay in the switch.

### A call carrying a block

A call carrying a literal block is an expression to CRuby whatever the method's fate, and whatever the call is written on: `defined?(loop { break })` is "expression", not "method". The codegen looked only at whether the call had a receiver, so it answered "method" for a receiverless call with a block and nil for one with a receiver. A block passed as `&arg` is not a literal block and leaves an ordinary call behind, so it keeps answering "method".

## Behaviour

Every row was run against both mruby and CRuby 4.0.6, which parses with the same Prism.

| Operand                                                             | Before     | After                 | CRuby 4.0.6           |
| ------------------------------------------------------------------- | ---------- | --------------------- | --------------------- |
| `lv && lv`, `lv or lv`                                              | nil        | `"expression"`        | `"expression"`        |
| `if`, `unless`, `lv ? 1 : 2`                                        | nil        | `"expression"`        | `"expression"`        |
| `case`/`when`, `case`/`in`, `lv in Integer`, `lv => Integer`        | nil        | `"expression"`        | `"expression"`        |
| `while`, `until`, `for`                                             | nil        | `"expression"`        | `"expression"`        |
| `begin; 1; end`                                                     | nil        | `"expression"`        | `"expression"`        |
| `return`, `break`, `next`, `redo`, `retry`                          | nil        | `"expression"`        | `"expression"`        |
| `def m; end`, `class C; end`, `module M; end`, `class << self; end` | nil        | `"expression"`        | `"expression"`        |
| `(lv)`                                                              | nil        | `"local-variable"`    | `"local-variable"`    |
| `(@iv)`                                                             | nil        | `"instance-variable"` | `"instance-variable"` |
| `(Object)`                                                          | nil        | `"constant"`          | `"constant"`          |
| `(1; 2)`                                                            | nil        | `"expression"`        | `"expression"`        |
| `loop { break }`                                                    | `"method"` | `"expression"`        | `"expression"`        |
| `[1, 2].map { }`                                                    | nil        | `"expression"`        | `"expression"`        |
| `nil&.no_such { }`                                                  | nil        | `"expression"`        | `"expression"`        |
| `no_such(&:to_s)`                                                   | nil        | nil                   | nil                   |

What the later steps are left is what still answers nil: a call through a receiver, so `defined?(1 + 1)` and `defined?(String.new)` and the safe-navigation call `defined?(nil&.to_s)`, which CRuby answers "method" for; and a constant path the two-symbol runtime helper cannot express, so `defined?(A::B::C)` and `defined?(::A)`. `defined?(puts(no_such_thing))` still answers "method" where CRuby answers nil, because the arguments are not checked yet.

## Testing

Each of the three commits was built and run through the whole suite on its own, `rake -m test` on the default build:

| Commit       | core `Total` | core `OK` | bintest        |
| ------------ | ------------ | --------- | -------------- |
| control flow | 2645         | 2573      | 130 (`OK` 129) |
| parentheses  | 2646         | 2574      | 130 (`OK` 129) |
| a block      | 2647         | 2575      | 130 (`OK` 129) |

`KO 0`, `Crash 0` and `Warning 0` in every run.

`MRUBY_CONFIG=ci/gcc-clang rake -m test`, all seven builds: `Total 2628-2893`, `KO 0`, `Crash 0`, `Warning 0`; bintest `Total 147`, `OK 146`.

The three new assert blocks in `test/t/syntax.rb` cover the three groups, including that `defined?(def m; end)` and `defined?(class C; end)` report "expression" without leaving a method or a constant behind. Every expectation in them was read off CRuby 4.0.6 rather than written from the spec.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `codegen.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `defined?` results for control-flow statements, jumps, definitions, and expressions wrapped in parentheses.
  - Improved handling of method calls with literal blocks.
  - Preserved correct behavior for multi-statement parentheses and calls using block arguments.

- **Tests**
  - Added coverage for `defined?` behavior across these expression types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->