### PR TITLE
variable.c: look up a superclass's constant before the top level's

### DIFF
--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -205,6 +205,29 @@ assert('Module#class_eval with string') do
   assert_equal 55, b.new.b.new.a
 end
 
+assert('Module#class_eval with string opens a constant scope') do
+  Test4EvalConstOrder = :top
+  class Test4EvalConstOrderBase
+    Test4EvalConstOrder = :base
+  end
+  class Test4EvalConstOrderOwner
+    Test4EvalConstOrder = :owner
+  end
+  Test4EvalConstOrderOwner.class_eval <<~CODE
+    class Test4EvalConstOrderSub < Test4EvalConstOrderBase
+      @in_body = Test4EvalConstOrder
+      def in_method; Test4EvalConstOrder; end
+      class << self
+        attr_reader :in_body
+      end
+    end
+  CODE
+
+  # the receiver's scope comes before the superclass, as with `class` nesting
+  assert_equal :owner, Test4EvalConstOrderOwner::Test4EvalConstOrderSub.in_body
+  assert_equal :owner, Test4EvalConstOrderOwner::Test4EvalConstOrderSub.new.in_method
+end
+
 assert 'method visibility with eval' do
   c = Class.new do
     eval <<~CODE

--- a/src/variable.c
+++ b/src/variable.c
@@ -1349,6 +1349,29 @@ mrb_const_get(mrb_state *mrb, mrb_value mod, mrb_sym sym)
   return const_get(mrb, mrb_class_ptr(mod), sym, FALSE);
 }
 
+static struct RClass*
+proc_class(mrb_state *mrb, const struct RProc *proc)
+{
+  struct RClass *c = MRB_PROC_TARGET_CLASS(proc);
+  return c ? c : mrb->object_class;
+}
+
+/* Whether a proc on the `upper` chain is a lexical scope of its own for
+   the constant walk, the way a cref is in CRuby. A class or method body
+   is one. A block is not: it runs in the class scope of the proc it was
+   written in, so its class is the class around it, and it adds nothing.
+   A proc given a class of its own, an eval string under a receiver,
+   is a scope, as its cref is in CRuby. The caller leaves out the proc
+   with no `upper`, the top level: it is not a scope of its own, and
+   its class is reached through the ancestors after the lexical scopes,
+   so that a superclass wins over a top-level constant. */
+static mrb_bool
+lexical_scope_p(mrb_state *mrb, const struct RProc *proc)
+{
+  if (MRB_PROC_SCOPE_P(proc)) return TRUE;
+  return proc_class(mrb, proc) != proc_class(mrb, proc->upper);
+}
+
 mrb_value
 mrb_vm_const_get(mrb_state *mrb, mrb_sym sym)
 {
@@ -1360,9 +1383,9 @@ mrb_vm_const_get(mrb_state *mrb, mrb_sym sym)
   if (iv_get(mrb, class_iv_ptr(c), sym, &v)) {
     return v;
   }
-  for (proc = proc->upper; proc; proc = proc->upper) {
-    c2 = MRB_PROC_TARGET_CLASS(proc);
-    if (!c2) c2 = mrb->object_class;
+  for (proc = proc->upper; proc && proc->upper; proc = proc->upper) {
+    if (!lexical_scope_p(mrb, proc)) continue;
+    c2 = proc_class(mrb, proc);
     if (iv_get(mrb, class_iv_ptr(c2), sym, &v)) {
       return v;
     }
@@ -1397,9 +1420,9 @@ mrb_vm_const_get_noraise(mrb_state *mrb, const struct RProc *proc, mrb_sym sym)
 
   if (!c) c = mrb->object_class;
   if (iv_get(mrb, class_iv_ptr(c), sym, &v)) return v;
-  for (proc = proc->upper; proc; proc = proc->upper) {
-    c2 = MRB_PROC_TARGET_CLASS(proc);
-    if (!c2) c2 = mrb->object_class;
+  for (proc = proc->upper; proc && proc->upper; proc = proc->upper) {
+    if (!lexical_scope_p(mrb, proc)) continue;
+    c2 = proc_class(mrb, proc);
     if (iv_get(mrb, class_iv_ptr(c2), sym, &v)) return v;
   }
   if (c->tt == MRB_TT_SCLASS) {

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1092,3 +1092,68 @@ assert('constant lookup #6506') do
     end
   end
 end
+
+assert('constant lookup: ancestors before the top level') do
+  Test4ConstOrder = :top
+  class Test4ConstOrderBase
+    Test4ConstOrder = :base
+  end
+  module Test4ConstOrderMixin
+    Test4ConstOrder = :mixin
+  end
+  class Test4ConstOrderSub < Test4ConstOrderBase
+    @in_body = Test4ConstOrder
+    @defined = defined?(Test4ConstOrder)
+    def in_method; Test4ConstOrder; end
+    class << self
+      attr_reader :in_body, :defined
+      def in_singleton; Test4ConstOrder; end
+    end
+  end
+  [1].each do
+    class Test4ConstOrderInBlock < Test4ConstOrderBase
+      @in_body = Test4ConstOrder
+      class << self
+        attr_reader :in_body
+      end
+    end
+  end
+  class Test4ConstOrderOwner
+    Test4ConstOrder = :owner
+  end
+  Test4ConstOrderOwner.class_eval do
+    class Test4ConstOrderInEvalBlock < Test4ConstOrderBase
+      @in_body = Test4ConstOrder
+      class << self
+        attr_reader :in_body
+      end
+    end
+  end
+  class Test4ConstOrderIncluder
+    include Test4ConstOrderMixin
+    @in_body = Test4ConstOrder
+    class << self
+      attr_reader :in_body
+    end
+  end
+  class Object
+    class Test4ConstOrderLexical < Test4ConstOrderBase
+      @in_body = Test4ConstOrder
+      class << self
+        attr_reader :in_body
+      end
+    end
+  end
+
+  assert_equal :base, Test4ConstOrderSub.in_body
+  assert_equal :base, Test4ConstOrderSub.new.in_method
+  assert_equal "constant", Test4ConstOrderSub.defined
+  assert_equal :mixin, Test4ConstOrderIncluder.in_body
+  # a block shares the scope around it; a class_eval block does not open one
+  assert_equal :base, Test4ConstOrderInBlock.in_body
+  assert_equal :base, Test4ConstOrderInEvalBlock.in_body
+  # the singleton class's own ancestors reach Object before the attached class
+  assert_equal :top, Test4ConstOrderSub.in_singleton
+  # `class Object` is a lexical scope of its own; only the top level is not
+  assert_equal :top, Test4ConstOrderLexical.in_body
+end


### PR DESCRIPTION
## Summary

A constant named in a subclass body, or in a method defined there, resolved to the top-level constant of that name when the superclass defined one too. The lexical walk reached the top-level scope, whose class is `Object`, before the ancestors were looked at; CRuby leaves the outermost scope out of the walk and reaches `Object` through the ancestors, so the superclass wins.

## Changes

| File                              | What                                                                                                                                    |
| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| `src/variable.c`                  | `lexical_scope_p()` and `proc_class()`; `mrb_vm_const_get()` and `mrb_vm_const_get_noraise()` stop their walk before the outermost proc |
| `test/t/module.rb`                | one assert block: the ancestors before the top level, from a class body, a method, a block, a `class_eval` block, and a singleton class |
| `mrbgems/mruby-eval/test/eval.rb` | one assert block: a string `class_eval` opens a constant scope of its own                                                               |

### The top level is not a scope of its own

`mrb_vm_const_get()` looks in the class of the running proc, then in the class of every proc up the `upper` chain, and only then in the ancestors through `const_get()`. The last proc on the chain is the top-level one, and its class is `Object`, so every constant of `Object` was found there before any ancestor was consulted. CRuby's `vm_get_ev_const()` walks the crefs `while (cref && CREF_NEXT(cref))`, which leaves the outermost one out, and then calls `rb_const_get()` on the innermost class, whose ancestors end at `Object`. The walk now stops before the proc that has no `upper` of its own. `Object` is still reached: `const_get()` with `skip` walks a class's ancestors through `Object`, and for a module it retries there.

An explicit `class Object` body is a scope like any other in CRuby (`X = :top; class Foo; X = :foo; end; class Object; class Bar < Foo; X; end; end` is `:top`), so the proc to leave out is the outermost one, not every proc whose class is `Object`. A test pins that case.

### Which procs on the chain are scopes

Leaving out the last proc alone is not enough, and leaving out every proc without `MRB_PROC_SCOPE` is too much.

A block is a proc of its own on the `upper` chain, but CRuby pushes no cref for a block: it runs in the cref of the code around it. A class body written inside a block, which is the shape of every mrbtest case, still found the top-level constant through the block's proc, whose class is `Object`. A string `class_eval` is the other way round. Its proc carries no `MRB_PROC_SCOPE`, but CRuby does push a cref for it, and `A.class_eval("class B < Foo; X; end")` answers `A::X` before `Foo::X`. Leaving every scopeless proc out lost the receiver's constants for the classes a string defines, and mruby-eval's `class_eval with string` test caught it.

What tells the two apart is the class. A block keeps the class of the proc it was written in, so `MRB_PROC_TARGET_CLASS()` of the block and of its `upper` agree; a string under a receiver is given a class of its own, so they differ. `lexical_scope_p()` counts a proc that carries `MRB_PROC_SCOPE` (a class or method body), and otherwise one whose class differs from its `upper`'s. A `class_eval` block is left out by the same test, since it keeps the class it was written in, which is also what CRuby does: the cref it pushes for a block is marked as pushed by eval and skipped in the lexical walk.

`mrb_vm_const_get_noraise()`, the `defined?` mirror, takes the same walk with the same helper.

## Behaviour

Every row was run against master (`a9151d778`), this PR and CRuby 4.0.6, in one file in this order, with `X = :top` at the top level, `Foo::X = :foo`, `A::X = :a`, `M::X = :m`, and `Bar < Foo`.

| Code                                                                | master       | this PR      | CRuby 4.0.6  |
| ------------------------------------------------------------------- | ------------ | ------------ | ------------ |
| `class Bar < Foo; X; end`                                           | `:top`       | `:foo`       | `:foo`       |
| `class Bar; def m; X; end; end; Bar.new.m`                          | `:top`       | `:foo`       | `:foo`       |
| `class Bar; defined?(X); end`                                       | `"constant"` | `"constant"` | `"constant"` |
| `class Baz; include M; X; end`                                      | `:top`       | `:m`         | `:m`         |
| `class Bar; [1].map { X }; end`                                     | `[:top]`     | `[:foo]`     | `[:foo]`     |
| `class Bar; define_method(:dm) { X }; end; Bar.new.dm`              | `:top`       | `:foo`       | `:foo`       |
| `Bar.class_eval { X }`                                              | `:top`       | `:top`       | `:top`       |
| `Bar.new.instance_eval { X }`                                       | `:top`       | `:top`       | `:top`       |
| `class Bar; class << self; X; end; end`                             | `:top`       | `:top`       | `:top`       |
| `class Bar; class << self; def s; X; end; end; end; Bar.s`          | `:top`       | `:top`       | `:top`       |
| `[1].each { class B9 < Foo; X; end }`                               | `:top`       | `:foo`       | `:foo`       |
| `class A; [1].each { class B10 < Foo; X; end }; end`                | `:a`         | `:a`         | `:a`         |
| `A.class_eval { class B11 < Foo; X; end }`                          | `:top`       | `:foo`       | `:foo`       |
| `A.class_eval("class B12 < Foo; X; end")`                           | `:a`         | `:a`         | `:a`         |
| `A.class_eval("class B13 < Foo; def m; X; end; end"); A::B13.new.m` | `:a`         | `:a`         | `:a`         |
| `class A; eval("class B14 < Foo; X; end"); end`                     | `:a`         | `:a`         | `:a`         |
| `class Bar; eval("X"); end`                                         | `:top`       | `:foo`       | `:foo`       |
| `class Object; class B16 < Foo; X; end; end`                        | `:top`       | `:top`       | `:top`       |
| `class Object; Y = :obj; end; class Bar; Y; end`                    | `:obj`       | `:obj`       | `:obj`       |
| `module M2; X; end`                                                 | `:top`       | `:top`       | `:top`       |

The singleton class rows answer `:top` on all three because the singleton class's own ancestors (`#<Class:Foo>`, `#<Class:Object>`, `#<Class:BasicObject>`, `Class`, `Module`, `Object`) reach `Object` before the walk falls back to the attached class; the fallback is what #6506 added and it is not touched here.

`OP_GETCONST` caches the value per `irep` and symbol (`MRB_CONST_CACHE_SIZE`), so the walk runs on a miss only, and the extra comparison per proc on the chain is not on the cached path.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang`, gcc 13.3.0, empty build directories at the same worktree path, base `a9151d778`.

| Build                | master    | this PR   | delta |
| -------------------- | --------- | --------- | ----- |
| `bintest`            | 1,369,846 | 1,369,782 | -64   |
| `ascii-ctype`        | 1,354,486 | 1,354,422 | -64   |
| `byte-string`        | 1,331,878 | 1,331,814 | -64   |
| `cxx_abi`            | 1,382,361 | 1,382,313 | -48   |
| `no-float`           | 1,294,942 | 1,294,878 | -64   |
| `no-bigint`          | 1,253,334 | 1,253,270 | -64   |
| `full-debug` (`-O0`) | 1,984,390 | 1,984,582 | +192  |

In every build the delta is `variable.o` alone: its `.text` moves by -64 in the `-O3` builds (-48 in `cxx_abi`), where gcc inlines the two helpers into both walks and the loop that stops one proc early comes out shorter, and by +187 in `full-debug`, where the two helpers are emitted as functions at `-O0`.

## Testing

`rake -m test`, green on the default build and on all seven of `build_config/ci/gcc-clang`. Each build's counts were read off its own `bin/mrbtest`, since the parallel run's output cannot be mapped back to a build.

| Build                            | Total | OK   | Skip | KO  | Crash | Warning |
| -------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host (`build_config/default.rb`) | 2674  | 2600 | 74   | 0   | 0     | 0       |
| `bintest`                        | 2922  | 2902 | 20   | 0   | 0     | 0       |
| `ascii-ctype`                    | 2906  | 2884 | 22   | 0   | 0     | 0       |
| `byte-string`                    | 2834  | 2760 | 74   | 0   | 0     | 0       |
| `cxx_abi`                        | 2922  | 2902 | 20   | 0   | 0     | 0       |
| `no-float`                       | 2657  | 2560 | 97   | 0   | 0     | 0       |
| `no-bigint`                      | 2874  | 2841 | 33   | 0   | 0     | 0       |
| `full-debug` (`-O0`)             | 2922  | 2911 | 11   | 0   | 0     | 0       |

The command bintests ran with them: `Total 130`, `OK 129` on the default build, and `Total 147`, `OK 146` over `ci/gcc-clang`.

The assert block in `test/t/module.rb` reads the constant from a subclass body, a method in it, and `defined?`, from a class that includes a module defining it, from a class body written inside a block and inside a `class_eval` block, and from a method in the subclass's singleton class; it also pins that an explicit `class Object` body is a scope of its own. The block in `mrbgems/mruby-eval/test/eval.rb` pins that a string `class_eval` opens a scope, from the body of a class it defines and from a method in it: that is the case that leaving out every scopeless proc breaks, and the existing `class_eval with string` test only reaches it by having no other constant of that name. Every expectation was read off CRuby 4.0.6.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `src/variable.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped, as is the `-E -P` presym scan that precedes each.

```console
# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected constant lookup in `class_eval` when evaluating class definitions from strings.
  * Constants now resolve according to lexical scope rules, ensuring the receiver’s scope takes precedence over inherited scopes where appropriate.
  * Improved constant resolution across nested scopes, methods, singleton methods, blocks, mixins, and `Object` contexts.

* **Tests**
  * Added coverage for constant lookup behavior across supported evaluation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->