### PR TITLE
mruby-compiler: count the registers a pattern's own calls touch

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3238,7 +3238,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
         /* **nil or empty {}: exact match - verify hash.size == num_keys */
         int chk = cursp();
         gen_move(s, chk, hash_reg, 0);
-        push(); pop(); /* touch block slot */
+        push_n(2); pop_n(2); /* space for receiver and a block */
         genop_3(s, OP_SEND, chk, new_sym(s, MRC_SYM_1(size)), 0);
         gen_int(s, chk + 1, num_keys);
         genop_1(s, OP_EQ, chk);

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3027,6 +3027,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           gen_move(s, cursp(), arr_reg, 0);
           push();
           gen_int(s, cursp(), -(post_len - i));
+          push(); pop();  /* space for the index */
           genop_1(s, OP_GETIDX, cursp() - 1);
           /* Element is now at cursp-1 */
           codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1);
@@ -3036,7 +3037,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       else {
         /* Call target.deconstruct() */
         gen_move(s, cursp(), target, 0);
-        push(); pop();  /* touch block slot for max stack */
+        push_n(2); pop_n(2);  /* space for receiver and a block */
         genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(deconstruct)), 0);
         arr_reg = cursp();
         push();  /* protect arr_reg on stack */
@@ -3049,7 +3050,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
         {
           int chk = cursp();
           gen_move(s, chk, arr_reg, 0);
-          push(); pop();  /* touch block slot */
+          push_n(2); pop_n(2);  /* space for receiver and a block */
           genop_3(s, OP_SEND, chk, new_sym(s, MRC_SYM_1(size)), 0);
           /* R[chk] = size */
           gen_int(s, chk + 1, pre_len + post_len);
@@ -3105,6 +3106,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           gen_move(s, cursp(), arr_reg, 0);
           push();
           gen_int(s, cursp(), -(post_len - i));
+          push(); pop();  /* space for the index */
           genop_1(s, OP_GETIDX, cursp() - 1);
           codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1);
           pop();

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3301,7 +3301,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
 
       /* Call deconstruct on target */
       gen_move(s, cursp(), target, 0);
-      push(); pop();
+      push_n(2); pop_n(2);  /* space for receiver and a block */
       genop_3(s, OP_SEND, arr_reg, new_sym(s, MRC_SYM_1(deconstruct)), 0);
       push(); /* protect arr_reg */
 
@@ -3311,7 +3311,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
 
       /* Check minimum length: arr.size >= elems_len */
       gen_move(s, cursp(), arr_reg, 0);
-      push(); pop();
+      push_n(2); pop_n(2);  /* space for receiver and a block, then for the GE operand */
       genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(size)), 0);
       gen_int(s, cursp() + 1, elems_len);
       genop_1(s, OP_GE, cursp());
@@ -3329,7 +3329,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
 
       /* Check if idx <= arr.size - elems_len */
       gen_move(s, cursp(), arr_reg, 0);
-      push(); pop();
+      push_n(2); pop_n(2);  /* space for receiver and a block, then for the SUB and GE operands */
       genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(size)), 0);
       gen_int(s, cursp() + 1, elems_len);
       genop_1(s, OP_SUB, cursp());
@@ -3351,6 +3351,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           gen_int(s, cursp() + 1, (int)i);
           genop_1(s, OP_ADD, cursp());
         }
+        push_n(2); pop_n(2);  /* space for the index and the ADD operand */
         genop_1(s, OP_GETIDX, cursp() - 1);
         int elem_reg = cursp() - 1;
         codegen_pattern(s, pat_find->requireds.nodes[i], elem_reg, &match_fail, -1);
@@ -3372,6 +3373,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             gen_int(s, cursp(), 0);
             push();
             gen_move(s, cursp(), idx_reg, 0);
+            push(); pop();  /* space for the range end, which is also the block slot */
             genop_1(s, OP_RANGE_EXC, cursp() - 1);
             pop(); pop();
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);
@@ -3396,6 +3398,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             genop_1(s, OP_ADD, cursp());
             push();
             gen_int(s, cursp(), -1);
+            push(); pop();  /* space for the range end, which is also the block slot */
             genop_1(s, OP_RANGE_INC, cursp() - 1);
             pop(); pop();
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1601,6 +1601,16 @@ assert('pattern matching - array pattern as the last expression of a frame') do
   assert_equal [1, 2], f.call([1, 2])
 end
 
+assert('pattern matching - find pattern as the last expression of a frame') do
+  # The elements are variables on purpose: a literal element calls `===`,
+  # and that call widens the frame past the gap this guards against.
+  f = ->(x) { x => [*, a, *]; a }
+  assert_equal 1, f.call([1, 2, 3])
+
+  f = ->(x) { x => [*p, a, *q]; [p, a, q] }
+  assert_equal [[], 1, [2, 3]], f.call([1, 2, 3])
+end
+
 assert('defined? on statically-decidable operands') do
   # literals and pure expressions
   assert_equal 'expression', defined?(1)

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1580,6 +1580,27 @@ assert('pattern matching - complex patterns') do
   end
 end
 
+assert('pattern matching - array pattern as the last expression of a frame') do
+  # Nothing follows the pattern here, so the frame is exactly as wide as the
+  # pattern's own code declares. The internal `deconstruct` and `size` calls
+  # and the post-rest index must fit in that width.
+  f = ->(x) { x => [a, b]; [a, b] }
+  assert_equal [1, 2], f.call([1, 2])
+
+  f = ->(x) { x => [a, [b, c]]; [a, b, c] }
+  assert_equal [1, 2, 3], f.call([1, [2, 3]])
+
+  f = ->(x) { x => [a, *, b]; [a, b] }
+  assert_equal [1, 3], f.call([1, 2, 3])
+
+  f = ->(x) { x in [a, b] }
+  assert_true f.call([1, 2])
+  assert_false f.call([1, 2, 3])
+
+  f = ->(x) { case x; in [a, b]; end; [a, b] }
+  assert_equal [1, 2], f.call([1, 2])
+end
+
 assert('defined? on statically-decidable operands') do
   # literals and pure expressions
   assert_equal 'expression', defined?(1)


### PR DESCRIPTION
## Summary

`x => [a, b]` aborts a debug build at the VM's `bidx < irep->nregs` assertion and runs in a release build by writing one register past its frame. The array pattern's `size` call, and ten other calls and binary operations written the same way inside a pattern, left their receiver or second operand out of the frame size.

## Changes

| File                                   | What                                                                                                                                                                       |
| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | eleven sites in `codegen_pattern` count the receiver and block slot of a call, or the second operand of a binary operation, before emitting the instruction that uses them |
| `test/t/syntax.rb`                     | two assert blocks whose patterns are the last expression of their frame, one for the array pattern and one for the find pattern                                            |

Three commits, one per pattern kind, each green on its own: the array pattern with its tests, the find pattern with its tests, and the hash pattern's `size` call, which no test can reach.

### A pattern's call counted only its block slot

`nregs` is the high-water mark of the codegen's stack pointer, and a call's operands count only when they are pushed. The call codegen pushes the receiver and every argument, then touches one more register for the block slot, so the frame reaches one past the slot `OP_SEND` clears. The pattern codegen moved its receiver into the register at the stack pointer without pushing it, then touched one register the same way. That touch landed on the receiver's own register, and the block slot one above it was never counted.

```console
$ printf 'x = [1, 2]\nx => [a, b]\n' > t.rb && bin/mrbc -v -o /dev/null t.rb
irep 0x... nregs=7 nlocals=4 pools=0 syms=2 reps=0 ilen=57
    2 019 MOVE      R6  R5
    2 022 SEND      R6  :size  n=0
    2 026 LOADI_2   R7  (2)
    2 028 EQ        R6  (R7)
```

`R7` is both the block slot of the `size` call and the operand of the `EQ`, and `nregs` says the frame ends at `R6`. Whatever followed the pattern usually pushed past `R7` on its own, which is why every existing test passed: `assert_equal [1, 2, 3], [a, b, c]` right after the pattern builds an array through those registers. The gap shows only when the pattern is the last expression in its frame, a lambda or method body that ends in `x => [a, b]`, or a `case`/`in` whose arm has no body.

The fix at each site is the idiom the call codegen already uses, `push_n(2); pop_n(2);` where a receiver and a block have to be counted and `push(); pop();` where a single register above the pointer is written. Bytecode is unchanged except for `nregs`.

### How the sites were found

The assertion fires only at `OP_SEND`, so a check on it alone would miss an `EQ` or `GETIDX` whose operand sits past the frame. A script read `mrbc -v` for forty pattern forms and compared each irep's `nregs` with the highest register any of its instructions names, counting the block slot of a `SEND`, the elements of an `ARRAY` and the second operand of a range or index instruction. Nineteen ireps came up short, at these sites:

- array pattern: the `deconstruct` call, the `size` call, and the negative index of each post-rest element
- hash pattern: the `size` call behind `{}` and `**nil`
- find pattern: the `deconstruct` call, both `size` calls and the `GE` and `SUB` operands beside them, the element index and the offset added to it, and the range end of the `*pre` and `*post` bindings

The hash pattern's site was never observable, since the argument pushed for `deconstruct_keys` widens the frame past it in every form, and is changed only because it is written the same way. After the change the script reports no short irep.

### What a release build did

`stack_extend` grows the stack while `ci->stack + nregs >= stend`, so there is always at least one slot past a frame inside the allocation. The stray writes were a nil from `OP_SEND` clearing the block slot and a small integer from `LOADI`, both into that slot, and nothing reads it while the frame is live. That is why the release build ran every form correctly and only the debug assertion saw the gap.

## Behaviour

On a build with `MRB_DEBUG`, before and after, with the pattern as the last expression of its frame:

| Form                                                                                               | Before                                            | After  |
| -------------------------------------------------------------------------------------------------- | ------------------------------------------------- | ------ |
| `->(x) { x => [a, b] }`                                                                            | abort at `bidx < irep->nregs`                     | passes |
| `->(x) { x => [a, [b, c]] }`                                                                       | abort                                             | passes |
| `->(x) { x => [*, a, *] }`                                                                         | abort                                             | passes |
| `->(x) { x => [*p, a, *q] }`                                                                       | abort                                             | passes |
| `->(x) { x => [*, 2, a, *] }`                                                                      | passes, the `===` of the literal widens the frame | passes |
| `->(x) { x in [a, b] }`                                                                            | abort                                             | passes |
| `->(x) { case x; in [a, b]; end }`                                                                 | abort                                             | passes |
| `->(x) { x => [a, *, b] }`                                                                         | abort                                             | passes |
| `[1, 2, 3] => [a, b, c]` followed by `assert_equal [1, 2, 3], [a, b, c]`, the existing test's form | passes                                            | passes |

A release build answers the same values before and after. `nregs` of the irep for `x => [a, b]` goes from 7 to 8.

## Size

`.text` of `bin/mruby` per `ci/gcc-clang` build, `size -A`, gcc 13.3.0, empty build directories on both sides, base `a9151d778`:

| Build              |    master |   this PR | delta |
| ------------------ | --------: | --------: | ----: |
| bintest            | 1,369,846 | 1,369,958 |  +112 |
| ascii-ctype        | 1,354,486 | 1,354,598 |  +112 |
| byte-string        | 1,331,878 | 1,331,990 |  +112 |
| cxx_abi            | 1,382,361 | 1,382,473 |  +112 |
| no-float           | 1,294,942 | 1,295,054 |  +112 |
| no-bigint          | 1,253,334 | 1,253,446 |  +112 |
| full-debug (`-O0`) | 1,984,390 | 1,984,598 |  +208 |

All of it is `codegen.o`: +112 in the `-O3` builds (`90,937` to `91,049`; `92,713` to `92,825` under `cxx_abi`; `90,889` to `91,001` under `no-float`) and +200 under `full-debug` (`115,579` to `115,779`). Each site either turns a `push` into a `push_n` or adds a `push` and a `pop`, and every push range-checks the stack pointer.

## Testing

`rake -m test` on the default build and on all seven `ci/gcc-clang` builds, gcc 13.3.0; each row is that build's `bin/mrbtest` run on its own:

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2674 | 2600 |   74 |   0 |     0 |       0 |
| full-debug  |  2922 | 2911 |   11 |   0 |     0 |       0 |
| bintest     |  2922 | 2902 |   20 |   0 |     0 |       0 |
| cxx_abi     |  2922 | 2902 |   20 |   0 |     0 |       0 |
| byte-string |  2834 | 2760 |   74 |   0 |     0 |       0 |
| ascii-ctype |  2906 | 2884 |   22 |   0 |     0 |       0 |
| no-float    |  2657 | 2560 |   97 |   0 |     0 |       0 |
| no-bigint   |  2874 | 2841 |   33 |   0 |     0 |       0 |

bintest: `Total 130`, `OK 129`, `Skip 1` on the host build and `Total 147`, `OK 146`, `Skip 1` on `ci/gcc-clang`.

Each commit was built and run through the whole suite on its own, `rake -m test` on `build_config/host-debug.rb`, which defines `MRB_DEBUG`:

| Commit        | Total |   OK | Skip |  KO | Crash | Warning |
| ------------- | ----: | ---: | ---: | --: | ----: | ------: |
| array pattern |  2921 | 2909 |   12 |   0 |     0 |       0 |
| find pattern  |  2922 | 2910 |   12 |   0 |     0 |       0 |
| hash pattern  |  2922 | 2910 |   12 |   0 |     0 |       0 |

Each of the two test commits was also checked the other way round, with its own `codegen.c` change taken back out and its tests left in: `mrbtest` aborts at `bidx < irep->nregs`, and every lambda of that commit's assert block aborts when run alone, while the find commit's abort leaves all five array lambdas passing. The array block's lambdas cover a two-element pattern, a nested one, one with a post-rest element, the boolean `in`, and a `case`/`in` whose arm has no body; the find block's cover a search with and without named splats. Every expected value was read off CRuby 4.0.6; the find pattern binds at the first position that matches, so `[*, a, *]` against `[1, 2, 3]` gives `a == 1`. The find pattern's elements are variables on purpose: a literal element calls `===`, and that call widens the frame past the gap, so `[*, 2, a, *]` passes on the base commit.

No test reaches the hash pattern's site, since the argument pushed for `deconstruct_keys` always covers it; that commit changes neither `nregs` nor any instruction, which `mrbc -v` over the forty forms confirms.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `codegen.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pattern matching in lambda expressions when the pattern is the final expression.
  * Improved support for array, nested, rest, hash, range, and find patterns without frame-size or operand handling errors.

* **Tests**
  * Added coverage for array and find patterns used as final lambda expressions, including nested and rest patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->