### PR TITLE
mruby-eval: give a string `class_eval` a scope of its own instead of the caller's env

### DIFF
--- a/mrbgems/mruby-eval/mrbgem.rake
+++ b/mrbgems/mruby-eval/mrbgem.rake
@@ -7,4 +7,5 @@ MRuby::Gem::Specification.new('mruby-eval') do |spec|
   add_dependency 'mruby-binding', :core => 'mruby-binding'
   spec.add_test_dependency('mruby-metaprog', :core => 'mruby-metaprog')
   spec.add_test_dependency('mruby-method', :core => 'mruby-method')
+  spec.add_test_dependency('mruby-kernel-ext', :core => 'mruby-kernel-ext')
 end

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -13,6 +13,7 @@
 mrb_bool mrb_binding_p(mrb_state *mrb, mrb_value binding);
 const struct RProc * mrb_binding_extract_proc(mrb_state *mrb, mrb_value binding);
 struct REnv * mrb_binding_extract_env(mrb_state *mrb, mrb_value binding);
+mrb_value mrb_binding_new(mrb_state *mrb, const struct RProc *proc, mrb_value recv, struct REnv *env);
 
 static struct RProc*
 create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value binding, const char *file, mrb_int line)
@@ -333,7 +334,21 @@ object_eval(mrb_state *mrb, mrb_value self, mrb_bool class_eval)
   mrb_get_args(mrb, "s|zi", &s, &len, &file, &line);
 
   struct RClass *c = class_eval ? mrb_class_ptr(self) : mrb_singleton_class_ptr(mrb, self);
-  struct RProc *proc = create_proc_from_string(mrb, s, len, mrb_nil_value(), file, line);
+  /* The string runs in its own scope with `c` as its cref, so the caller's
+     locals are reached through a binding of the caller's frame, the way
+     Kernel#eval with an explicit binding does. Sharing the caller's env
+     directly would put `c` into that env and move every later `def` in
+     the caller's frame onto `c`. */
+  struct REnv *env;
+  const struct RProc *caller = mrb_proc_get_caller(mrb, &env);
+  mrb_value binding = mrb_nil_value();
+  if (env) {
+    binding = mrb_binding_new(mrb, caller, self, env);
+    /* The binding's own env starts with no method name; keep the caller's
+       so `__method__` and `super` inside the string see the caller. */
+    mrb_binding_extract_env(mrb, binding)->mid = env->mid;
+  }
+  struct RProc *proc = create_proc_from_string(mrb, s, len, binding, file, line);
   MRB_PROC_SET_TARGET_CLASS(proc, c);
   mrb_assert(!MRB_PROC_CFUNC_P(proc));
   mrb_vm_ci_target_class_set(mrb->c->ci, c);

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -268,3 +268,52 @@ assert('eval in a scope whose locals are named after a presym literal') do
   }
   assert_equal ['caught', 6, 1], results
 end
+
+assert('a string class_eval leaves the caller\'s scope on its own class') do
+  # The string runs with the receiver as its cref. That cref used to be
+  # written into the env the string shared with the caller's frame, so the
+  # caller's later `def` landed on the receiver and a block made afterwards
+  # started its constant lookup there.
+  c = Class.new
+  c.const_set(:EVAL_CREF_PROBE, :receiver)
+  Object.const_set(:EVAL_CREF_PROBE, :caller) unless Object.const_defined?(:EVAL_CREF_PROBE, false)
+  c.class_eval("def from_string; end")
+  def eval_cref_probe_def; end
+  assert_false c.private_instance_methods(false).include?(:eval_cref_probe_def)
+  assert_true Object.private_instance_methods(false).include?(:eval_cref_probe_def)
+  assert_equal :caller, proc { EVAL_CREF_PROBE }.call
+  assert_true c.method_defined?(:from_string)
+end
+
+assert('a string instance_eval leaves the caller\'s scope on its own class') do
+  o = Object.new
+  o.instance_eval("def from_string; end")
+  Object.instance_eval("1")
+  def eval_cref_probe_def2; end
+  assert_false o.singleton_methods(false).include?(:eval_cref_probe_def2)
+  assert_false Object.singleton_methods(false).include?(:eval_cref_probe_def2)
+  assert_true Object.private_instance_methods(false).include?(:eval_cref_probe_def2)
+  assert_true o.singleton_methods(false).include?(:from_string)
+end
+
+assert('a string class_eval still runs inside the caller\'s scope') do
+  # The string now reaches the caller's frame through a binding of it, so
+  # what a binding carries is what the string keeps: the locals for reading
+  # and writing from any depth, the receiver's constants as its cref, and
+  # the caller's method name.
+  c = Class.new
+  c.const_set(:EVAL_LOCAL_PROBE, :receiver)
+  x = 1
+  assert_equal 2, c.class_eval("x + 1")
+  assert_equal :receiver, c.class_eval("x = 2; EVAL_LOCAL_PROBE")
+  assert_equal 2, x
+  [1].each { c.class_eval("x = 3") }
+  assert_equal 3, x
+  assert_equal :receiver, c.class_eval("proc { EVAL_LOCAL_PROBE }").call
+  k = Class.new { def probe(c); c.class_eval("__method__"); end }
+  assert_equal :probe, k.new.probe(c)
+  # A C function as the caller has no frame to bind; the string still
+  # defines on the receiver.
+  c.method(:class_eval).call("def from_c_caller; end")
+  assert_true c.method_defined?(:from_c_caller)
+end


### PR DESCRIPTION
## Summary

A string handed to `class_eval` or `instance_eval` was compiled to share the caller's `REnv`, and the receiver was then written into that env as the cref, so every `def` the caller ran afterwards landed on the receiver and every block it created afterwards looked constants up there first. The string now runs against a binding of the caller's frame, which gives it an env of its own to carry the cref.

## Changes

| File                              | What                                                                                                                |
| --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-eval/src/eval.c`   | `object_eval()` compiles the string against `mrb_binding_new()` of the caller's frame and copies the caller's `mid` |
| `mrbgems/mruby-eval/test/eval.rb` | three tests: the caller's scope after a string `class_eval` / `instance_eval`, and what the string still reaches    |
| `mrbgems/mruby-eval/mrbgem.rake`  | mruby-kernel-ext as a test dependency, for `__method__`                                                             |

### The string wrote its cref into the caller's env

`create_proc_from_string()` gives the compiled string the caller's env, creating one on the caller's callinfo when the frame has none yet, so the string can read and assign the caller's locals as level 0 upvalues. `object_eval()` then called `MRB_PROC_SET_TARGET_CLASS(proc, c)`. For a proc with `MRB_PROC_ENVSET` that macro writes `e.env->c`, which was the caller's env: the caller's `OP_TCLASS` read the receiver from it, and `closure_setup()` handed the same env to every block the caller made afterwards. `mrb_define_method_raw()` already refuses this write for a proc that carries an env (`src/class.c`), so `define_method` with a block keeps the block's lexical cref; the string path was the one place that wrote through.

### A binding of the caller's frame

`Kernel#eval` with an explicit binding already has the shape the string needs: `mrb_binding_new()` wraps the caller's proc in an lvspace proc and gives the binding a fresh env, and a string compiled against it gets the fresh env as its own with the caller's env one level up. `object_eval()` now takes the caller's frame with `mrb_proc_get_caller()`, makes a binding of it, and passes that binding to `create_proc_from_string()` instead of nil. The existing `MRB_PROC_SET_TARGET_CLASS()` write lands in the binding's env, nothing the caller holds changes, and the caller's locals are still read and written through the upvalue chain. When the caller is a C function there is no frame to bind and the nil path stays as it was.

The binding's env starts with `mid = 0`, and `__method__` inside the string fell through to the frame's `:class_eval`; the caller's `mid` is copied into it so the string answers the enclosing method's name, as before.

## Behaviour

```ruby
class Foo; end
Foo.class_eval("def bar; end")
def baz; end
Foo.private_instance_methods(false)      # master: [:baz]   this PR: []
Object.private_instance_methods(false)   # master: []       this PR: [:baz]

X = :top
class Bar; X = :bar; end
Bar.class_eval("1")
proc { X }.call                          # master: :bar     this PR: :top

o = Object.new
o.instance_eval("1")
def qux; end
o.singleton_methods(false)               # master: [:qux]   this PR: []
```

CRuby answers as this PR does. What the string reaches is unchanged: `Foo.class_eval("X")` resolves `Foo::X`, `Foo.class_eval("x = 2")` assigns the caller's `x`, a proc returned from the string still sees `Foo::X`, and a `def` inside the string still lands on the receiver.

## Speed

A string `class_eval` now allocates a `Binding`, its lvspace proc with a one-instruction irep, and an env, on top of the compile it already did. Instructions per call, measured with callgrind as `(Ir(2N) - Ir(N)) / N` at N = 100,000 on the `bintest` build; `Kernel#eval` and the block form do not take the new path and are the controls:

| Case                             | base Ir | this PR Ir |  delta |       |
| -------------------------------- | ------: | ---------: | -----: | ----: |
| `eval("1")` (control)            |  42,759 |     42,759 |     +0 | +0.0% |
| `Foo.class_eval { 1 }` (control) |   1,719 |      1,728 |     +9 | +0.5% |
| `Foo.class_eval("1")`            |  42,919 |     46,627 | +3,708 | +8.6% |
| `o.instance_eval("1")`           |  43,945 |     47,857 | +3,912 | +8.9% |
| `Foo.class_eval("def bar; end")` |  60,921 |     65,726 | +4,805 | +7.9% |

The string forms pay about 3,700 more instructions per call, the `Binding` object, its lvspace proc and one-instruction irep, and the env, on top of the 43,000 the compile already costs; `Kernel#eval` is bit for bit the same, and the block form pays the 9 instructions of a call into `object_eval()`, which gcc no longer inlines into `f_class_eval()` (see Size).

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, base `a9151d778`:

| Build            |      base |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,369,846 | 1,369,686 |  -160 |
| ascii-ctype      | 1,354,486 | 1,354,326 |  -160 |
| byte-string      | 1,331,878 | 1,331,718 |  -160 |
| cxx_abi          | 1,382,361 | 1,382,505 |  +144 |
| no-float         | 1,294,942 | 1,294,782 |  -160 |
| no-bigint        | 1,253,334 | 1,253,174 |  -160 |
| full-debug (-O0) | 1,984,390 | 1,984,486 |   +96 |

The change is all in `eval.o`: its `.text` goes from 3,045 to 2,885 on `bintest` (-160, and the same on the other four gcc C builds), 3,093 to 3,237 on `cxx_abi` (+144) and 4,295 to 4,384 on `full-debug` (+89). On the C builds gcc had inlined `object_eval()` into both `f_class_eval()` (329 bytes) and `f_instance_eval()` (347 bytes); with the binding call it stops, and one outlined `object_eval()` (492 bytes) plus two 11 and 14 byte callers is 159 bytes less (`nm -S` on `eval.o`). Where the inlining does not flip, the added call shows as the growth.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,675 | 2,601 |   74 |   0 |     0 |       0 |
| bintest                          | 2,923 | 2,903 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 2,907 | 2,885 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,835 | 2,761 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 2,923 | 2,903 |   20 |   0 |     0 |       0 |
| no-float                         | 2,658 | 2,561 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,875 | 2,842 |   33 |   0 |     0 |       0 |
| full-debug                       | 2,923 | 2,912 |   11 |   0 |     0 |       0 |

bintest passes on every build. The new tests check that a top-level `def` after a string `class_eval` lands on `Object` and a block made afterwards resolves constants from `Object`, the same for a string `instance_eval` on an object and on `Object` itself, and that the string still reads the caller's locals, writes them from one and two scopes down, resolves the receiver's constants (directly and from a proc it returns), answers the enclosing method's `__method__`, and defines on the receiver when the caller is a C function.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item      | Value                                                  |
| --------- | ------------------------------------------------------ |
| OS        | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU       | AMD Ryzen 9 5950X                                      |
| C         | gcc 13.3.0 (`CC=gcc`)                                  |
| C++       | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils  | GNU ld 2.47                                            |
| callgrind | valgrind 3.27.1                                        |
| CRuby     | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-eval/src/eval.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-eval/src/eval.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRB_NO_FLOAT -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/giggly-wishing-pretzel=." -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected string-based `class_eval` and `instance_eval` so definitions and constant lookups remain in the caller’s scope.
  * Preserved caller context for local variables, `__method__`, and `super` during evaluation.
  * Ensured evaluation from native code continues to define methods on the intended receiver.

* **Tests**
  * Added coverage for caller-scope behavior across class and instance evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->