### PR TITLE
limitations.md: drop the argument destructuring entry

### DIFF
--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -164,36 +164,6 @@ puts(a.nil? ? "truthy" : "falsy")
 
 Ruby outputs `truthy`. mruby outputs `falsy`.
 
-## Argument Destructuring
-
-```ruby
-def m(a,(b,c),d); p [a,b,c,d]; end
-m(1,[2,3],4)  # => [1,2,3,4]
-```
-
-Destructured arguments (`b` and `c` in above example) cannot be accessed
-from the default expression of optional arguments and keyword arguments,
-since actual assignment is done after the evaluation of those default
-expressions. Thus:
-
-```ruby
-def f(a,(b,c),d=b)
-  p [a,b,c,d]
-end
-f(1,[2,3])
-```
-
-CRuby gives `[1,2,3,nil]`. mruby raises `NoMethodError` for `b`.
-
-Keyword argument expansion has similar restrictions. The following example, gives `[1, 1]` for CRuby, mruby raises `NoMethodError` for `b`.
-
-```ruby
-def g(a: 1, b: a)
-  p [a,b]
-end
-g(a:1)
-```
-
 ## No Double Dispatch in Module Loading
 
 To make implementation simpler, mruby does not use double dispatching in module loading (`include`/`prepend`/`extend`).

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -747,6 +747,30 @@ assert('local variable definition in default value and subsequent arguments') do
   assert_equal([:a, nil, true], m(:a){})
 end
 
+assert('destructured parameter read from a later default expression') do
+  def m(a, (b, c), d) [a, b, c, d] end
+  assert_equal([1, 2, 3, 4], m(1, [2, 3], 4))
+
+  # the names are locals from the start, so a default evaluated before the
+  # destructuring assignment reads nil rather than calling a method
+  def m(a, (b, c), d = b) [a, b, c, d] end
+  assert_equal([1, 2, 3, nil], m(1, [2, 3]))
+  assert_equal([1, 2, 3, 4], m(1, [2, 3], 4))
+
+  def m((a, (b, c)), d = c) [a, b, c, d] end
+  assert_equal([1, 2, 3, nil], m([1, [2, 3]]))
+
+  def m((a, b), c: a) [a, b, c] end
+  assert_equal([1, 2, nil], m([1, 2]))
+  assert_equal([1, 2, 3], m([1, 2], c: 3))
+
+  # a keyword default may read a keyword assigned before it
+  def m(a: 1, b: a) [a, b] end
+  assert_equal([1, 1], m)
+  assert_equal([2, 2], m(a: 2))
+  assert_equal([1, 9], m(b: 9))
+end
+
 assert('multiline comments work correctly') do
 =begin
 this is a comment with nothing after begin and end


### PR DESCRIPTION
## Summary

`doc/limitations.md` still lists "Argument Destructuring" as a difference from CRuby: reading a destructured parameter from the default expression of a later optional or keyword parameter was said to raise `NoMethodError`. Since the parameter destructuring rework that introduced `NODE_MARG` (791f63119), both examples in the entry answer the same as CRuby, so the entry is removed.

## Changes

- `test/t/syntax.rb`: add a test for the four shapes the entry involved, since nothing in the suite asserted `def` parameter destructuring beyond the arity checks in `test/t/proc.rb`: plain destructuring, a default reading a destructured name (nested and not), a keyword default reading a destructured name, and a keyword default reading an earlier keyword.
- Remove the "Argument Destructuring" entry from `doc/limitations.md`. No other entry is touched.

## Behaviour

Both examples from the removed entry, on this branch and on CRuby 4.0.6:

```ruby
def f(a, (b, c), d = b)
  [a, b, c, d]
end
f(1, [2, 3])  # => [1, 2, 3, nil]

def g(a: 1, b: a)
  [a, b]
end
g(a: 1)       # => [1, 1]
```

## Testing

- Ran 33 destructuring cases against CRuby 4.0.6 and mruby (`build_config/default.rb` and `build_config/host-debug.rb`): optional parameters before and after the destructured one, chained defaults, keyword defaults reading destructured names, nested and splatted destructuring, block and lambda parameters, `each` block parameters, `local_variables`, `Method#parameters`, `Method#arity`, and missing, extra, `nil`, and non-array arguments. Every case matched except a `to_ary` object passed to a destructured parameter, which the "No Implicit Type Conversion" entry already documents.
- `MRUBY_CONFIG=build_config/host-debug.rb rake -m test`: OK 2909, KO 0, Crash 0.
- `prettier --check doc/limitations.md` and the prek hooks pass on both commits.

<details>
<summary>Environment</summary>

- Linux x86_64, gcc, mruby at a9151d778
- CRuby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the outdated documentation describing limitations with destructured parameters in optional and keyword argument defaults.

- **Tests**
  - Added coverage for default expressions that reference earlier destructured or keyword parameters.
  - Verified that destructured names are treated as locals during default evaluation and that explicitly provided arguments override defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->