### PR TITLE
mruby-os-memsize: fix two crashes and count what the GC would free

### DIFF
--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -38,6 +38,16 @@ os_memsize_of_irep(mrb_state* state, const struct mrb_irep *irep)
   return size;
 }
 
+/* Heap behind the code a proc runs. A C function has none, and neither
+ * does an alias, whose body holds the aliased method's id, not an irep. */
+static size_t
+os_memsize_of_proc_body(mrb_state* mrb, const struct RProc *proc)
+{
+  if (MRB_PROC_CFUNC_P(proc) || MRB_PROC_ALIAS_P(proc) || !proc->body.irep)
+    return 0;
+  return os_memsize_of_irep(mrb, proc->body.irep);
+}
+
 static size_t
 os_memsize_of_method(mrb_state* mrb, mrb_value method_obj)
 {
@@ -46,9 +56,7 @@ os_memsize_of_method(mrb_state* mrb, mrb_value method_obj)
   if (mrb_nil_p(proc_value)) return 0;
   struct RProc *proc = mrb_proc_ptr(proc_value);
 
-  size_t size = sizeof(struct RProc);
-  if (!MRB_PROC_CFUNC_P(proc)) size += os_memsize_of_irep(mrb, proc->body.irep);
-  return size;
+  return sizeof(struct RProc) + os_memsize_of_proc_body(mrb, proc);
 }
 
 static mrb_bool
@@ -118,8 +126,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
         size += MRB_ENV_LEN(env) * sizeof(mrb_value);
         if (MRB_ENV_SVAR_P(env)) size += sizeof(mrb_value);
       }
-      if (!MRB_PROC_CFUNC_P(proc))
-        size += os_memsize_of_irep(mrb, proc->body.irep);
+      size += os_memsize_of_proc_body(mrb, proc);
       break;
     }
     case MRB_TT_RANGE:

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -197,7 +197,8 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       size += mrb_objspace_page_slot_size();
       break;
     case MRB_TT_BACKTRACE:
-      size +=((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
+      size += mrb_objspace_page_slot_size();
+      size += ((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
       break;
     case MRB_TT_SVAR:
       size += mrb_objspace_page_slot_size();

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -78,13 +78,19 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
   size_t size = 0;
 
   switch(mrb_type(obj)) {
-    case MRB_TT_STRING:
+    case MRB_TT_STRING: {
+      struct RString *s = RSTRING(obj);
       size += mrb_objspace_page_slot_size();
-      if (!RSTR_EMBED_P(RSTRING(obj)) && !RSTR_SHARED_P(RSTRING(obj))) {
-        size += RSTRING_CAPA(obj);
+      /* the buffer is the string's own only when the GC would free it:
+       * not embedded, not a refcounted shared buffer, not borrowed from a
+       * frozen string (FSHARED), and not static storage (NOFREE) */
+      if (!RSTR_EMBED_P(s) && !RSTR_SHARED_P(s) &&
+          !RSTR_FSHARED_P(s) && !RSTR_NOFREE_P(s)) {
+        size += RSTR_CAPA(s);
         size++; /* NUL terminator */
       }
       break;
+    }
     case MRB_TT_CLASS:
     case MRB_TT_MODULE:
     case MRB_TT_SCLASS:
@@ -191,7 +197,7 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       size += mrb_objspace_page_slot_size();
       break;
     case MRB_TT_BACKTRACE:
-      size += ((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
+      size +=((struct RBacktrace*)mrb_obj_ptr(obj))->len * sizeof(struct mrb_backtrace_location);
       break;
     case MRB_TT_SVAR:
       size += mrb_objspace_page_slot_size();

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -130,13 +130,18 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       break;
     case MRB_TT_FIBER: {
       struct RFiber* f = (struct RFiber*)mrb_ptr(obj);
-      ptrdiff_t stack_size = f->cxt->stend - f->cxt->stbase;
-      ptrdiff_t ci_size = f->cxt->ciend - f->cxt->cibase;
+      const struct mrb_context *c = f->cxt;
 
-      size += mrb_objspace_page_slot_size() +
-        sizeof(struct mrb_context) +
-        sizeof(mrb_value) * stack_size +
-        sizeof(mrb_callinfo) * ci_size;
+      size += mrb_objspace_page_slot_size();
+      /* Fiber.allocate leaves cxt NULL until initialize runs */
+      if (c) {
+        ptrdiff_t stack_size = c->stend - c->stbase;
+        ptrdiff_t ci_size = c->ciend - c->cibase;
+
+        size += sizeof(struct mrb_context) +
+          sizeof(mrb_value) * stack_size +
+          sizeof(mrb_callinfo) * ci_size;
+      }
       break;
     }
 #ifndef MRB_NO_FLOAT

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -108,12 +108,14 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
     }
     case MRB_TT_STRUCT:
     case MRB_TT_ARRAY: {
-      mrb_int len = RARRAY_LEN(obj);
-      /* Arrays that do not fit within an RArray perform a heap allocation
-      *  storing an array of pointers to the original objects*/
+      struct RArray *a = mrb_ary_ptr(obj);
       size += mrb_objspace_page_slot_size();
-      if (len > MRB_ARY_EMBED_LEN_MAX)
-        size += sizeof(mrb_value*) * len;
+      /* An array that does not fit within the RArray keeps its elements in
+       * a heap buffer sized by its capacity. A shared buffer belongs to a
+       * refcounted mrb_shared_array, as a shared string's does, and is
+       * charged to none of its owners. */
+      if (!ARY_EMBED_P(a) && !ARY_SHARED_P(a))
+        size += sizeof(mrb_value) * ARY_CAPA(a);
       break;
     }
     case MRB_TT_PROC: {

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -11,30 +11,76 @@
 #include <mruby/proc.h>
 #include <mruby/value.h>
 #include <mruby/range.h>
+#include <mruby/debug.h>
 #include <mruby/internal.h>
 
+/* Heap behind an irep's debug info, as mrb_debug_info_free() releases
+ * it: the info, its file table, and one line table per file. */
+static size_t
+os_memsize_of_debug_info(const mrb_irep_debug_info *d)
+{
+  size_t size = sizeof(*d);
+
+  if (!d->files) return size;
+  size += d->flen * sizeof(*d->files);
+  for (uint32_t i = 0; i < d->flen; i++) {
+    const mrb_irep_debug_info_file *f = d->files[i];
+    if (!f) continue;
+    size += sizeof(*f);
+    switch (f->line_type) {
+      case mrb_debug_line_ary:
+        size += f->line_entry_count * sizeof(uint16_t);
+        break;
+      case mrb_debug_line_flat_map:
+        size += f->line_entry_count * sizeof(mrb_irep_debug_info_line);
+        break;
+      case mrb_debug_line_packed_map:
+        size += f->line_entry_count;
+        break;
+    }
+  }
+  return size;
+}
+
+/* Heap behind an irep, the struct included, following what
+ * mrb_irep_free() releases. An irep loaded from a binary keeps its pool,
+ * syms and reps in one block with the struct; the same bytes are counted
+ * here, only the padding between them is not. */
 static size_t
 os_memsize_of_irep(mrb_state* state, const struct mrb_irep *irep)
 {
-  size_t size = (irep->slen * sizeof(mrb_sym)) +
+  /* a static irep and everything it points to live in read-only data */
+  if (irep->flags & MRB_IREP_NO_FREE) return 0;
+
+  size_t size = sizeof(struct mrb_irep) +
+                (irep->slen * sizeof(mrb_sym)) +
                 (irep->plen * sizeof(mrb_irep_pool)) +
-                (irep->ilen * sizeof(mrb_code)) +
                 (irep->rlen * sizeof(struct mrb_irep*));
+
+  /* the catch handler table sits in the same block, after the iseq */
+  if (!(irep->flags & MRB_ISEQ_NO_FREE)) {
+    size += (irep->ilen * sizeof(mrb_code)) +
+            (irep->clen * sizeof(struct mrb_irep_catch_handler));
+  }
 
   for (int i = 0; i < irep->plen; i++) {
     const mrb_irep_pool *p = &irep->pool[i];
-    if ((p->tt & IREP_TT_NFLAG) == 0) { /* string pool value */
-      size += (p->tt>>2);
+    if ((p->tt & (IREP_TT_NFLAG|IREP_TT_SFLAG)) == IREP_TT_STR) {
+      size += (p->tt>>2) + 1; /* copied with its NUL; a static one is not */
     }
-    else if (p->tt == IREP_TT_BIGINT) { /* bigint pool value */
-      size += p->u.str[0];
+    else if (p->tt == IREP_TT_BIGINT) {
+      size += (uint8_t)p->u.str[0] + 2; /* length byte, sign byte, digits */
     }
   }
 
+  /* local variable names, one per local past self */
+  if (irep->lv) size += (irep->nlocals - 1) * sizeof(mrb_sym);
+
   for (int i = 0; i < irep->rlen; i++) {
-    size += sizeof(struct mrb_irep); /* size of irep structure */
-    size += os_memsize_of_irep(state, irep->reps[i]);
+    if (irep->reps[i]) size += os_memsize_of_irep(state, irep->reps[i]);
   }
+
+  if (irep->debug_info) size += os_memsize_of_debug_info(irep->debug_info);
   return size;
 }
 

--- a/mrbgems/mruby-os-memsize/src/memsize.c
+++ b/mrbgems/mruby-os-memsize/src/memsize.c
@@ -151,12 +151,12 @@ os_memsize_of_object(mrb_state* mrb, mrb_value obj)
       }
       break;
     }
-#ifndef MRB_NO_FLOAT
-    case MRB_TT_FLOAT:
-#endif
+    case MRB_TT_FLOAT: /* the type exists without a Float, only no value has it */
     case MRB_TT_INTEGER:
-      if (mrb_immediate_p(obj))
-        break;
+      /* boxed as RFloat/RInteger when the value does not fit the word */
+      if (!mrb_immediate_p(obj))
+        size += mrb_objspace_page_slot_size();
+      break;
     case MRB_TT_RATIONAL:
 #if defined(MRB_USE_RATIONAL)
 #if defined(MRB_INT64) && defined(MRB_32BIT)

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -30,10 +30,17 @@ assert 'ObjectSpace.memsize_of' do
       a = 0
       a + 1
     end
+    alias bar foo
   end
 
   m_size = ObjectSpace.memsize_of class_with_methods.instance_method(:foo)
   assert_not_equal m_size, 0, 'method size not zero'
+
+  # an alias proc carries a method id where an irep would be; must not crash
+  alias_size = ObjectSpace.memsize_of class_with_methods.instance_method(:bar)
+  assert_not_equal alias_size, 0, 'alias size not zero'
+  assert_operator alias_size, :<, m_size, 'alias carries no code of its own'
+  assert_operator ObjectSpace.memsize_of_all, :>=, alias_size, 'memsize_of_all walks past the alias'
 
   # collections
   empty_array_size = ObjectSpace.memsize_of []

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -44,6 +44,13 @@ assert 'ObjectSpace.memsize_of' do
   empty_fiber_size = ObjectSpace.memsize_of(Fiber.new {})
   assert_not_equal empty_fiber_size, 0, 'empty fiber not zero'
 
+  # Fiber.allocate has no context yet; must not crash
+  bare_fiber = Fiber.allocate
+  bare_fiber_size = ObjectSpace.memsize_of(bare_fiber)
+  assert_not_equal bare_fiber_size, 0, 'uninitialized fiber not zero'
+  assert_operator bare_fiber_size, :<, empty_fiber_size, 'uninitialized fiber smaller than initialized'
+  assert_operator ObjectSpace.memsize_of_all, :>=, bare_fiber_size, 'memsize_of_all walks past the uninitialized fiber'
+
   #hash
   assert_not_equal ObjectSpace.memsize_of({}), 0, 'empty hash size not zero'
 end

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -1,4 +1,6 @@
 assert 'ObjectSpace.memsize_of' do
+  slot = ObjectSpace.__memsize_slot
+
   # immediate literals
   int_size = ObjectSpace.memsize_of 1
   assert_equal int_size, 0, 'int zero'
@@ -8,6 +10,12 @@ assert 'ObjectSpace.memsize_of' do
 
   assert_equal ObjectSpace.memsize_of(true), int_size
   assert_equal ObjectSpace.memsize_of(false), int_size
+
+  # a number the boxing puts on the heap is its object slot; an immediate
+  # one is nothing, and which is which is the boxing's call
+  ObjectSpace.__memsize_heap_number.each do |value, immediate|
+    assert_equal immediate ? 0 : slot, ObjectSpace.memsize_of(value), "#{value.class} beyond the boxed word"
+  end
 
   assert_not_equal ObjectSpace.memsize_of('a'), 0, 'memsize of str'
 

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -81,6 +81,10 @@ assert 'ObjectSpace.memsize_of' do
   assert_operator bare_fiber_size, :<, empty_fiber_size, 'uninitialized fiber smaller than initialized'
   assert_operator ObjectSpace.memsize_of_all, :>=, bare_fiber_size, 'memsize_of_all walks past the uninitialized fiber'
 
+  # backtrace: the slot and one location per frame
+  backtrace, frames, location = ObjectSpace.__memsize_backtrace
+  assert_equal slot + frames * location, ObjectSpace.memsize_of(backtrace), 'a backtrace is its slot and its locations'
+
   #hash
   assert_not_equal ObjectSpace.memsize_of({}), 0, 'empty hash size not zero'
 end

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -18,6 +18,7 @@ assert 'ObjectSpace.memsize_of' do
   end
 
   assert_not_equal ObjectSpace.memsize_of('a'), 0, 'memsize of str'
+  assert_equal slot, ObjectSpace.memsize_of(ObjectSpace.__memsize_nofree_string), 'static storage is not the string\'s to free'
 
   if __ENCODING__ == "UTF-8"
     assert_not_equal ObjectSpace.memsize_of("こんにちは世界"), 0, 'memsize of utf8 str'

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -54,6 +54,20 @@ assert 'ObjectSpace.memsize_of' do
   empty_array_size = ObjectSpace.memsize_of []
   assert_not_equal empty_array_size, 0, 'empty array size not zero'
   assert_operator empty_array_size, :<, ObjectSpace.memsize_of(Array.new(16)), 'large array size greater than embed'
+  assert_equal slot + 16 * ObjectSpace.__memsize_value_width, ObjectSpace.memsize_of(Array.new(16)), 'a heap buffer holds one mrb_value per slot of capacity'
+
+  # the buffer is sized by capacity; pop keeps it, so a push back into it costs nothing
+  grown = Array.new(16)
+  grown.pop
+  grown_size = ObjectSpace.memsize_of(grown)
+  grown << nil
+  assert_equal grown_size, ObjectSpace.memsize_of(grown), 'growing within capacity costs nothing'
+
+  # a dup of a long enough array shares one buffer, charged to neither owner
+  shared = Array.new(32)
+  shared_dup = shared.dup
+  assert_equal ObjectSpace.memsize_of(shared), ObjectSpace.memsize_of(shared_dup), 'shared arrays weigh the same'
+  assert_operator ObjectSpace.memsize_of(shared), :<, ObjectSpace.memsize_of(Array.new(32)), 'shared buffer not charged'
 
   # fiber
   empty_fiber_size = ObjectSpace.memsize_of(Fiber.new {})

--- a/mrbgems/mruby-os-memsize/test/memsize.rb
+++ b/mrbgems/mruby-os-memsize/test/memsize.rb
@@ -51,6 +51,11 @@ assert 'ObjectSpace.memsize_of' do
   assert_operator alias_size, :<, m_size, 'alias carries no code of its own'
   assert_operator ObjectSpace.memsize_of_all, :>=, alias_size, 'memsize_of_all walks past the alias'
 
+  # ireps built by hand, each with the heap mrb_irep_free() would release
+  ObjectSpace.__memsize_ireps.each do |name, proc, owned|
+    assert_equal slot + owned, ObjectSpace.memsize_of(proc), "irep: #{name}"
+  end
+
   # collections
   empty_array_size = ObjectSpace.memsize_of []
   assert_not_equal empty_array_size, 0, 'empty array size not zero'

--- a/mrbgems/mruby-os-memsize/test/memsize_test.c
+++ b/mrbgems/mruby-os-memsize/test/memsize_test.c
@@ -1,0 +1,35 @@
+#include <string.h>
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/error.h>
+#include <mruby/gc.h>
+#include <mruby/irep.h>
+#include <mruby/proc.h>
+#include <mruby/string.h>
+#include <mruby/value.h>
+#include <mruby/debug.h>
+#include <mruby/internal.h>
+
+/* What the tests of ObjectSpace.memsize_of ask about but cannot reach from
+ * Ruby: the size of an object slot and of an mrb_value, and objects that only
+ * C builds. Each helper answers in bytes or hands out the object itself. */
+
+static mrb_value
+memsize_slot(mrb_state *mrb, mrb_value self)
+{
+  return mrb_int_value(mrb, (mrb_int)mrb_objspace_page_slot_size());
+}
+
+static mrb_value
+memsize_value_width(mrb_state *mrb, mrb_value self)
+{
+  return mrb_int_value(mrb, (mrb_int)sizeof(mrb_value));
+}
+
+void
+mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
+{
+  struct RClass *os = mrb_module_get(mrb, "ObjectSpace");
+  mrb_define_module_function(mrb, os, "__memsize_slot", memsize_slot, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, os, "__memsize_value_width", memsize_value_width, MRB_ARGS_NONE());
+}

--- a/mrbgems/mruby-os-memsize/test/memsize_test.c
+++ b/mrbgems/mruby-os-memsize/test/memsize_test.c
@@ -51,6 +51,15 @@ memsize_heap_number(mrb_state *mrb, mrb_value self)
   return ary;
 }
 
+/* A string over static storage, as OP_STRING builds from a pool string a
+ * static irep holds; long enough not to embed in the object header. */
+static mrb_value
+memsize_nofree_string(mrb_state *mrb, mrb_value self)
+{
+  static const char body[] = "a body long enough to sit outside the object header";
+  return mrb_str_new_static(mrb, body, sizeof(body) - 1);
+}
+
 void
 mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
 {
@@ -58,4 +67,5 @@ mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
   mrb_define_module_function(mrb, os, "__memsize_slot", memsize_slot, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_value_width", memsize_value_width, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_heap_number", memsize_heap_number, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, os, "__memsize_nofree_string", memsize_nofree_string, MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-os-memsize/test/memsize_test.c
+++ b/mrbgems/mruby-os-memsize/test/memsize_test.c
@@ -26,10 +26,36 @@ memsize_value_width(mrb_state *mrb, mrb_value self)
   return mrb_int_value(mrb, (mrb_int)sizeof(mrb_value));
 }
 
+static void
+push_number(mrb_state *mrb, mrb_value ary, mrb_value v)
+{
+  mrb_value pair = mrb_ary_new_capa(mrb, 2);
+
+  mrb_ary_push(mrb, pair, v);
+  mrb_ary_push(mrb, pair, mrb_bool_value(mrb_immediate_p(v)));
+  mrb_ary_push(mrb, ary, pair);
+}
+
+/* An Integer and a Float the boxed word cannot hold, each paired with whether
+ * the boxing kept it immediate after all: MRB_NO_BOXING has room for both,
+ * and word boxing for a Float. The Float pair only where there is one. */
+static mrb_value
+memsize_heap_number(mrb_state *mrb, mrb_value self)
+{
+  mrb_value ary = mrb_ary_new_capa(mrb, 2);
+
+  push_number(mrb, ary, mrb_int_value(mrb, MRB_INT_MAX));
+#ifndef MRB_NO_FLOAT
+  push_number(mrb, ary, mrb_float_value(mrb, 1.5));
+#endif
+  return ary;
+}
+
 void
 mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
 {
   struct RClass *os = mrb_module_get(mrb, "ObjectSpace");
   mrb_define_module_function(mrb, os, "__memsize_slot", memsize_slot, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_value_width", memsize_value_width, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, os, "__memsize_heap_number", memsize_heap_number, MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-os-memsize/test/memsize_test.c
+++ b/mrbgems/mruby-os-memsize/test/memsize_test.c
@@ -60,6 +60,35 @@ memsize_nofree_string(mrb_state *mrb, mrb_value self)
   return mrb_str_new_static(mrb, body, sizeof(body) - 1);
 }
 
+static mrb_value
+raise_for_backtrace(mrb_state *mrb, void *data)
+{
+  mrb_raise(mrb, E_RUNTIME_ERROR, "memsize");
+  return mrb_nil_value();
+}
+
+/* The packed backtrace an exception keeps from being raised, with how many
+ * frames it holds and what one frame takes. The object is internal
+ * (MRB_TT_BACKTRACE); memsize_of is the only thing to ask it. */
+static mrb_value
+memsize_backtrace(mrb_state *mrb, mrb_value self)
+{
+  mrb_bool error;
+  mrb_value exc = mrb_protect_error(mrb, raise_for_backtrace, NULL, &error);
+  struct RBacktrace *bt;
+  mrb_value ary;
+
+  mrb_gc_protect(mrb, exc); /* the backtrace is reachable through it alone */
+  bt = (struct RBacktrace*)mrb_exc_ptr(exc)->backtrace;
+  ary = mrb_ary_new_capa(mrb, 3);
+
+  mrb_assert(error && bt && bt->tt == MRB_TT_BACKTRACE);
+  mrb_ary_push(mrb, ary, mrb_obj_value(bt));
+  mrb_ary_push(mrb, ary, mrb_int_value(mrb, (mrb_int)bt->len));
+  mrb_ary_push(mrb, ary, mrb_int_value(mrb, (mrb_int)sizeof(struct mrb_backtrace_location)));
+  return ary;
+}
+
 void
 mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
 {
@@ -68,4 +97,5 @@ mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
   mrb_define_module_function(mrb, os, "__memsize_value_width", memsize_value_width, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_heap_number", memsize_heap_number, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_nofree_string", memsize_nofree_string, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, os, "__memsize_backtrace", memsize_backtrace, MRB_ARGS_NONE());
 }

--- a/mrbgems/mruby-os-memsize/test/memsize_test.c
+++ b/mrbgems/mruby-os-memsize/test/memsize_test.c
@@ -89,6 +89,125 @@ memsize_backtrace(mrb_state *mrb, mrb_value self)
   return ary;
 }
 
+static void
+push_irep_case(mrb_state *mrb, mrb_value ary, const char *name, mrb_irep *irep, size_t owned)
+{
+  int ai = mrb_gc_arena_save(mrb);
+  mrb_value row = mrb_ary_new_capa(mrb, 3);
+
+  mrb_ary_push(mrb, row, mrb_str_new_cstr(mrb, name));
+  mrb_ary_push(mrb, row, mrb_obj_value(mrb_proc_new(mrb, irep)));
+  mrb_ary_push(mrb, row, mrb_int_value(mrb, (mrb_int)owned));
+  mrb_ary_push(mrb, ary, row);
+  mrb_irep_decref(mrb, irep); /* the proc holds it now */
+  mrb_gc_arena_restore(mrb, ai);
+}
+
+/* Procs over ireps built by hand, each with the bytes its irep owns: what
+ * mrb_irep_free() would release, at the size it was allocated. None of them
+ * is ever run. */
+static mrb_value
+memsize_ireps(mrb_state *mrb, mrb_value self)
+{
+  static const mrb_code static_iseq[4] = { 0, 0, 0, 0 };
+  static const char static_str[] = "a pool string in read-only data";
+  static mrb_irep static_irep;
+  mrb_value ary = mrb_ary_new(mrb);
+  mrb_irep *irep;
+  mrb_irep_pool *pool;
+  size_t owned;
+
+  /* a bigint entry: a length byte with its top bit set, a sign byte, digits */
+  irep = mrb_add_irep(mrb);
+  pool = (mrb_irep_pool*)mrb_malloc(mrb, sizeof(mrb_irep_pool));
+  {
+    const size_t digits = 200;
+    char *p = (char*)mrb_malloc(mrb, digits + 2);
+    p[0] = (char)digits;
+    p[1] = 0;
+    memset(p + 2, 1, digits);
+    pool[0].tt = IREP_TT_BIGINT;
+    pool[0].u.str = p;
+    owned = sizeof(mrb_irep) + sizeof(mrb_irep_pool) + digits + 2;
+  }
+  irep->pool = pool;
+  irep->plen = 1;
+  push_irep_case(mrb, ary, "bigint pool entry", irep, owned);
+
+  /* a heap pool string is copied with its NUL */
+  irep = mrb_add_irep(mrb);
+  pool = (mrb_irep_pool*)mrb_malloc(mrb, sizeof(mrb_irep_pool));
+  {
+    const size_t len = sizeof(static_str) - 1;
+    char *p = (char*)mrb_malloc(mrb, len + 1);
+    memcpy(p, static_str, len + 1);
+    pool[0].tt = (uint32_t)(len << 2) | IREP_TT_STR;
+    pool[0].u.str = p;
+    owned = sizeof(mrb_irep) + sizeof(mrb_irep_pool) + len + 1;
+  }
+  irep->pool = pool;
+  irep->plen = 1;
+  push_irep_case(mrb, ary, "heap pool string", irep, owned);
+
+  /* a static pool string stays where the binary put it */
+  irep = mrb_add_irep(mrb);
+  pool = (mrb_irep_pool*)mrb_malloc(mrb, sizeof(mrb_irep_pool));
+  pool[0].tt = (uint32_t)((sizeof(static_str) - 1) << 2) | IREP_TT_SSTR;
+  pool[0].u.str = static_str;
+  irep->pool = pool;
+  irep->plen = 1;
+  push_irep_case(mrb, ary, "static pool string", irep, sizeof(mrb_irep) + sizeof(mrb_irep_pool));
+
+  /* the catch handler table shares the iseq's block */
+  irep = mrb_add_irep(mrb);
+  {
+    const size_t len = 8 * sizeof(mrb_code) + 2 * sizeof(struct mrb_irep_catch_handler);
+    irep->iseq = (const mrb_code*)mrb_calloc(mrb, 1, len);
+    irep->ilen = 8;
+    irep->clen = 2;
+    owned = sizeof(mrb_irep) + len;
+  }
+  push_irep_case(mrb, ary, "iseq and catch handlers", irep, owned);
+
+  /* a static iseq, as a binary in read-only data is read */
+  irep = mrb_add_irep(mrb);
+  irep->iseq = static_iseq;
+  irep->ilen = sizeof(static_iseq);
+  irep->flags |= MRB_ISEQ_NO_FREE;
+  push_irep_case(mrb, ary, "static iseq", irep, sizeof(mrb_irep));
+
+  /* local variable names, one per local past self */
+  irep = mrb_add_irep(mrb);
+  irep->nlocals = 3;
+  irep->lv = (const mrb_sym*)mrb_calloc(mrb, 2, sizeof(mrb_sym));
+  push_irep_case(mrb, ary, "local variable names", irep, sizeof(mrb_irep) + 2 * sizeof(mrb_sym));
+
+  /* debug info: the info, its file table, one file with a packed line map */
+  irep = mrb_add_irep(mrb);
+  {
+    const size_t packed = 5;
+    mrb_irep_debug_info *d = (mrb_irep_debug_info*)mrb_calloc(mrb, 1, sizeof(*d));
+    mrb_irep_debug_info_file *f = (mrb_irep_debug_info_file*)mrb_calloc(mrb, 1, sizeof(*f));
+
+    f->line_type = mrb_debug_line_packed_map;
+    f->line_entry_count = (uint32_t)packed;
+    f->lines.ptr = mrb_calloc(mrb, 1, packed);
+    d->flen = 1;
+    d->files = (mrb_irep_debug_info_file**)mrb_calloc(mrb, 1, sizeof(*d->files));
+    d->files[0] = f;
+    irep->debug_info = d;
+    owned = sizeof(mrb_irep) + sizeof(*d) + sizeof(*d->files) + sizeof(*f) + packed;
+  }
+  push_irep_case(mrb, ary, "debug info", irep, owned);
+
+  /* a static irep: everything it points to is read-only data */
+  static_irep.flags = MRB_IREP_NO_FREE;
+  static_irep.refcnt = 1;
+  push_irep_case(mrb, ary, "static irep", &static_irep, 0);
+
+  return ary;
+}
+
 void
 mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
 {
@@ -98,4 +217,5 @@ mrb_mruby_os_memsize_gem_test(mrb_state *mrb)
   mrb_define_module_function(mrb, os, "__memsize_heap_number", memsize_heap_number, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_nofree_string", memsize_nofree_string, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, os, "__memsize_backtrace", memsize_backtrace, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, os, "__memsize_ireps", memsize_ireps, MRB_ARGS_NONE());
 }


### PR DESCRIPTION
## Summary

`ObjectSpace.memsize_of` crashed on two kinds of object, and `memsize_of_all` with them the moment one existed anywhere in the heap. Several other cases counted memory the GC does not own, or missed memory it does. Each symptom is one commit, after a first one that gives the tests a C helper, so that every count is checked as a number rather than as "not zero".

## Changes

| File                                           | What                                                                                                                                                                                                                   |
| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-os-memsize/src/memsize.c`       | `os_memsize_of_proc_body` and `os_memsize_of_debug_info` added; the Fiber, Float/Integer, Array, String, Backtrace and irep cases decide from the same flags the GC frees by; the `MRB_TT_FLOAT` label loses its guard |
| `mrbgems/mruby-os-memsize/test/memsize_test.c` | new: `ObjectSpace.__memsize_*` helpers for mrbtest, handing out the slot and `mrb_value` sizes, a heap number, a static string, a packed backtrace, and procs over hand-built ireps                                    |
| `mrbgems/mruby-os-memsize/test/memsize.rb`     | exact counts for each case above; `Fiber.allocate` and an aliased method, walked by `memsize_of_all` too; a push within capacity; a shared array buffer                                                                |

### Two crashes

`Fiber.allocate` leaves the object's `cxt` NULL until `initialize` runs, and the Fiber case read the stack bounds through it. A method defined by `alias` is an `RProc` flagged `MRB_PROC_ALIAS` whose body holds the aliased method's symbol, and the Proc and Method cases tested only for a C function before following `body.irep`. Both were found under ASan; the second reproduces with `memsize_of_all` on any program that contains an `alias`.

A fiber without a context is counted as its object slot alone, which is what it occupies. The Proc and Method cases now share `os_memsize_of_proc_body`, which follows `body.irep` only when the proc has one, as the GC does before freeing it.

### What the GC owns

Each remaining change takes its decision from the function that frees the object, so the count is the memory that goes away with it.

- **Float and Integer on the heap.** A value that does not fit the boxed word is an `RFloat` or `RInteger` in an object slot. The switch let those fall through into the Rational case, so they were counted only when `MRB_USE_RATIONAL` happened to be defined, and as zero otherwise; `dreamcast_shelf` ships this gem without mruby-rational. The `MRB_TT_FLOAT` label also loses its `MRB_NO_FLOAT` guard: the enumerator is declared either way, and leaving it out of the switch is what `-Wswitch` warned about in every build without a Float.
- **Array buffer.** The heap buffer holds `mrb_value` elements, one per slot of capacity, but the count was `sizeof(mrb_value*) * len`: half the size under `MRB_NO_BOXING`, and never the capacity beyond the length. An array made by `dup` or slicing shares one refcounted buffer with its source, and both owners reported it. Now `sizeof(mrb_value) * ARY_CAPA` for an owned buffer and nothing for a shared one, as the String case already does.
- **String buffer.** The count skipped an embedded or refcount-shared buffer but still charged a `NOFREE` buffer (static storage, such as a presym name behind `Symbol#to_s` or a literal from a static irep) and an `FSHARED` buffer (borrowed from a frozen string; nothing in the tree creates one any more, but the GC still tests for it). It now tests the same four flags `mrb_gc_free_str()` does.
- **Backtrace.** Every other heap type adds its object slot; this case added only the locations array.
- **irep.** The walk follows `mrb_irep_free()` now. Added: the irep struct itself (it was added for each child but never for the irep a proc points at), the catch handler table that follows the iseq in its block, the local variable names, and the debug info with its line tables. Fixed: a string pool entry is copied with its NUL and a bigint entry carries a length and a sign byte before its digits, neither of which was counted, and the bigint length was read through a plain `char`, so a constant whose digits run past 127 bytes came out negative. Removed: a static irep (`MRB_IREP_NO_FREE`), a static iseq (`MRB_ISEQ_NO_FREE`) and a static pool string (`IREP_TT_SSTR`) sit in read-only data and were charged as heap. An irep loaded from a binary keeps its pool, syms and reps in one block with the struct; the same bytes are counted, only the padding between them is not.

An irep is refcounted and shared by every proc made from the same code, and `memsize_of_all` still charges it once per proc. That is as before and is left alone here.

## Behaviour

`bin/mruby` from `build_config/default.rb` with the gem added, word boxing, 64-bit, gcc. One process per row, so a crash on master does not hide the others.

| Object                                                 | master  | this PR |
| ------------------------------------------------------ | ------- | ------- |
| `Fiber.allocate`                                       | SIGSEGV | 40      |
| `UnboundMethod` of an `alias`                          | SIGSEGV | 128     |
| `UnboundMethod` of `def foo; a = 0; a + 1; end`        | 142     | 272     |
| the same method with a `rescue` clause around its body | 171     | 314     |
| a method whose body is a 150-digit integer literal     | 47      | 431     |
| `Array.new(16)`                                        | 168     | 168     |
| `[]` after 20 pushes (capacity 32)                     | 200     | 296     |
| `Array.new(32).dup`                                    | 296     | 40      |
| `ObjectSpace.memsize_of_all` at the end of the script  | 50903   | 50789   |

`Array.new(16)` is unchanged because its capacity equals its length. The 150-digit literal weighed 47 on master because its length byte, 0x80 and above, was read as a negative `char`.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds with `mruby-os-memsize` added to each, gcc, base `a9151d778` and this PR built in the same worktree path into an empty build directory with plain `rake`.

| Build                | master    | this PR   | delta |
| -------------------- | --------- | --------- | ----- |
| `full-debug` (`-O0`) | 1,984,390 | 1,984,902 | +512  |
| `bintest`            | 1,369,846 | 1,370,166 | +320  |
| `cxx_abi`            | 1,382,361 | 1,382,633 | +272  |
| `byte-string`        | 1,331,878 | 1,332,198 | +320  |
| `ascii-ctype`        | 1,354,486 | 1,354,806 | +320  |
| `no-float`           | 1,294,942 | 1,295,230 | +288  |
| `no-bigint`          | 1,253,334 | 1,253,638 | +304  |

All of it is `memsize.o`: 1,381 to 1,701 on `bintest`, 2,418 to 2,923 on `full-debug`.

## Testing

`mruby-os-memsize` is in no gembox, so every build below adds it to the config it names. Each of the eight commits was built and run on its own on the host build (`build_config/default.rb` plus the gem): `mrbtest` `Total 2674`, `OK 2600`, `Skip 74`, `KO 0`, `Crash 0`, `Warning 0`, and bintest `Total 130`, `OK 129`, `Skip 1`, at every commit.

The head, per build, from `build/<build>/bin/mrbtest` run one at a time:

| Build         | Total | OK   | Skip | KO  | Crash | Warning |
| ------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host          | 2674  | 2600 | 74   | 0   | 0     | 0       |
| `full-debug`  | 2920  | 2909 | 11   | 0   | 0     | 0       |
| `bintest`     | 2920  | 2900 | 20   | 0   | 0     | 0       |
| `cxx_abi`     | 2920  | 2900 | 20   | 0   | 0     | 0       |
| `byte-string` | 2832  | 2758 | 74   | 0   | 0     | 0       |
| `ascii-ctype` | 2904  | 2882 | 22   | 0   | 0     | 0       |
| `no-float`    | 2655  | 2558 | 97   | 0   | 0     | 0       |
| `no-bigint`   | 2872  | 2839 | 33   | 0   | 0     | 0       |
| `gcc-asan`    | 2920  | 2908 | 12   | 0   | 0     | 0       |

bintest: `Total 147`, `OK 146`, `Skip 1` on `ci/gcc-clang`; `Total 103`, `OK 102`, `Skip 1` on `gcc-asan`.

`build_config/gcc-asan.rb` plus the gem (`-fsanitize=address,undefined`, `-O0`) is the last row; the two crashes were first seen there, and the suite runs under it with no sanitizer report.

Word, no and NaN boxing, each with `MRB_INT64` and `MRB_INT32`, 64-bit, full-core plus the gem, `-Wall -Werror`: six builds, `Total 2920`, `OK 2900`, `Skip 20`, `KO 0`, `Crash 0`, `Warning 0` in five of them. NaN boxing with `MRB_INT64` has `KO 1` in `sprintf - a width near mrb_int is refused, not wrapped`, which master fails the same way in that build.

The base build of `no-float` prints `warning: enumeration value 'MRB_TT_FLOAT' not handled in switch`; this PR's builds print no warning.

The tests ask for exact numbers. `test/memsize_test.c` is linked into mrbtest the way mruby-objectspace's and mruby-io's helpers are, and answers what Ruby cannot reach: the size of an object slot and of an `mrb_value`, an Integer and a Float beyond the boxed word with whether the boxing kept them immediate, a string over static storage, the packed backtrace an exception keeps with its frame count, and procs over ireps built by hand, each with the bytes `mrb_irep_free()` would release: a bigint entry whose length byte has its top bit set, a heap and a static pool string, an iseq with its catch handlers, a static iseq, local variable names, debug info with a packed line map, and a static irep. The Ruby side checks each against `memsize_of`, alongside `Fiber.allocate` and an aliased method, which `memsize_of_all` now walks past too, a push back into the capacity a `pop` left behind, and a `dup` of a 32-element array.

Each fix's tests were also run on the tree of its parent commit, where they must fail: the Fiber and alias tests crash mrbtest there, and the Array, String, Backtrace and irep tests fail their assertions. The heap number test passes on its parent in this host build, because with mruby-rational present master counted the slot through the Rational case; in the same build minus mruby-rational and mruby-complex it fails on the parent (`Integer beyond the boxed word`, expected 40, actual 0) and passes on its own commit.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `memsize.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed.

```console
# host (build_config/default.rb + mruby-os-memsize)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_OS_MEMSIZE_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ObjectSpace.memsize_of` accuracy for arrays, strings, numbers, fibers, backtraces, procedures, and compiled code.
  * Corrected accounting for shared, embedded, static, and dynamically allocated data.
  * Prevented memory-size inspection from failing on uninitialized fibers, aliases, and other special cases.

* **Tests**
  * Expanded coverage for object sizes, shared data, capacity-based allocations, debug information, and backtraces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->