### PR TITLE
mruby-sprintf: read the width of mrb_int off an Array index, not off identity

### DIFF
--- a/mrbgems/mruby-sprintf/test/sprintf.rb
+++ b/mrbgems/mruby-sprintf/test/sprintf.rb
@@ -228,14 +228,17 @@ assert('sprintf - a width near mrb_int is refused, not wrapped') do
   # what a String can hold and has to be refused; where mrb_int is wider it is
   # an ordinary request and the answer is a 2GB string, which is not something
   # to allocate in a test.  Asking sprintf which build this is would build that
-  # string to find out, so the width is read off an integer instead: 2**31 is
-  # an object of its own where mrb_int stops below it, and where the build has
-  # no wider integer at all it cannot be reached.  Spelling it as a literal
-  # would take the whole file down on the builds this guards, so it is raised.
+  # string to find out, so the width is read off an integer instead: an Array
+  # index has to be an mrb_int, so `[][2**31]` is nil where mrb_int holds the
+  # width, and RangeError where the value is a big integer or, with no wider
+  # integer in the build, cannot be made at all.  Identity is not the question:
+  # under NaN boxing a 64-bit mrb_int past 32 bits is a heap object of its own,
+  # and two of them are never `equal?`.  Spelling the value as a literal would
+  # take the whole file down on the builds this guards, so it is computed.
   narrow =
     begin
-      n = 2 ** 31
-      !n.equal?(2 ** 31)
+      [][2 ** 31]
+      false
     rescue RangeError
       true
     end


### PR DESCRIPTION
## Summary

The width guard in the mruby-sprintf test file reads "mrb_int stops below 2147483647" off object identity, and under NaN boxing with `MRB_INT64` every integer past 32 bits is a heap object of its own, so `boxing-nan-m64-i64` ran the assertions meant for a 32-bit mrb_int and failed all five. The guard now reads the width off an Array index, the probe the `%c` test in the same file already uses.

## Changes

| File                                    | What                                                                                                                  |
| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-sprintf/test/sprintf.rb` | the `narrow` probe of `sprintf - a width near mrb_int is refused, not wrapped` asks `[][2 ** 31]` instead of `equal?` |

No source file changes.

### Identity is the wrong question

be129e390 replaced the `%c` call that used to probe the build (it built the 2GB string on every wide build before skipping) with `!(2 ** 31).equal?(2 ** 31)`: where mrb_int stops below 2**31 the value is a big integer, an object of its own, and where there is no big integer at all the arithmetic raises `RangeError`. Both read as narrow. Where mrb_int holds the value the two are the same immediate, so they are `equal?`, and the build skips.

That last step does not hold under NaN boxing with `MRB_INT64`. The immediate there is 32 bits wide; `mrb_boxing_int_value()` gives anything that does not fit a fresh `RInteger` from `mrb_obj_alloc()`, and `mrb_obj_eq()` compares the two words, which are two pointers. So `(2 ** 31).equal?(2 ** 31)` is false on that build even though mrb_int is 64 bits wide:

```ruby
# boxing-nan-m64-i64
(2 ** 30).equal?(2 ** 30)  #=> true
(2 ** 31).equal?(2 ** 31)  #=> false
```

The guard read the build as narrow, the five assertions ran, and sprintf answered each with the 2GB string it is entitled to give a 64-bit width instead of the `ArgumentError` a 32-bit width earns:

```
Fail: sprintf - a width near mrb_int is refused, not wrapped (mrbgems: mruby-sprintf)
 - Assertion[1]
    ArgumentError expected but nothing was raised.
 (and the same for [2] to [5])
```

### What the guard needs to know

The question is whether the value is an mrb_int, and an Array index answers it without formatting anything: `Array#[]` takes an mrb_int, so `[][2 ** 31]` is `nil` where mrb_int holds 2**31 (a heap `RInteger` is still an mrb_int, so NaN boxing answers `nil` too), and `RangeError` where the value is a big integer or, with no big integer in the build, cannot be made at all. The `%c` test earlier in the file already probes the build this way, with `[][wrapping]`. The comment above the probe now says why identity is not asked.

## Testing

`rake -m test`, green on the default build and on all seven of `build_config/ci/gcc-clang`. Each build's counts were read off its own `bin/mrbtest`, since the parallel run's output cannot be mapped back to a build.

| Build                            | Total | OK   | Skip | KO  | Crash | Warning |
| -------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host (`build_config/default.rb`) | 2672  | 2598 | 74   | 0   | 0     | 0       |
| `bintest`                        | 2920  | 2900 | 20   | 0   | 0     | 0       |
| `ascii-ctype`                    | 2904  | 2882 | 22   | 0   | 0     | 0       |
| `byte-string`                    | 2832  | 2758 | 74   | 0   | 0     | 0       |
| `cxx_abi`                        | 2920  | 2900 | 20   | 0   | 0     | 0       |
| `no-float`                       | 2655  | 2558 | 97   | 0   | 0     | 0       |
| `no-bigint`                      | 2872  | 2839 | 33   | 0   | 0     | 0       |
| `full-debug` (`-O0`)             | 2920  | 2909 | 11   | 0   | 0     | 0       |

The command bintests ran with them: `Total 130`, `OK 129` on the default build, and `Total 147`, `OK 146` over `ci/gcc-clang`.

None of those eight builds is the one that failed, since every one of them boxes words. The change was verified on the builds it is about: the four `-m64` targets of `build_config/boxing.rb`, declared in a copy of that file without the `-m32` pair (this host has no 32-bit multilib), plus the NaN 64-bit and word 32-bit targets with `mruby-bigint` deleted from the gembox. Every one is `enable_debug` (`-O0`) under the `full-core` gembox, as `boxing.rb` declares.

| Build                            | mrb_int | Total | OK   | Skip | KO  | Crash | Warning | width test |
| -------------------------------- | ------- | ----- | ---- | ---- | --- | ----- | ------- | ---------- |
| `boxing-nan-m64-i64`             | 64-bit  | 2920  | 2908 | 12   | 0   | 0     | 0       | skips      |
| `boxing-word-m64-i64`            | 64-bit  | 2920  | 2908 | 12   | 0   | 0     | 0       | skips      |
| `boxing-nan-m64-i64`, no bigint  | 64-bit  | 2872  | 2847 | 25   | 0   | 0     | 0       | skips      |
| `boxing-nan-m64-i32`             | 32-bit  | 2920  | 2908 | 12   | 0   | 0     | 0       | runs, OK   |
| `boxing-word-m64-i32`            | 32-bit  | 2920  | 2908 | 12   | 0   | 0     | 0       | runs, OK   |
| `boxing-word-m64-i32`, no bigint | 32-bit  | 2869  | 2837 | 32   | 0   | 0     | 0       | runs, OK   |

On master `boxing-nan-m64-i64` is `KO 1` with the five failed assertions quoted above; the other five builds answer the same on master and here.

The test still catches what it was written for. With the `CHECK()` hunk of 9f82c532c reverted, so that `blen+(l)` wraps again, the same six binaries were rebuilt and run: the three wide builds skip the test as before, and the three narrow ones die in it, with `mrbtest -v` stopping at

```
sprintf - a width near mrb_int is refused, not wrapped :
```

followed by a segmentation fault.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

No C file changes here; the test file is compiled to bytecode by each build's own `mrbc` and linked into `bin/mrbtest`. The compile line for `src/string.c` in each build, as `rake --verbose` printed it after touching the file, says what each build is. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed. The six boxing builds differ from one another only in the two defines after `-O0`, and the no-bigint pair drops `-DMRB_USE_BIGINT`.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# boxing-nan-m64-i64 (boxing-nan-m64-i32 says -DMRB_INT32; the word pair says -DMRB_WORD_BOXING)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NAN_BOXING -DMRB_INT64 -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# boxing-nan-m64-i64, no bigint (boxing-word-m64-i32, no bigint says -DMRB_WORD_BOXING -DMRB_INT32)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_NAN_BOXING -DMRB_INT64 -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for formatted output widths near the integer limit.
  - Updated platform-specific checks to reliably distinguish supported integer sizes, including NaN-boxed environments.
  - Preserved validation that oversized widths raise an `ArgumentError`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->