### PR TITLE
mruby-compiler: resolve a defined? constant path of any depth

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1842,6 +1842,11 @@ mrc_generate_code(mrc_ccontext *c, mrc_node *node)
 
 #define nint(node) PM_NODE_TYPE(node)
 
+/* Names `defined?` will name in one constant path.  The walk holds them on
+   the stack of a recursive codegen, so the bound stays well under what
+   OP_ARRAY could carry; a path deeper than this is answered nil. */
+#define DEFINED_PATH_MAX 32
+
 #define CAST3(name, from, to) \
   pm_##name##_node_t *to = (pm_##name##_node_t *)from
 #define CAST(name) CAST3(name,tree,cast)
@@ -6259,7 +6264,9 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       const char *type = NULL;
       int helper = 0;             /* runtime helper symbol, 0 = none */
       pm_constant_id_t arg = 0;   /* symbol operand for the helper, 0 = none */
-      pm_constant_id_t arg2 = 0;  /* second symbol operand (A::B), 0 = none */
+      pm_constant_id_t path[DEFINED_PATH_MAX];  /* A::B::C, root first */
+      int path_len = 0;           /* names in `path`, 0 = not a constant path */
+      mrc_bool path_toplevel = FALSE;           /* ::A, so rooted at Object */
       /* parentheses around a single expression are transparent here, so
          `defined?((x))` answers what `defined?(x)` does; parentheses holding
          no statement or several fall through to the "expression" cases */
@@ -6333,14 +6340,35 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         arg = ((pm_constant_read_node_t *)value)->name;
         break;
       case PM_CONSTANT_PATH_NODE:
-        /* only A::B where A is a plain constant; nested/toplevel/expression
-           parents are left to fall through to nil */
+        /* Walk the path to its root, collecting the names leaf first.  The
+           root is either a plain constant, so the first name resolves in the
+           lexical scope, or nothing at all, so `::A` starts at Object.  A
+           root that is any other expression would have to be evaluated, and
+           falls through to nil. */
         {
-          pm_constant_path_node_t *cp = (pm_constant_path_node_t *)value;
-          if (cp->parent && nint(cp->parent) == PM_CONSTANT_READ_NODE) {
+          mrc_node *seg = value;
+          pm_constant_id_t names[DEFINED_PATH_MAX];
+          int n = 0;
+          mrc_bool rooted = FALSE;
+
+          while (nint(seg) == PM_CONSTANT_PATH_NODE && n < DEFINED_PATH_MAX) {
+            names[n++] = ((pm_constant_path_node_t *)seg)->name;
+            seg = (mrc_node *)((pm_constant_path_node_t *)seg)->parent;
+            if (seg == NULL) {      /* ::A, rooted at Object */
+              path_toplevel = TRUE;
+              rooted = TRUE;
+              break;
+            }
+          }
+          if (!rooted && seg != NULL && nint(seg) == PM_CONSTANT_READ_NODE &&
+              n < DEFINED_PATH_MAX) {
+            names[n++] = ((pm_constant_read_node_t *)seg)->name;
+            rooted = TRUE;
+          }
+          if (rooted) {
             helper = MRC_SYM_2(defined_const_path_q);
-            arg = ((pm_constant_read_node_t *)cp->parent)->name;
-            arg2 = cp->name;
+            path_len = n;
+            for (int i = 0; i < n; i++) path[i] = names[n - 1 - i];
           }
         }
         break;
@@ -6385,11 +6413,17 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         }
         else if (helper) {
           genop_1(s, OP_LOADSELF, cursp());   /* receiver slot for the SSEND */
-          if (arg2 != 0) {          /* A::B: two symbol operands */
+          if (path_len > 0) {       /* A::B::C: where to start, then the names */
             push();
-            genop_2(s, OP_LOADSYM, cursp(), new_sym(s, arg));
+            if (path_toplevel) genop_1(s, OP_OCLASS, cursp());
+            else genop_1(s, OP_LOADNIL, cursp());
             push();
-            genop_2(s, OP_LOADSYM, cursp(), new_sym(s, arg2));
+            for (int i = 0; i < path_len; i++) {
+              genop_2(s, OP_LOADSYM, cursp(), new_sym(s, path[i]));
+              push();
+            }
+            pop_n(path_len);
+            genop_2(s, OP_ARRAY, cursp(), path_len);
             push(); push();         /* reserve args + block slots (nregs) */
             pop_n(4);
             genop_3(s, OP_SSEND, cursp(), new_sym(s, helper), 2);

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -790,22 +790,43 @@ mrb_f_defined_super(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
+/* `path` holds the names of a constant path from its root down, and `start`
+   says where to look the first one up: nil for the caller's lexical scope
+   (`A::B::C`), or the module the path is rooted at (`Object` for `::A::B`).
+   A name that is missing, or an outer value that is not a module, ends the
+   walk at nil rather than raising. */
 static mrb_value
 mrb_f_defined_const_path(mrb_state *mrb, mrb_value self)
 {
-  mrb_sym parent, child;
-  mrb_get_args(mrb, "nn", &parent, &child);
-  /* resolve the parent constant in the caller's lexical scope (ci[-1]) */
-  mrb_callinfo *ci = &mrb->c->ci[-1];
-  if (ci < mrb->c->cibase || ci->proc == NULL) return mrb_nil_value();
-  mrb_value pv = mrb_vm_const_get_noraise(mrb, ci->proc, parent);
-  if (mrb_undef_p(pv)) return mrb_nil_value();
-  enum mrb_vtype t = mrb_type(pv);
-  if (t != MRB_TT_CLASS && t != MRB_TT_MODULE && t != MRB_TT_SCLASS) {
-    return mrb_nil_value();
+  mrb_value start, path;
+  mrb_get_args(mrb, "oA", &start, &path);
+  mrb_int len = RARRAY_LEN(path);
+  mrb_int i = 0;
+  mrb_value outer;
+
+  if (len == 0) return mrb_nil_value();
+  if (!mrb_symbol_p(RARRAY_PTR(path)[0])) return mrb_nil_value();
+  if (mrb_nil_p(start)) {
+    mrb_callinfo *ci = &mrb->c->ci[-1];
+    if (ci < mrb->c->cibase || ci->proc == NULL) return mrb_nil_value();
+    outer = mrb_vm_const_get_noraise(mrb, ci->proc, mrb_symbol(RARRAY_PTR(path)[0]));
+    if (mrb_undef_p(outer)) return mrb_nil_value();
+    i = 1;
   }
-  if (mrb_const_defined(mrb, pv, child)) return mrb_str_new_lit(mrb, "constant");
-  return mrb_nil_value();
+  else {
+    outer = start;
+  }
+  for (; i < len; i++) {
+    enum mrb_vtype t = mrb_type(outer);
+    if (t != MRB_TT_CLASS && t != MRB_TT_MODULE && t != MRB_TT_SCLASS) {
+      return mrb_nil_value();
+    }
+    if (!mrb_symbol_p(RARRAY_PTR(path)[i])) return mrb_nil_value();
+    mrb_sym name = mrb_symbol(RARRAY_PTR(path)[i]);
+    if (!mrb_const_defined(mrb, outer, name)) return mrb_nil_value();
+    if (i + 1 < len) outer = mrb_const_get(mrb, outer, name);
+  }
+  return mrb_str_new_lit(mrb, "constant");
 }
 
 /* ---------------------------*/

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1682,6 +1682,67 @@ assert('defined? on constant paths (A::B)') do
   assert_equal 'constant', defined?(Float::INFINITY) if Object.const_defined?(:Float)
 end
 
+module DefinedDeepOuter
+  module Mid
+    Leaf = 1
+  end
+  NotAModule = 1
+
+  def self.from_lexical_scope;      defined?(Mid::Leaf); end
+  def self.from_lexical_scope_miss; defined?(Mid::Missing); end
+end
+
+class DefinedPathRaises
+  def self.boom; raise 'defined? evaluated a constant path root'; end
+end
+
+assert('defined? on a constant path of any depth') do
+  assert_equal 'constant', defined?(DefinedDeepOuter::Mid)
+  assert_equal 'constant', defined?(DefinedDeepOuter::Mid::Leaf)
+  assert_nil defined?(DefinedDeepOuter::Mid::Missing)
+  assert_nil defined?(DefinedDeepOuter::Missing::Leaf)
+  assert_nil defined?(NoSuchOuterAtAll::Mid::Leaf)
+
+  # the walk stops where a name resolves to something that is not a module
+  assert_nil defined?(DefinedDeepOuter::NotAModule::Leaf)
+  assert_nil defined?(DefinedDeepOuter::Mid::Leaf::Deeper)
+
+  # the first name resolves in the lexical scope of the code asking
+  assert_equal 'constant', DefinedDeepOuter.from_lexical_scope
+  assert_nil DefinedDeepOuter.from_lexical_scope_miss
+end
+
+# a module that holds itself, so a path of any length can be written out and
+# its length is the only thing under test
+module DefinedDeepSelf
+  S = self
+end
+
+assert('defined? on a constant path at the length limit') do
+  # the compiler collects at most DEFINED_PATH_MAX (32) names of one path,
+  # since it holds them on the stack of a recursive codegen; a longer path
+  # is answered nil, where CRuby, which has no such bound, answers "constant"
+  assert_equal 'constant', defined?(DefinedDeepSelf::S::S::S::S::S::S::S::S::
+                                    S::S::S::S::S::S::S::S::S::S::S::S::S::S::
+                                    S::S::S::S::S::S::S::S::S)
+  assert_nil defined?(DefinedDeepSelf::S::S::S::S::S::S::S::S::S::S::S::S::S::
+                      S::S::S::S::S::S::S::S::S::S::S::S::S::S::S::S::S::S::S)
+end
+
+assert('defined? on a constant path rooted at Object') do
+  assert_equal 'constant', defined?(::Object)
+  assert_equal 'constant', defined?(::DefinedDeepOuter)
+  assert_equal 'constant', defined?(::DefinedDeepOuter::Mid::Leaf)
+  assert_nil defined?(::NoSuchOuterAtAll)
+  assert_nil defined?(::DefinedDeepOuter::Missing)
+end
+
+assert('defined? does not evaluate a constant path') do
+  # a root that would have to be evaluated is not a path the compiler names,
+  # and the call it is built from stays unmade
+  assert_nil defined?(DefinedPathRaises.boom::Leaf)
+end
+
 assert('defined? on control flow, jumps and definitions') do
   lv = 1
 


### PR DESCRIPTION
## Summary

`defined?` resolves a constant path through a runtime helper that took the path as exactly two symbols, so `A::B` was the only shape it could be asked about. A deeper path, and one rooted at `Object`, had no way to be expressed and answered nil where CRuby answers `"constant"`.

## Changes

| File                                   | What                                                                                                                                              |
| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | the `PM_CONSTANT_PATH_NODE` case walks a path of any depth to its root and hands the helper all of its names; `DEFINED_PATH_MAX` bounds that walk |
| `src/kernel.c`                         | `mrb_f_defined_const_path` takes where to start looking plus the names as an array, in place of a parent and a child symbol                       |
| `test/t/syntax.rb`                     | three assert blocks: a path of any depth, a path rooted at `Object`, and that neither evaluates its root                                          |

This is the second of four steps toward a CRuby-compatible `defined?`, after #7510. The two that follow cover a method reached through an explicit receiver, and the arguments of a call and the elements of an array literal.

### The whole path, and where to start looking

The codegen named a path only where its parent was a plain constant, and passed the two symbols on; the helper resolved the parent in the caller's lexical scope and asked whether the child was there. Neither half could carry `A::B::C`, and neither could say "start at `Object`" for `::A`.

Walk the path to its root instead, collecting the names, and hand the helper an array of them from the root down plus where to start looking: nil for the caller's lexical scope, or the module the path is rooted at, which `::A` fills in with `OP_OCLASS`. The helper walks the names in turn, stopping at nil where one is missing, or where an outer value turns out not to be a module.

The compiler names at most `DEFINED_PATH_MAX` (32) segments of one path, since it collects them on the stack of a recursive codegen; the bound stays well under what `OP_ARRAY` could carry. A path with more names than that answers nil where CRuby still answers `"constant"`; a test pins both sides of the bound.

### The operand is still not evaluated

A root that is neither a constant nor the toplevel `::` would have to be evaluated before it could be looked into, so it is not a path the codegen names and it falls through to nil, as it did before. `defined?(Boom.explode::Leaf)` is nil with the call unmade, which is what CRuby does too. The case stays a compile-time decision followed by one helper call.

## Behaviour

Every row was run against both mruby and CRuby 4.0.6, which parses with the same Prism.

| Operand                        | Before       | After        | CRuby 4.0.6  |
| ------------------------------ | ------------ | ------------ | ------------ |
| `Outer::Mid::Leaf`             | nil          | `"constant"` | `"constant"` |
| `::Object`                     | nil          | `"constant"` | `"constant"` |
| `::Outer::Mid::Leaf`           | nil          | `"constant"` | `"constant"` |
| `Outer::Mid::Missing`          | nil          | nil          | nil          |
| `Outer::Missing::Leaf`         | nil          | nil          | nil          |
| `NoSuchOuter::Mid::Leaf`       | nil          | nil          | nil          |
| `Outer::NotAModule::Leaf`      | nil          | nil          | nil          |
| `Outer::Mid::Leaf::Deeper`     | nil          | nil          | nil          |
| `::NoSuchOuter`                | nil          | nil          | nil          |
| `Boom.explode::Leaf`           | nil          | nil          | nil          |
| `Outer::Mid`                   | `"constant"` | `"constant"` | `"constant"` |
| `Mid::Leaf` in a lexical scope | `"constant"` | `"constant"` | `"constant"` |
| `Mid::Missing` in the same one | nil          | nil          | nil          |

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang`, gcc 13.3.0, empty build directories at the same worktree path, base `dede7fddc`.

| Build                | master    | this PR   | delta |
| -------------------- | --------- | --------- | ----- |
| `bintest`            | 1,385,462 | 1,386,374 | +912  |
| `ascii-ctype`        | 1,371,046 | 1,371,958 | +912  |
| `byte-string`        | 1,348,438 | 1,349,350 | +912  |
| `cxx_abi`            | 1,419,257 | 1,420,217 | +960  |
| `no-float`           | 1,311,918 | 1,312,782 | +864  |
| `no-bigint`          | 1,269,974 | 1,270,886 | +912  |
| `full-debug` (`-O0`) | 1,979,366 | 1,980,278 | +912  |

In `bintest` the delta is the two changed objects and nothing else: `codegen.o` +640 for the walk that collects the names, and `kernel.o` +272 for the one that resolves them.

## Testing

`rake -m test`, green on the default build and on all seven of `build_config/ci/gcc-clang`. Each build's counts were read off its own `bin/mrbtest`, since the parallel run's output cannot be mapped back to a build.

| Build                            | Total | OK   | Skip | KO  | Crash | Warning |
| -------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host (`build_config/default.rb`) | 2654  | 2582 | 72   | 0   | 0     | 0       |
| `bintest`                        | 2900  | 2880 | 20   | 0   | 0     | 0       |
| `ascii-ctype`                    | 2886  | 2864 | 22   | 0   | 0     | 0       |
| `byte-string`                    | 2814  | 2742 | 72   | 0   | 0     | 0       |
| `cxx_abi`                        | 2900  | 2880 | 20   | 0   | 0     | 0       |
| `no-float`                       | 2635  | 2538 | 97   | 0   | 0     | 0       |
| `no-bigint`                      | 2852  | 2819 | 33   | 0   | 0     | 0       |
| `full-debug` (`-O0`)             | 2900  | 2889 | 11   | 0   | 0     | 0       |

The command bintests ran with them: `Total 130`, `OK 129` on the default build, and `Total 147`, `OK 146` over `ci/gcc-clang`.

The four new assert blocks in `test/t/syntax.rb` cover a path of any depth, one rooted at `Object`, the two ways the walk stops early (a name that is missing, and an outer value that is not a module), and both sides of the `DEFINED_PATH_MAX` bound: a path of 32 names answers `"constant"`, one of 33 answers nil. They also check that the first name of a path resolves in the lexical scope of the code asking, and that a root the compiler does not name leaves its call unmade. Every expectation in them was read off CRuby 4.0.6 rather than written from the spec.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `codegen.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed. `src/kernel.c` is compiled with the same line in each build, minus the compiler gem's own defines (`-DPRISM_*`, `-DMRC_*`, `-DMRBGEM_MRUBY_COMPILER_VERSION`, and in `cxx_abi` `-D__STDC_LIMIT_MACROS` and `-D__STDC_CONSTANT_MACROS`) and plus `-DMRB_REVISION_HEADER`.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `defined?` to support constant paths of any depth, including absolute paths such as `::A::B`.
  * Constant lookup now correctly handles lexical scope and validates each path segment.

* **Bug Fixes**
  * Prevented incorrect results for missing constants, non-module path components, overly long paths, and unevaluated path roots.

* **Tests**
  * Added coverage for deep, absolute, lexical, invalid, and length-limited constant paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->