### PR TITLE
mruby-compiler: answer defined? for nil, true, false, () and a bare begin

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4136,8 +4136,8 @@ struct defined_answer {
   mrc_node *recv;                           /* recv.meth, NULL for none */
 };
 
-/* Whether a body holds no statement at all: `()` is the nil it evaluates
-   to, not an expression. */
+/* Whether a body holds no statement at all: `()` and `begin; end` are the
+   nil they evaluate to, not an expression. */
 static mrc_bool
 defined_body_empty_p(mrc_node *body)
 {
@@ -4146,27 +4146,44 @@ defined_body_empty_p(mrc_node *body)
          ((pm_statements_node_t *)body)->body.size == 0;
 }
 
+/* Whether a `begin` carries no rescue, else or ensure clause, and so is
+   only its body. */
+static mrc_bool
+defined_bare_begin_p(mrc_node *value)
+{
+  pm_begin_node_t *b = (pm_begin_node_t *)value;
+  return b->rescue_clause == NULL && b->else_clause == NULL &&
+         b->ensure_clause == NULL;
+}
+
 /* Parentheses around a single expression are transparent here, so
-   `defined?((x))` answers what `defined?(x)` does; parentheses holding no
-   statement or several stay, and answer for themselves.  The value a pair
-   leaves implicit, as in `{x:}`, is the `x` it stands for. */
+   `defined?((x))` answers what `defined?(x)` does, and so is a bare `begin`
+   around one; either holding no statement or several stays, and answers for
+   itself.  The value a pair leaves implicit, as in `{x:}`, is the `x` it
+   stands for. */
 static mrc_node *
 defined_operand(mrc_node *value)
 {
   for (;;) {
+    mrc_node *body;
+
     if (nint(value) == PM_IMPLICIT_NODE) {
       value = (mrc_node *)((pm_implicit_node_t *)value)->value;
+      continue;
     }
     else if (nint(value) == PM_PARENTHESES_NODE) {
-      mrc_node *body = (mrc_node *)((pm_parentheses_node_t *)value)->body;
-      if (body == NULL || nint(body) != PM_STATEMENTS_NODE) break;
-      pm_node_list_t *stmts = &((pm_statements_node_t *)body)->body;
-      if (stmts->size != 1) break;
-      value = (mrc_node *)stmts->nodes[0];
+      body = (mrc_node *)((pm_parentheses_node_t *)value)->body;
+    }
+    else if (nint(value) == PM_BEGIN_NODE && defined_bare_begin_p(value)) {
+      body = (mrc_node *)((pm_begin_node_t *)value)->statements;
     }
     else {
       break;
     }
+    if (body == NULL || nint(body) != PM_STATEMENTS_NODE) break;
+    pm_node_list_t *stmts = &((pm_statements_node_t *)body)->body;
+    if (stmts->size != 1) break;
+    value = (mrc_node *)stmts->nodes[0];
   }
   return value;
 }
@@ -4191,7 +4208,6 @@ defined_answer_for(mrc_node *value, struct defined_answer *a)
   case PM_IF_NODE: case PM_UNLESS_NODE:
   case PM_CASE_NODE: case PM_CASE_MATCH_NODE:
   case PM_WHILE_NODE: case PM_UNTIL_NODE: case PM_FOR_NODE:
-  case PM_BEGIN_NODE:
   case PM_RETURN_NODE: case PM_BREAK_NODE: case PM_NEXT_NODE:
   case PM_REDO_NODE: case PM_RETRY_NODE:
   case PM_DEF_NODE: case PM_CLASS_NODE: case PM_MODULE_NODE:
@@ -4213,6 +4229,13 @@ defined_answer_for(mrc_node *value, struct defined_answer *a)
     /* `()` is the nil it evaluates to; parentheses holding several
        statements are an expression of their own */
     a->type = defined_body_empty_p((mrc_node *)((pm_parentheses_node_t *)value)->body)
+              ? "nil" : "expression";
+    break;
+  case PM_BEGIN_NODE:
+    /* likewise for a bare `begin`; one with a rescue, else or ensure
+       clause is an expression whatever it holds */
+    a->type = (defined_bare_begin_p(value) &&
+               defined_body_empty_p((mrc_node *)((pm_begin_node_t *)value)->statements))
               ? "nil" : "expression";
     break;
   case PM_SELF_NODE:

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4136,10 +4136,20 @@ struct defined_answer {
   mrc_node *recv;                           /* recv.meth, NULL for none */
 };
 
+/* Whether a body holds no statement at all: `()` is the nil it evaluates
+   to, not an expression. */
+static mrc_bool
+defined_body_empty_p(mrc_node *body)
+{
+  if (body == NULL) return TRUE;
+  return nint(body) == PM_STATEMENTS_NODE &&
+         ((pm_statements_node_t *)body)->body.size == 0;
+}
+
 /* Parentheses around a single expression are transparent here, so
    `defined?((x))` answers what `defined?(x)` does; parentheses holding no
-   statement or several are an expression of their own and stay.  The value
-   a pair leaves implicit, as in `{x:}`, is the `x` it stands for. */
+   statement or several stay, and answer for themselves.  The value a pair
+   leaves implicit, as in `{x:}`, is the `x` it stands for. */
 static mrc_node *
 defined_operand(mrc_node *value)
 {
@@ -4173,7 +4183,6 @@ defined_answer_for(mrc_node *value, struct defined_answer *a)
   case PM_SYMBOL_NODE: case PM_INTERPOLATED_SYMBOL_NODE:
   case PM_REGULAR_EXPRESSION_NODE: case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
   case PM_ARRAY_NODE: case PM_HASH_NODE: case PM_KEYWORD_HASH_NODE:
-  case PM_NIL_NODE: case PM_TRUE_NODE: case PM_FALSE_NODE:
   case PM_RANGE_NODE: case PM_LAMBDA_NODE: case PM_DEFINED_NODE:
   case PM_SOURCE_FILE_NODE: case PM_SOURCE_LINE_NODE: case PM_SOURCE_ENCODING_NODE:
   /* control flow, jumps and definitions: CRuby answers "expression" for
@@ -4182,13 +4191,29 @@ defined_answer_for(mrc_node *value, struct defined_answer *a)
   case PM_IF_NODE: case PM_UNLESS_NODE:
   case PM_CASE_NODE: case PM_CASE_MATCH_NODE:
   case PM_WHILE_NODE: case PM_UNTIL_NODE: case PM_FOR_NODE:
-  case PM_BEGIN_NODE: case PM_PARENTHESES_NODE:
+  case PM_BEGIN_NODE:
   case PM_RETURN_NODE: case PM_BREAK_NODE: case PM_NEXT_NODE:
   case PM_REDO_NODE: case PM_RETRY_NODE:
   case PM_DEF_NODE: case PM_CLASS_NODE: case PM_MODULE_NODE:
   case PM_SINGLETON_CLASS_NODE:
   case PM_MATCH_PREDICATE_NODE: case PM_MATCH_REQUIRED_NODE:
     a->type = "expression";
+    break;
+  /* the literals CRuby names rather than calling expressions */
+  case PM_NIL_NODE:
+    a->type = "nil";
+    break;
+  case PM_TRUE_NODE:
+    a->type = "true";
+    break;
+  case PM_FALSE_NODE:
+    a->type = "false";
+    break;
+  case PM_PARENTHESES_NODE:
+    /* `()` is the nil it evaluates to; parentheses holding several
+       statements are an expression of their own */
+    a->type = defined_body_empty_p((mrc_node *)((pm_parentheses_node_t *)value)->body)
+              ? "nil" : "expression";
     break;
   case PM_SELF_NODE:
     a->type = "self";

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1966,7 +1966,8 @@ assert('defined? on control flow, jumps and definitions') do
   assert_equal 'expression', defined?(while false do end)
   assert_equal 'expression', defined?(until true do end)
   assert_equal 'expression', defined?(for i in [1] do end)
-  assert_equal 'expression', defined?(begin; 1; end)
+  assert_equal 'expression', defined?(begin; 1; rescue; end)
+  assert_equal 'expression', defined?(begin; 1; ensure; end)
   assert_equal 'expression', defined?(if (lv == 1)..(lv == 2) then 1 end)
 
   # jumps, which `defined?` reports on without needing a place to jump to
@@ -2002,6 +2003,33 @@ assert('defined? sees through parentheses around one expression') do
   assert_equal 'expression', defined?((1; 2))
   assert_equal 'nil', defined?(())
   assert_equal 'nil', defined?(((())))
+end
+
+assert('defined? sees through a bare begin around one expression') do
+  lv = 1
+
+  assert_equal 'local-variable', defined?(begin; lv; end)
+  assert_equal 'constant', defined?(begin; Object; end)
+  assert_equal 'assignment', defined?(begin; unset = 1; end)
+  assert_nil unset
+  assert_nil defined?(begin; no_such_method_at_all; end)
+  assert_nil defined?(begin; begin; (no_such_method_at_all); end; end)
+
+  # the same where the begin is a receiver, or an argument
+  assert_nil defined?(begin; no_such_method_at_all; end.to_s)
+  assert_nil defined?(puts(begin; no_such_method_at_all; end))
+  assert_equal 'method', defined?(begin; lv; end.to_s)
+
+  # a begin holding several statements is an expression of its own, and an
+  # empty one the nil it evaluates to
+  assert_equal 'expression', defined?(begin; 1; 2; end)
+  assert_equal 'nil', defined?(begin; end)
+  assert_equal 'nil', defined?(begin; (); end)
+
+  # a rescue, else or ensure clause makes it an expression whatever it holds
+  assert_equal 'expression', defined?(begin; no_such_method_at_all; rescue; end)
+  assert_equal 'expression', defined?(begin; no_such_method_at_all; ensure; end)
+  assert_equal 'expression', defined?(begin; rescue; end)
 end
 
 assert('defined? on a call carrying a block') do

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1611,14 +1611,14 @@ assert('defined? on statically-decidable operands') do
   assert_equal 'expression', defined?(:sym)
   assert_equal 'expression', defined?([1, 2])
   assert_equal 'expression', defined?({a: 1})
-  assert_equal 'expression', defined?(nil)
-  assert_equal 'expression', defined?(true)
-  assert_equal 'expression', defined?(false)
   assert_equal 'expression', defined?(1..2)
   assert_equal 'expression', defined?(defined?(x))
 
-  # self
+  # self, and the literals named rather than called expressions
   assert_equal 'self', defined?(self)
+  assert_equal 'nil', defined?(nil)
+  assert_equal 'true', defined?(true)
+  assert_equal 'false', defined?(false)
 
   # a local variable in scope
   lv = 1
@@ -1995,9 +1995,13 @@ assert('defined? sees through parentheses around one expression') do
   assert_equal 'instance-variable', defined?((@defined_paren_iv))
   assert_equal 'constant', defined?((Object))
   assert_nil defined?((no_such_method_at_all))
+  assert_equal 'nil', defined?((nil))
 
-  # parentheses holding several statements are an expression of their own
+  # parentheses holding several statements are an expression of their own,
+  # and empty ones the nil they evaluate to
   assert_equal 'expression', defined?((1; 2))
+  assert_equal 'nil', defined?(())
+  assert_equal 'nil', defined?(((())))
 end
 
 assert('defined? on a call carrying a block') do


### PR DESCRIPTION
## Summary

`defined?` answered `"expression"` for `nil`, `true`, `false` and `()`, and for any `begin` block without looking inside it. CRuby names the three literals, answers `()` with the nil it evaluates to, and treats a `begin` that carries no rescue, else or ensure clause as the one statement it holds, so `defined?(begin; no_such; end)` is nil.

## Changes

| File                                   | What                                                                                                                                                                                                                                                                 |
| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | `defined_answer_for` names `nil` / `true` / `false` and answers `()` and `begin; end` with `"nil"` through `defined_body_empty_p`; `defined_operand` sees through a bare `begin` around one statement, the test being `defined_bare_begin_p`, as it does parentheses |
| `test/t/syntax.rb`                     | the three literals and `()` join the statically decidable block; one new assert block for the bare `begin`                                                                                                                                                           |

Two commits: the literals, then the `begin`.

### The literals CRuby names

`nil`, `true` and `false` are the only literals `defined?` names rather than calling expressions, and their node type settles the answer at compile time as `self` does. `()` is a parentheses node holding no statement; CRuby answers it with the name of the nil it evaluates to, and parentheses holding several statements stay an `"expression"`.

### A bare `begin` is its body

CRuby's `defined?` looks through a `begin` block that carries no rescue, else or ensure clause the way it looks through parentheses: one statement is answered for itself, none is `"nil"`, and several are an `"expression"`. A `begin` with one of the three clauses is an `"expression"` whatever it holds. `defined_operand` already unwrapped parentheses and the implicit value of `{x:}`; the `begin` joins that loop, so the same rule applies where the `begin` is the operand, a receiver, or an argument, and `defined?(begin; no_such; end.to_s)` answers nil with nothing evaluated.

## Behaviour

Every row was run against both mruby and CRuby 4.0.6, which parses with the same Prism. `lv` is a local.

| Operand                             | Before         | After              | CRuby 4.0.6        |
| ----------------------------------- | -------------- | ------------------ | ------------------ |
| `nil`                               | `"expression"` | `"nil"`            | `"nil"`            |
| `true`                              | `"expression"` | `"true"`           | `"true"`           |
| `false`                             | `"expression"` | `"false"`          | `"false"`          |
| `()`                                | `"expression"` | `"nil"`            | `"nil"`            |
| `(nil)`                             | `"expression"` | `"nil"`            | `"nil"`            |
| `(1; 2)`                            | `"expression"` | `"expression"`     | `"expression"`     |
| `begin; lv; end`                    | `"expression"` | `"local-variable"` | `"local-variable"` |
| `begin; x = 1; end`                 | `"expression"` | `"assignment"`     | `"assignment"`     |
| `begin; no_such; end`               | `"expression"` | nil                | nil                |
| `begin; begin; (no_such); end; end` | `"expression"` | nil                | nil                |
| `begin; end`                        | `"expression"` | `"nil"`            | `"nil"`            |
| `begin; 1; 2; end`                  | `"expression"` | `"expression"`     | `"expression"`     |
| `begin; no_such; rescue; end`       | `"expression"` | `"expression"`     | `"expression"`     |
| `begin; no_such; ensure; end`       | `"expression"` | `"expression"`     | `"expression"`     |
| `begin; no_such; end.to_s`          | nil, evaluated | nil                | nil                |
| `puts(begin; no_such; end)`         | `"method"`     | nil                | nil                |

Before, the `begin` as a receiver answered nil only by being evaluated: `no_such` reached `method_missing` and the `NameError` it raised was discarded. Now, as in CRuby, `method_missing` is not called.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang`, gcc 13.3.0, empty build directories at the same worktree path, base `defb32aed`.

| Build                | master    | this PR   | delta |
| -------------------- | --------- | --------- | ----- |
| `bintest`            | 1,369,622 | 1,370,294 | +672  |
| `ascii-ctype`        | 1,354,262 | 1,354,934 | +672  |
| `byte-string`        | 1,331,654 | 1,332,326 | +672  |
| `cxx_abi`            | 1,382,457 | 1,383,321 | +864  |
| `no-float`           | 1,294,718 | 1,295,422 | +704  |
| `no-bigint`          | 1,253,110 | 1,253,782 | +672  |
| `full-debug` (`-O0`) | 1,984,662 | 1,984,806 | +144  |

The whole of each delta is `codegen.o`: +672 in `bintest` (+864 in `cxx_abi`, +704 in `no-float`, +143 in `full-debug`), from the two predicates and the `begin` arm of the unwrapping loop.

## Testing

`rake -m test`, green on the default build and on all seven of `build_config/ci/gcc-clang`, built with gcc. Each build's counts were read off its own `bin/mrbtest`, since the parallel run's output cannot be mapped back to a build. Each of the two commits builds and runs green on the default build on its own.

| Build                            | Total | OK   | Skip | KO  | Crash | Warning |
| -------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| host (`build_config/default.rb`) | 2679  | 2605 | 74   | 0   | 0     | 0       |
| `bintest`                        | 2927  | 2907 | 20   | 0   | 0     | 0       |
| `ascii-ctype`                    | 2911  | 2889 | 22   | 0   | 0     | 0       |
| `byte-string`                    | 2839  | 2765 | 74   | 0   | 0     | 0       |
| `cxx_abi`                        | 2927  | 2907 | 20   | 0   | 0     | 0       |
| `no-float`                       | 2662  | 2565 | 97   | 0   | 0     | 0       |
| `no-bigint`                      | 2879  | 2846 | 33   | 0   | 0     | 0       |
| `full-debug` (`-O0`)             | 2927  | 2916 | 11   | 0   | 0     | 0       |

The command bintests ran with them: `Total 130`, `OK 129` on the default build, and `Total 147`, `OK 146` over `ci/gcc-clang`.

The assertions in `test/t/syntax.rb` cover the three literals, `()`, `(nil)` and `((()))`, and for the bare `begin` a local, a constant, an assignment, a missing method, a nested `begin` with parentheses, the `begin` as a receiver and as an argument, several statements, the empty `begin`, `begin; (); end`, and the rescue and ensure forms. The four assert blocks the branch touches were also run under CRuby 4.0.6 with a small assert shim, 69 assertions, all passing; 58 further operands (the `begin` in a condition, as a receiver, an argument, an array element and a hash key, nested, and with `&&`, a ternary, a range, a lambda and a block inside) answer the same on both.

## Environment

<details>

|            |                                                                   |
| ---------- | ----------------------------------------------------------------- |
| OS         | Ubuntu 24.04.4 LTS                                                |
| Kernel     | Linux 7.0.0-31-generic x86_64                                     |
| CPU        | AMD Ryzen 9 5950X, 16C/32T                                        |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils   | GNU ld 2.47.20260726                                              |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

The compile line for `codegen.c` in each build, as `rake --verbose` printed it after touching the file. `-I`, `-o`, `-MMD`, `-ffile-prefix-map` and the source path are dropped; the mrbc donor builds are not listed.

```console
# host (build_config/default.rb)
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: full-debug
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: bintest
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

# ci/gcc-clang: cxx_abi
gcc -c -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: byte-string
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: ascii-ctype
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-float
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

# ci/gcc-clang: no-bigint
gcc -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `defined?` results for `nil`, `true`, and `false` literals.
  - Empty parentheses and empty bare `begin` expressions now return `"nil"`.
  - Improved handling of bare `begin` expressions in `defined?`, including nested and multi-statement expressions.
  - Preserved `"expression"` results for `begin` blocks containing `rescue` or `ensure` clauses.

- **Tests**
  - Expanded syntax coverage for literal, parenthesized, and bare `begin` expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->