### PR TITLE
build_config: leave one blank line where two stood

### DIFF
--- a/build_config/IntelEdison.rb
+++ b/build_config/IntelEdison.rb
@@ -14,7 +14,6 @@ MRuby::CrossBuild.new('core2-32-poky-linux') do |conf|
   POKY_EDISON_X86_PATH = "#{POKY_EDISON_PATH}/sysroots/i386-pokysdk-darwin"
   POKY_EDISON_BIN_PATH = "#{POKY_EDISON_X86_PATH}/usr/bin/i586-poky-linux"
 
-
   conf.cc do |cc|
     cc.command = "#{POKY_EDISON_BIN_PATH}/i586-poky-linux-gcc"
     cc.include_paths << ["#{POKY_EDISON_SYSROOT}/usr/include", "#{POKY_EDISON_X86_PATH}/usr/include"]

--- a/build_config/IntelGalileo.rb
+++ b/build_config/IntelGalileo.rb
@@ -15,7 +15,6 @@ MRuby::CrossBuild.new("Galileo") do |conf|
   GALILEO_SYSROOT  = "#{GALILEO_ARDUINO_PATH}/hardware/tools/x86/i586-poky-linux-uclibc"
   GALILEO_X86_PATH = "#{GALILEO_ARDUINO_PATH}/hardware/arduino/x86"
 
-
   conf.cc do |cc|
     cc.command = "#{GALILEO_BIN_PATH}/i586-poky-linux-uclibc-gcc"
     cc.include_paths << ["#{GALILEO_X86_PATH}/cores/arduino", "#{GALILEO_X86_PATH}/variants/galileo_fab_d"]

--- a/build_config/boxing.rb
+++ b/build_config/boxing.rb
@@ -16,7 +16,6 @@ boxings.product(bits, ints) do |boxing, bit, int|
     end
     conf.linker.flags << "-m#{bit}"
 
-
     conf.enable_debug
     conf.enable_test
     conf.enable_bintest

--- a/build_config/ci/gcc-clang.rb
+++ b/build_config/ci/gcc-clang.rb
@@ -16,7 +16,6 @@ MRuby::Build.new('full-debug') do |conf|
   conf.gembox 'full-core'
   conf.cc.defines += %w(MRB_GC_STRESS MRB_USE_DEBUG_HOOK)
 
-
   conf.enable_test
 end
 end

--- a/build_config/clang-asan.rb
+++ b/build_config/clang-asan.rb
@@ -5,7 +5,6 @@ MRuby::Build.new('clang-asan') do |conf|
   # include the GEM box
   conf.gembox 'full-core'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_sanitizer "address,undefined"
   conf.enable_debug

--- a/build_config/cross-mingw-winetest.rb
+++ b/build_config/cross-mingw-winetest.rb
@@ -56,7 +56,6 @@
 #       operations. It's unclear if this indicates more serious problems.
 #
 
-
 MRuby::CrossBuild.new("cross-mingw-winetest") do |conf|
   conf.toolchain :gcc
 

--- a/build_config/default.rb
+++ b/build_config/default.rb
@@ -79,7 +79,6 @@ MRuby::Build.new do |conf|
   # Turn on `enable_debug` for better debugging
   # conf.enable_debug
 
-
   conf.enable_bintest
   conf.enable_test
 end

--- a/build_config/gcc-asan.rb
+++ b/build_config/gcc-asan.rb
@@ -7,7 +7,6 @@ MRuby::Build.new('gcc-asan') do |conf|
   # include the GEM box
   conf.gembox 'full-core'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_sanitizer "address,undefined"
   conf.enable_debug

--- a/build_config/helpers/wine_runner.rb
+++ b/build_config/helpers/wine_runner.rb
@@ -40,7 +40,6 @@ def clean(output, stderr = false)
   results.join("\n")
 end
 
-
 # Run a Windows program under Wine and hand back what it wrote and how it
 # ended, the way `Open3.capture3` would.
 #
@@ -69,7 +68,6 @@ def capture(argv)
   end
 end
 
-
 def main
   if ARGV.empty? || ARGV[0] =~ /^- (-?) (\?|help|h) $/x
     puts "#{$0} <command-line>"
@@ -88,6 +86,5 @@ def main
 
   exit(status.exitstatus)
 end
-
 
 main()

--- a/build_config/host-cxx.rb
+++ b/build_config/host-cxx.rb
@@ -7,7 +7,6 @@ MRuby::Build.new('host-cxx') do |conf|
   # C compiler settings
   conf.cc.defines = %w(MRB_USE_DEBUG_HOOK)
 
-
   conf.enable_debug
   conf.enable_cxx_abi
   conf.enable_test

--- a/build_config/host-debug.rb
+++ b/build_config/host-debug.rb
@@ -16,7 +16,6 @@ MRuby::Build.new('host') do |conf|
 
   # Regexp is included via stdlib.gembox
 
-
   # test
   conf.enable_test
   # bintest

--- a/build_config/host-f32.rb
+++ b/build_config/host-f32.rb
@@ -9,7 +9,6 @@ MRuby::Build.new('host-f32') do |conf|
 
   conf.cc.defines << 'MRB_USE_FLOAT32'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-gprof.rb
+++ b/build_config/host-gprof.rb
@@ -10,7 +10,6 @@ MRuby::Build.new('host-gprof') do |conf|
   conf.cc.flags << '-pg'
   conf.linker.flags << '-pg'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-m32-f32.rb
+++ b/build_config/host-m32-f32.rb
@@ -11,7 +11,6 @@ MRuby::Build.new('host-m32-f32') do |conf|
   conf.cc.defines << 'MRB_USE_FLOAT32'
   conf.linker.flags << '-m32'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-m32.rb
+++ b/build_config/host-m32.rb
@@ -10,7 +10,6 @@ MRuby::Build.new('host-m32') do |conf|
   conf.cc.flags << '-m32'
   conf.linker.flags << '-m32'
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_test

--- a/build_config/host-nofloat.rb
+++ b/build_config/host-nofloat.rb
@@ -21,7 +21,6 @@ MRuby::Build.new('host-nofloat') do |conf|
     c.defines << "MRB_NO_FLOAT"
   end
 
-
   conf.enable_debug
   conf.enable_test
   conf.enable_bintest

--- a/build_config/host-shared.rb
+++ b/build_config/host-shared.rb
@@ -35,7 +35,6 @@ MRuby::Build.new('host-shared') do |conf|
     cc.flags << '-fPIC'
   end
 
-
   # Turn on `enable_debug` for better debugging
   conf.enable_debug
   conf.enable_bintest

--- a/build_config/no-float.rb
+++ b/build_config/no-float.rb
@@ -11,7 +11,6 @@ MRuby::CrossBuild.new('no-float') do |conf|
 
   conf.test_runner.command = 'env'
 
-
   conf.enable_debug
 #  conf.enable_bintest
   conf.enable_test


### PR DESCRIPTION
## Summary

Every build description under `build_config/` separates its sections with a single blank line, except for one spot in each of sixteen of them where two remained. The Wine runner and the Wine test build kept two blank lines between their top-level definitions, which no other Ruby file in the tree does. Each of those places now has one blank line.

## Changes

| File                                                                                                                                                                                                                                                     | What                                                                                                         |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| `IntelEdison.rb` `IntelGalileo.rb` `boxing.rb` `ci/gcc-clang.rb` `clang-asan.rb` `default.rb` `gcc-asan.rb` `host-cxx.rb` `host-debug.rb` `host-f32.rb` `host-gprof.rb` `host-m32-f32.rb` `host-m32.rb` `host-nofloat.rb` `host-shared.rb` `no-float.rb` | one blank line dropped in each, between the gembox or compiler settings and the `enable_*` calls that follow |
| `cross-mingw-winetest.rb`                                                                                                                                                                                                                                | one blank line dropped between the header comment and `MRuby::CrossBuild.new`                                |
| `helpers/wine_runner.rb`                                                                                                                                                                                                                                 | three blank lines dropped, one between each pair of top-level definitions and one before `main()`            |

The diff is 20 deleted blank lines and nothing else: `git diff --ignore-blank-lines` against master is empty.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2672  | 2598 | 74   | 0   | 0     | 0       |
| full-debug  | 2920  | 2909 | 11   | 0   | 0     | 0       |
| bintest     | 2920  | 2900 | 20   | 0   | 0     | 0       |
| cxx_abi     | 2920  | 2900 | 20   | 0   | 0     | 0       |
| byte-string | 2832  | 2758 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2904  | 2882 | 22   | 0   | 0     | 0       |
| no-float    | 2655  | 2558 | 97   | 0   | 0     | 0       |
| no-bigint   | 2872  | 2839 | 33   | 0   | 0     | 0       |

The bintest suite of `bintest` ran to Total 147, OK 146, KO 0, Crash 0, Warning 0, Skip 1. Every touched file passes `ruby -c`. The cross builds among the touched files cannot be run here; a change that deletes blank lines does not alter what Ruby loads from them.

## Environment

<details>

| Item     | Value                                             |
| -------- | ------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic x86_64 |
| CPU      | AMD Ryzen 9 5950X                                 |
| gcc      | 13.3.0                                            |
| binutils | 2.47.20260726                                     |
| CRuby    | 4.0.6                                             |
| base     | a9151d778                                         |

Compile line of each build, taken from `rake --verbose` after touching `src/string.c`, with `-MMD -c`, the `-I` list and `-o` dropped:

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/string.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map=... -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/string.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map=... -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map=... -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Cleaned up whitespace and blank lines across build configuration files.
  - Removed unused comments and spacing without changing build settings or behavior.

- **Refactor**
  - Updated the Wine-based test runner handling for command output, diagnostics, and exit statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->