### PR TITLE
mruby-task: drop the double spaces prettier collapses in the README

### DIFF
--- a/mrbgems/mruby-task/README.md
+++ b/mrbgems/mruby-task/README.md
@@ -825,16 +825,16 @@ The equivalent C entry points are `mrb_gc_scheduler_driven()`,
 ### Relationship with Fiber
 
 A fiber works as it does in any other build: create one, resume it, let it
-finish, inside a task body or outside one.  Adding this gem takes nothing away.
+finish, inside a task body or outside one. Adding this gem takes nothing away.
 
-What the two cannot do is share a context.  A `mrb_context` carries a 4-bit
+What the two cannot do is share a context. A `mrb_context` carries a 4-bit
 `status`, and the scheduler reads the same field mruby-fiber writes, down to
-the same value: `MRB_TASK_STOPPED` is `MRB_FIBER_TERMINATED`.  So a context is
+the same value: `MRB_TASK_STOPPED` is `MRB_FIBER_TERMINATED`. So a context is
 either a fiber's or a task's, and code that arranges for one context to be both
 leaves the scheduler unable to tell which it is looking at.
 
 - Tasks are scheduled by the scheduler; fibers are driven by `Fiber.yield` and
-  `#resume`.  Each owns its context for as long as it lives.
+  `#resume`. Each owns its context for as long as it lives.
 - Do not hand a task's context to a fiber or the other way round.
 
 ### Relationship with mruby-sleep


### PR DESCRIPTION
## Summary

The manual pre-commit job runs prettier 3.7.4 with `--write` over every markdown file and fails when the tree changes. 4d90c9f2c wrote the Fiber section of `mrbgems/mruby-task/README.md` with two spaces after each full stop, which prettier collapses to one. That commit went to master directly, so the job has not run on it yet and will fail on the next pull request that reaches it.

## Changes

Drops the second space after four full stops in the "Relationship with Fiber" section. No words change. The single space is what the rest of the README already uses.

## Testing

```
npx prettier@3.7.4 --check mrbgems/mruby-task/README.md
```

reports `[warn] Code style issues found` on master and `All matched files use Prettier code style!` on this branch. `prek run --files mrbgems/mruby-task/README.md --hook-stage manual` passes on this branch and fails on master with the same four-line diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the “Relationship with Fiber” section formatting for consistent spacing.
  - No content or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->