### PR TITLE
mruby-regexp: reach the engine paths no test ran

### DIFF
--- a/mrbgems/mruby-regexp/test/regexp.rb
+++ b/mrbgems/mruby-regexp/test/regexp.rb
@@ -11,6 +11,12 @@ assert("Regexp.new with regexp") do
   assert_true r2.match?("ABC")
 end
 
+assert("Regexp.new refuses what is neither a String nor a Regexp") do
+  [nil, 1, :abc, [], true].each do |arg|
+    assert_raise(TypeError, arg.inspect) { Regexp.new(arg) }
+  end
+end
+
 class RegexpInitializedTwice < Regexp
   def initialize(first, second)
     super(first)

--- a/mrbgems/mruby-regexp/test/regexp_call.rb
+++ b/mrbgems/mruby-regexp/test/regexp_call.rb
@@ -182,6 +182,16 @@ assert("Regexp - calls and lookarounds") do
   assert_equal "xy", "xy".match(Regexp.new("(?<a>^x)y\\g<a>?"))[0]
 end
 
+assert("Regexp - a lookbehind on the way to a call") do
+  need_backtracking_stack
+  # A lookbehind before a group a call names, or inside one, is asserted
+  # where it stands each time the group runs, as in CRuby.
+  assert_equal "yy", "xyy".match(Regexp.new("(?<=x)(?<a>y)\\g<a>"))[0]
+  assert_nil "yy".match(Regexp.new("(?<=x)(?<a>y)\\g<a>"))
+  assert_equal "yxy", "xyxy".match(Regexp.new("(?<a>(?<=x)y)x\\g<a>"))[0]
+  assert_nil "xyy".match(Regexp.new("(?<a>(?<=x)y)\\g<a>"))
+end
+
 assert("Regexp - a call in a lookbehind must measure fixed") do
   need_backtracking_stack
   assert_equal "xy", "xy".match(Regexp.new("(?<a>xy)(?<=\\g<a>)"))[0]

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -740,6 +740,31 @@ assert("Regexp - \\Z matches before a trailing newline under the backtracking en
   assert_equal "aX\n", "ab\n".sub(/b\Z(?=)/, "X")
 end
 
+assert("Regexp - \\A fails off the start wherever the pattern puts it") do
+  # \A inside an alternation is an assertion like any other: off the start
+  # it fails its own branch, the other branch is tried, and the search goes
+  # on to later positions. CRuby answers all three the same way.
+  assert_equal 1, (/(?:\A|b)c/ =~ "xbc")
+  assert_equal 0, (/(?:\A|b)c/ =~ "cbc")
+  assert_nil(/(?:\A|b)c/ =~ "xc")
+end
+
+assert("Regexp - a dot under /m crosses a newline under the backtracking engine too") do
+  need_backtracking_stack
+  # The backreference is what routes the pattern to the other engine.
+  assert_equal 0, (/(a).\1/m =~ "a\na")
+  assert_nil(/(a).\1/ =~ "a\na")
+  assert_equal 0, (/(a).\1/ =~ "aba")
+end
+
+assert("Regexp - \\B under the backtracking engine too") do
+  need_backtracking_stack
+  # The backreference routes the pattern the same way.
+  assert_equal 0, (/(a)\B\1/ =~ "aa")
+  assert_nil(/(a)\B\1/ =~ "a a")
+  assert_equal 1, (/(\s)\B\1/ =~ "a  b")
+end
+
 assert("Regexp - case insensitive") do
   re = Regexp.new("abc", Regexp::IGNORECASE)
   assert_true re.match?("ABC")
@@ -2747,6 +2772,20 @@ assert("Regexp - lookbehind at string start") do
   assert_equal "d", md[0]
 end
 
+assert("Regexp - a lookbehind body holds a zero-width assertion") do
+  need_backtracking_stack
+  # An anchor or a word boundary inside a lookbehind body is asserted at the
+  # position the body has rewound to, as in CRuby. CRuby refuses \z and \Z
+  # in a lookbehind, which this gem accepts, so neither is asked about here.
+  assert_equal 1, (/(?<=^a)b/ =~ "ab")
+  assert_nil(/(?<=^a)b/ =~ "xab")
+  assert_equal 1, (/(?<=\Aa)b/ =~ "ab")
+  assert_nil(/(?<=\Aa)b/ =~ "xab")
+  assert_equal 1, (/(?<=a$)/ =~ "a")
+  assert_equal 5, (/(?<=\ba)b/ =~ "xab ab")
+  assert_nil(/(?<=a\b)b/ =~ "a b")
+end
+
 assert("Regexp - negative lookbehind at string start") do
   need_backtracking_stack
   # negative lookbehind succeeds when not enough text before
@@ -3117,6 +3156,16 @@ assert("Regexp - octal and hex escapes") do
   end
 end
 
+assert("Regexp - the bell and escape characters have escapes of their own") do
+  # `\a` and `\e` name U+0007 and U+001B as the string escapes do, outside a
+  # class and inside one.
+  assert_equal 1, (/\a\e/ =~ "x\a\e")
+  assert_equal 1, (Regexp.new("\\a\\e") =~ "x\a\e")
+  assert_equal 2, "\a\e".scan(/[\a\e]/).size
+  assert_nil(/\a/ =~ "a")
+  assert_nil(/\e/ =~ "e")
+end
+
 assert("Regexp - a backslash the pattern ends after says which it was") do
   # A `\\` with nothing after it is an escape that ends early, which is what
   # CRuby calls it, and the same one it calls a `\\u` with no digits after
@@ -3324,6 +3373,35 @@ assert("Regexp - `&&` narrows a character class to what both sides hold") do
   assert_equal "&", "&"[/[\&]/]
   assert_equal "&", "x&y"[/[\&&]/]
   assert_equal "&", "x&y"[/[a\&&b&]/]
+end
+
+assert("Regexp - `&&` between ranges above ASCII") do
+  skip unless __ENCODING__ == "UTF-8"
+  # Two ranges above ASCII meet in the span they share, and in nothing when
+  # they share none. The same pair is asked both ways round: which of the
+  # two ends first must not matter.
+  assert_equal 0, (/[\u{100}-\u{200}&&[\u{150}-\u{300}]]/ =~ "\u{160}")
+  assert_nil(/[\u{100}-\u{200}&&[\u{150}-\u{300}]]/ =~ "\u{120}")
+  assert_nil(/[\u{100}-\u{200}&&[\u{150}-\u{300}]]/ =~ "\u{250}")
+  assert_equal 0, (/[\u{150}-\u{300}&&[\u{100}-\u{200}]]/ =~ "\u{160}")
+  assert_nil(/[\u{150}-\u{300}&&[\u{100}-\u{200}]]/ =~ "\u{120}")
+  assert_nil(/[\u{150}-\u{300}&&[\u{100}-\u{200}]]/ =~ "\u{250}")
+  # several entries on one side, one of which the other side misses entirely
+  assert_equal ["\u{210}"],
+    "\u{105}\u{130}\u{210}\u{280}".scan(/[\u{100}-\u{120}\u{200}-\u{300}&&[\u{110}-\u{250}]]/)
+end
+
+assert("Regexp - `&&` narrows a class holding everything above ASCII") do
+  skip unless __ENCODING__ == "UTF-8"
+  # \H and a negated nested class each hold every character above ASCII, so
+  # what they share with a range is the range: its members and no other
+  # character above ASCII, nor any below it that the other side leaves out.
+  assert_equal 0, (/[\H&&[\u{100}-\u{200}]]/ =~ "\u{150}")
+  assert_nil(/[\H&&[\u{100}-\u{200}]]/ =~ "\u{250}")
+  assert_nil(/[\H&&[\u{100}-\u{200}]]/ =~ "a")
+  assert_equal 0, (/[[^a]&&[\u{100}-\u{200}]]/ =~ "\u{150}")
+  assert_nil(/[[^a]&&[\u{100}-\u{200}]]/ =~ "\u{250}")
+  assert_nil(/[[^a]&&[\u{100}-\u{200}]]/ =~ "b")
 end
 
 assert("Regexp - a nested class carries its own intersection into the union") do

--- a/mrbgems/mruby-regexp/test/string_index.rb
+++ b/mrbgems/mruby-regexp/test/string_index.rb
@@ -850,6 +850,7 @@ assert("String#start_with? with regexp") do
   assert_true "hello".start_with?(/z/, /h/)
   assert_true "hello".start_with?("z", /h/)
   assert_true "hello".start_with?(/h/, "z")
+  assert_true "hello".start_with?(/z/, "he")
   assert_false "hello".start_with?(/z/, "z")
   assert_false "hello".start_with?
 

--- a/mrbgems/mruby-regexp/test/string_regexp.rb
+++ b/mrbgems/mruby-regexp/test/string_regexp.rb
@@ -96,6 +96,11 @@ assert("String#scan with a block that changes the receiver") do
   assert_raise_with_message(RuntimeError, "string modified") { s.scan("l") { s << "z" } }
   s = "ab"
   assert_raise_with_message(RuntimeError, "string modified") { s.scan(/x*/) { s.clear } }
+  # a change made on the last match is refused too, though no search follows
+  # it: the match left behind is where CRuby refuses it, and so here
+  s = "ab"
+  assert_raise_with_message(RuntimeError, "string modified") { s.scan(/$/) { s << "x" } }
+  assert_equal "abx", s
 end
 
 assert("String#gsub - regexp search position is byte-based internally") do

--- a/mrbgems/mruby-regexp/test/unicode_ctype.rb
+++ b/mrbgems/mruby-regexp/test/unicode_ctype.rb
@@ -102,6 +102,22 @@ assert("Regexp - POSIX brackets combine above ASCII") do
   assert_equal "!", "あ€!".match(/[^€[:alpha:]]/)[0]
 end
 
+assert("Regexp - nested classes each holding a bracket join their types") do
+  skip unless __ENCODING__ == "UTF-8"
+  # Two nested classes each carrying a bracket hold what either bracket
+  # holds, which is what the two brackets written flat hold, so the answer
+  # has to come out the same however it is spelled.
+  nested = Regexp.new("[[[:alpha:]][[:digit:]]]+")
+  flat = Regexp.new("[[:alpha:][:digit:]]+")
+  assert_equal "٣a1", nested.match("-٣a1!")[0]
+  assert_equal "٣a1", flat.match("-٣a1!")[0]
+  assert_equal "あ１", nested.match("あ１€")[0]
+  assert_nil nested =~ "-€!"
+  # one bracket nested beside one written flat, either way round
+  assert_equal "٣a1", Regexp.new("[[:alpha:][[:digit:]]]+").match("-٣a1!")[0]
+  assert_equal "٣a1", Regexp.new("[[[:alpha:]][:digit:]]+").match("-٣a1!")[0]
+end
+
 assert("Regexp - POSIX brackets fold above ASCII under /i") do
   skip unless __ENCODING__ == "UTF-8"
   upper = Regexp.new("[[:upper:]]", Regexp::IGNORECASE)
@@ -226,4 +242,13 @@ assert("Regexp - `&&` puts the brackets either side of it as one question") do
     "this character class intersection is not supported: /[[:alpha:][:digit:]&&[:alpha:][:digit:]]/") do
     Regexp.new("[[:alpha:][:digit:]&&[:alpha:][:digit:]]")
   end
+end
+
+assert("Regexp - `&&` between a bracket and a range through the C1 controls") do
+  skip unless __ENCODING__ == "UTF-8"
+  # A range that starts inside the C1 controls (U+0080 to U+009F) and
+  # reaches past them meets a bracket the way any range does: what is kept
+  # is the members the bracket admits, on both sides of U+009F.
+  assert_equal ["\u{85}"], "\u{85}\u{a0}\u{e9}".scan(/[\u{80}-\u{100}&&[[:cntrl:]]]/)
+  assert_equal ["\u{e9}"], "\u{85}\u{a0}\u{e9}".scan(/[\u{90}-\u{100}&&[[:alpha:]]]/)
 end


### PR DESCRIPTION
## Summary

A gcov run of the full-core build over mrbtest left 107 lines of mruby-regexp unexecuted. Forty-two of them answer to a shape of pattern or subject the existing tests never wrote, and this adds the tests that write it. Every one is a behaviour CRuby 4.0.6 shares.

## Changes

| File                    | What                                                                                                                                                                                                                                                  |
| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `test/regexp_syntax.rb` | seven assert blocks: `&&` between ranges above ASCII and against a class holding everything above ASCII, `\a` and `\e`, `\A` failing inside an alternation, `.` under `/m` and `\B` under the backtracking engine, an anchor inside a lookbehind body |
| `test/unicode_ctype.rb` | two assert blocks: two nested classes each carrying a bracket, and `&&` between a bracket and a range through the C1 controls                                                                                                                         |
| `test/regexp_call.rb`   | one assert block: a lookbehind on the way to a `\g` call                                                                                                                                                                                              |
| `test/regexp.rb`        | one assert block: `Regexp.new` refusing what is neither a String nor a Regexp                                                                                                                                                                         |
| `test/string_regexp.rb` | two lines in the `scan` block that changes its receiver: a change made on the last match                                                                                                                                                              |
| `test/string_index.rb`  | one line in the `start_with?` block: a String answering after a Regexp failed                                                                                                                                                                         |

No source file changes. Every expected value was read off CRuby 4.0.6 before it was written down, and the comments say what the behaviour is rather than which branch of the engine answers it, so that they stay true if the engine is rearranged.

### What was never asked

- **`&&` above ASCII.** Every intersection the existing tests write has at least one side below 128. Two ranges above ASCII, in both orders; a range against `\H` and against a negated nested class, which hold every character above ASCII; and a range starting inside the C1 controls (U+0080 to U+009F) against `[[:cntrl:]]` and `[[:alpha:]]`.
- **A bracket inside a nested class.** `[[[:alpha:]][[:digit:]]]` has to hold what `[[:alpha:][:digit:]]` holds, and so has each mixed spelling.
- **Escapes and assertions spelled another way.** `\a` and `\e` had no test at all. `\A` had only ever stood at the head of a pattern, where it is answered before the engine runs; inside an alternation it fails its branch and the search goes on. `.` under `/m` and `\B` had been asked only of the Pike VM; a backreference asks the backtracking engine. A lookbehind body had never held `^`, `\A`, `$` or `\b`. CRuby refuses `\z` and `\Z` in a lookbehind, which this gem accepts, so those two are not asked about.
- **A lookbehind on the way to a call.** Before a group a `\g` names and inside one, asserted each time the group runs.
- **One shape of subject.** `Regexp.new(1)`; `scan` with a block that changes the receiver's length on the last match, which CRuby refuses through the match it leaves behind rather than through a next search; `start_with?(/z/, "he")`, a String answering after a Regexp failed.

### What stays unexecuted

The other 65 lines are allocation failures (`mrb_malloc_simple` returning NULL, `RE_NOMEM`), the Pike VM's generation counter wrapping near `UINT32_MAX`, arms a compiled pattern cannot reach (a called body always closes with `RE_RETURN`; the VM cache is allocated at compile time and never re-entered; `RE_BYTE` never matches inside a character of a validated subject), defensive `default:` arms, the stack limit crossed from inside an absent repeater, the parse depth refusal that only the `ascii-ctype` build's limit reaches, and a few lines that are reachable but only by a pattern shaped after the current code: the width measure of a lookbehind outgrowing a 1024-entry block, a byte range under `&&`, and edge positions of the prefix and literal scans. Tests for those last ones would pin the structure rather than a behaviour, so they are left out.

## Testing

`rake -m test`, green on the default build and on all seven of `build_config/ci/gcc-clang`. Each build's counts were read off its own `bin/mrbtest`, since the parallel run's output cannot be mapped back to a build.

| Build                            | Total | OK   | Skip | KO  | Crash | Warning |
| -------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host (`build_config/default.rb`) | 2663  | 2589 | 74   | 0   | 0     | 0       |
| `bintest`                        | 2911  | 2891 | 20   | 0   | 0     | 0       |
| `ascii-ctype`                    | 2895  | 2873 | 22   | 0   | 0     | 0       |
| `byte-string`                    | 2823  | 2749 | 74   | 0   | 0     | 0       |
| `cxx_abi`                        | 2911  | 2891 | 20   | 0   | 0     | 0       |
| `no-float`                       | 2646  | 2549 | 97   | 0   | 0     | 0       |
| `no-bigint`                      | 2863  | 2830 | 33   | 0   | 0     | 0       |
| `full-debug` (`-O0`)             | 2911  | 2900 | 11   | 0   | 0     | 0       |

The command bintests ran with them: `Total 130`, `OK 129` on the default build, and `Total 147`, `OK 146` over `ci/gcc-clang`.

The 42 lines were confirmed with gcov: a full-core build compiled with `--coverage`, its counters cleared, then mrbtest run once. What stays at zero after that run is exactly the 65 lines above. The eleven new assert blocks and the three lines added to existing blocks are what the delta comes to; the four of them that need a UTF-8 or Unicode ctype build skip themselves elsewhere, and the four that reach the backtracking engine sit under `need_backtracking_stack` like the blocks around them.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

No C file changes here; the test files are compiled to bytecode by each build's own `mrbc` and linked into `bin/mrbtest`. The compile line for `src/string.c` in each build, as `rake --verbose` printed it after touching the file, says what each build is. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed. The gem's own objects (`mrbgems/mruby-regexp/src/*.c`) are compiled with the same line plus `-DMRBGEM_MRUBY_REGEXP_VERSION=0.0.0` and minus `-DMRB_REVISION_HEADER`.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded regular expression coverage for invalid constructor arguments, lookbehind behavior, anchors, boundaries, escape sequences, Unicode character classes, and character-class intersections.
  * Added coverage for multi-pattern `String#start_with?` behavior.
  * Added validation that modifying a string during the final `String#scan` match raises the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->