### PR TITLE
vm.c: honor an operator redefined on Integer, Float, String or Symbol

### DIFF
--- a/doc/limitations.md
+++ b/doc/limitations.md
@@ -103,30 +103,6 @@ alias $a $__a__
 
 Syntax error
 
-## Operator modification
-
-Operators on some of the primitive classes cannot be overridden, as they are
-optimized in the VM.
-
-```ruby
-class String
-  def +
-  end
-end
-
-'a' + 'b'
-```
-
-#### CRuby
-
-`ArgumentError` is raised.
-The re-defined `+` operator does not accept any arguments.
-
-#### mruby
-
-`'ab'`
-Behavior of the operator wasn't changed.
-
 ## `nil?` redefinition in conditional expressions
 
 Redefinition of `nil?` is ignored in conditional expressions.

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -323,6 +323,31 @@ enum mrb_idx_op_slot {
   MRB_IDX_OP_SLOT_COUNT
 };
 
+/**
+ * Operators the arithmetic and comparison opcodes (`OP_ADD`, `OP_LT`, `OP_EQ`
+ * and their kin) answer in C for an Integer, Float or Symbol receiver.  Each
+ * (receiver class, operator) pair owns a bit of `mrb_state.bop_redefined`,
+ * numbered by the macros below.
+ */
+enum mrb_bop {
+  MRB_BOP_ADD,                  /* +  */
+  MRB_BOP_SUB,                  /* -  */
+  MRB_BOP_MUL,                  /* *  */
+  MRB_BOP_DIV,                  /* /  */
+  MRB_BOP_EQ,                   /* == */
+  MRB_BOP_LT,                   /* <  */
+  MRB_BOP_LE,                   /* <= */
+  MRB_BOP_GT,                   /* >  */
+  MRB_BOP_GE,                   /* >= */
+  MRB_BOP_COUNT
+};
+
+#define MRB_BOP_INTEGER(op) (1u << (op))                  /* Integer#op */
+#define MRB_BOP_FLOAT(op)   (1u << (MRB_BOP_COUNT + (op))) /* Float#op   */
+#define MRB_BOP_NUMERIC(op) (MRB_BOP_INTEGER(op) | MRB_BOP_FLOAT(op))
+#define MRB_BOP_SYMBOL_EQ   (1u << (2 * MRB_BOP_COUNT))    /* Symbol#==  */
+#define MRB_BOP_SLOT_COUNT  (2 * MRB_BOP_COUNT + 1)
+
 #ifdef MRB_USE_TASK_SCHEDULER
 struct mrb_task;
 
@@ -458,10 +483,20 @@ struct mrb_state {
      and NULL once it does not, so the class-pointer test the opcodes already
      perform rejects a redefined operator at no extra cost.  NULL is safe as
      the disabled value because no live object has a NULL class pointer.
-     Armed by mrb_idx_op_init(), rechecked by mrb_idx_op_update().  Placed at
+     Armed by mrb_builtin_op_init(), rechecked by mrb_builtin_op_update().  Placed at
      the end of the struct so that adding them moves no existing field. */
   struct RClass *idx_class[MRB_IDX_OP_SLOT_COUNT];
   mrb_method_t idx_builtin[MRB_IDX_OP_SLOT_COUNT];
+
+  /* The arithmetic and comparison opcodes answer `+`, `<`, `==` and their kin
+     from C for an Integer, Float or Symbol receiver.  Those are immediate
+     values whose type tag names the class, so there is no class pointer for a
+     slot to disarm; each (class, operator) pair owns a bit here instead, clear
+     while the operator still resolves to the builtin recorded in
+     `bop_builtin` and set once it does not.  Bit numbers are the `MRB_BOP_*`
+     macros, which also index `bop_builtin`. */
+  uint32_t bop_redefined;
+  mrb_method_t bop_builtin[MRB_BOP_SLOT_COUNT];
 
 #ifdef MRB_USE_TASK_SCHEDULER
   mrb_task_state task;                    /* Task scheduler state */

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -311,7 +311,8 @@ typedef void (*mrb_atexit_func)(mrb_state*);
 
 /**
  * Slots of `mrb_state.idx_class`, one per builtin the inline index opcodes
- * (`OP_GETIDX`, `OP_GETIDX0`, `OP_SETIDX`) reimplement in C.
+ * (`OP_GETIDX`, `OP_GETIDX0`, `OP_SETIDX`) reimplement in C, plus one for
+ * `String#+`, which `OP_ADD` guards the same way.
  */
 enum mrb_idx_op_slot {
   MRB_IDX_OP_ARY_AREF,          /* Array#[]  */
@@ -320,6 +321,7 @@ enum mrb_idx_op_slot {
   MRB_IDX_OP_ARY_ASET,          /* Array#[]= */
   MRB_IDX_OP_HASH_ASET,         /* Hash#[]=  */
   MRB_IDX_OP_STR_ASET,          /* String#[]= */
+  MRB_IDX_OP_STR_ADD,           /* String#+  */
   MRB_IDX_OP_SLOT_COUNT
 };
 
@@ -477,7 +479,8 @@ struct mrb_state {
   uint16_t atexit_stack_len;
 
   /* The inline index opcodes answer `[]` and `[]=` from C for a receiver whose
-     class is exactly Array, Hash or String, which would bypass a redefinition
+     class is exactly Array, Hash or String, and `OP_ADD` answers `+` for one
+     whose class is exactly String, which would bypass a redefinition
      installed on those classes themselves.  Each slot holds the core class
      while the name still resolves to the builtin recorded in `idx_builtin`,
      and NULL once it does not, so the class-pointer test the opcodes already

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -65,9 +65,10 @@ size_t mrb_class_mt_memsize(mrb_state*, struct RClass*);
 mrb_value mrb_obj_extend(mrb_state*, mrb_value obj);
 #endif
 
-/* inline index opcode guards (class.c); see `idx_class` in `struct mrb_state` */
-void mrb_idx_op_init(mrb_state *mrb);
-void mrb_idx_op_update(mrb_state *mrb, mrb_sym mid);
+/* builtin operator guards (class.c); see `idx_class` and `bop_redefined` in
+   `struct mrb_state` */
+void mrb_builtin_op_init(mrb_state *mrb);
+void mrb_builtin_op_update(mrb_state *mrb, mrb_sym mid);
 void mrb_idx_op_rearm(mrb_state *mrb, enum mrb_idx_op_slot slot);
 
 mrb_value mrb_obj_equal_m(mrb_state *mrb, mrb_value);

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1361,7 +1361,6 @@ gen_addsub(mrc_codegen_scope *s, uint8_t op, uint16_t dst)
          for negative n would change the method sent on user override (#2557). */
       if (n < 0 || n > UINT8_MAX) goto normal;
       rewind_pc(s);
-      if (n == 0) return;
       if (op == OP_ADD) genop_2(s, OP_ADDI, dst, (uint16_t)n);
       else genop_2(s, OP_SUBI, dst, (uint16_t)n);
       return;

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -91,95 +91,6 @@
 #define MRC_ARGS_NONE()     ((mrc_aspec)0)
 
 
-#define MRC_INT_OVERFLOW_MASK ((mrc_uint)1 << (MRC_INT_BIT - 1))
-
-static inline mrc_bool
-mrc_int_add_overflow(mrc_int a, mrc_int b, mrc_int *c)
-{
-  mrc_uint x = (mrc_uint)a;
-  mrc_uint y = (mrc_uint)b;
-  mrc_uint z = (mrc_uint)(x + y);
-  *c = (mrc_int)z;
-  return !!(((x ^ z) & (y ^ z)) & MRC_INT_OVERFLOW_MASK);
-}
-
-static inline mrc_bool
-mrc_int_sub_overflow(mrc_int a, mrc_int b, mrc_int *c)
-{
-  mrc_uint x = (mrc_uint)a;
-  mrc_uint y = (mrc_uint)b;
-  mrc_uint z = (mrc_uint)(x - y);
-  *c = (mrc_int)z;
-  return !!(((x ^ z) & (~y ^ z)) & MRC_INT_OVERFLOW_MASK);
-}
-
-static inline mrc_bool
-mrc_int_mul_overflow(mrc_int a, mrc_int b, mrc_int *c)
-{
-#ifdef MRC_INT32
-  int64_t n = (int64_t)a * b;
-  *c = (mrc_int)n;
-  return n > MRC_INT_MAX || n < MRC_INT_MIN;
-#else /* MRC_INT64 */
-  if (a > 0 && b > 0 && a > MRC_INT_MAX / b) return TRUE;
-  if (a < 0 && b > 0 && a < MRC_INT_MIN / b) return TRUE;
-  if (a > 0 && b < 0 && b < MRC_INT_MIN / a) return TRUE;
-  if (a < 0 && b < 0 && (a <= MRC_INT_MIN || b <= MRC_INT_MIN || -a > MRC_INT_MAX / -b))
-    return TRUE;
-  *c = a * b;
-  return FALSE;
-#endif
-}
-
-static mrc_int
-mrc_div_int(mrc_int x, mrc_int y)
-{
-  mrc_int div = x / y;
-
-  if ((x ^ y) < 0 && x != div * y) {
-    div -= 1;
-  }
-  return div;
-}
-
-#define NUMERIC_SHIFT_WIDTH_MAX (MRC_INT_BIT-1)
-
-static mrc_bool
-mrc_num_shift(mrc_int val, mrc_int width, mrc_int *num)
-{
-  if (width < 0) {              /* rshift */
-    if (width == MRC_INT_MIN || -width >= NUMERIC_SHIFT_WIDTH_MAX) {
-      if (val < 0) {
-        *num = -1;
-      }
-      else {
-        *num = 0;
-      }
-    }
-    else {
-      *num = val >> -width;
-    }
-  }
-  else if (val > 0) {
-    if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
-        (val   > (MRC_INT_MAX >> width))) {
-      return FALSE;
-    }
-    *num = val << width;
-  }
-  else {
-    if ((width > NUMERIC_SHIFT_WIDTH_MAX) ||
-        (val   < (MRC_INT_MIN >> width))) {
-      return FALSE;
-    }
-    if (width == NUMERIC_SHIFT_WIDTH_MAX)
-      *num = MRC_INT_MIN;
-    else
-      *num = val * ((mrc_int)1 << width);
-  }
-  return TRUE;
-}
-
 #ifdef MRC_ENDIAN_BIG
 # define MRC_ENDIAN_LOHI(a,b) a b
 #else
@@ -1031,19 +942,6 @@ gen_move(mrc_codegen_scope *s, uint16_t dst, uint16_t src, int nopeep)
         struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
         if (data0.insn != OP_MOVE || data0.a != data.a || data0.b != dst) goto normal;
         s->pc = addr_pc(s, data0.addr);
-        if (addr_pc(s, data0.addr) != s->lastlabel) {
-          /* constant folding */
-          struct mrc_insn_data data1 = mrc_decode_insn(mrc_prev_pc(s, data0.addr));
-          mrc_int n;
-          if (data1.a == dst && get_int_operand(s, &data1, &n)) {
-            if ((data.insn == OP_ADDI && !mrc_int_add_overflow(n, data.b, &n)) ||
-                (data.insn == OP_SUBI && !mrc_int_sub_overflow(n, data.b, &n))) {
-              s->pc = addr_pc(s, data1.addr);
-              gen_int(s, dst, n);
-              return;
-            }
-          }
-        }
         /* ADDILV/SUBILV fusion: MOVE temp local; ADDI/SUBI temp imm; MOVE local temp */
         /* -> ADDILV/SUBILV local temp imm (temp is working space for method fallback) */
         genop_3(s, data.insn == OP_ADDI ? OP_ADDILV : OP_SUBILV, dst, data.a, data.b);
@@ -1354,57 +1252,15 @@ gen_addsub(mrc_codegen_scope *s, uint8_t op, uint16_t dst)
       /* not integer immediate */
       goto normal;
     }
-    struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
-    mrc_int n0;
-    if (addr_pc(s, data.addr) == s->lastlabel || !get_int_operand(s, &data0, &n0)) {
-      /* Fold to OP_ADDI/OP_SUBI only for non-negative 8-bit n; flipping op
-         for negative n would change the method sent on user override (#2557). */
-      if (n < 0 || n > UINT8_MAX) goto normal;
-      rewind_pc(s);
-      if (op == OP_ADD) genop_2(s, OP_ADDI, dst, (uint16_t)n);
-      else genop_2(s, OP_SUBI, dst, (uint16_t)n);
-      return;
-    }
-    if (op == OP_ADD) {
-      if (mrc_int_add_overflow(n0, n, &n)) goto normal;
-    }
-    else { /* OP_SUB */
-      if (mrc_int_sub_overflow(n0, n, &n)) goto normal;
-    }
-    s->pc = addr_pc(s, data0.addr);
-    gen_int(s, dst, n);
-  }
-}
-
-static void
-gen_muldiv(mrc_codegen_scope *s, uint8_t op, uint16_t dst)
-{
-  if (no_peephole(s)) {
-  normal:
-    genop_1(s, op, dst);
-    return;
-  }
-  else {
-    struct mrc_insn_data data = mrc_last_insn(s);
-    mrc_int n, n0;
-    if (addr_pc(s, data.addr) == s->lastlabel || !get_int_operand(s, &data, &n)) {
-      /* not integer immediate */
-      goto normal;
-    }
-    struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
-    if (!get_int_operand(s, &data0, &n0)) {
-      goto normal;
-    }
-    if (op == OP_MUL) {
-      if (mrc_int_mul_overflow(n0, n, &n)) goto normal;
-    }
-    else { /* OP_DIV */
-      if (n == 0) goto normal;
-      if (n0 == MRC_INT_MIN && n == -1) goto normal;
-      n = mrc_div_int(n0, n);
-    }
-    s->pc = addr_pc(s, data0.addr);
-    gen_int(s, dst, n);
+    /* Fold to OP_ADDI/OP_SUBI only for non-negative 8-bit n; flipping op
+       for negative n would change the method sent on user override (#2557).
+       Two literals are not folded to their sum for the same reason: the
+       operator is a method of the receiver, and only the opcode can tell
+       whether it is still the builtin. */
+    if (n < 0 || n > UINT8_MAX) goto normal;
+    rewind_pc(s);
+    if (op == OP_ADD) genop_2(s, OP_ADDI, dst, (uint16_t)n);
+    else genop_2(s, OP_SUBI, dst, (uint16_t)n);
   }
 }
 
@@ -1423,10 +1279,9 @@ gen_uniop(mrc_codegen_scope *s, mrc_sym sym, uint16_t dst)
     if (n == MRC_INT_MIN) return FALSE;
     n = -n;
   }
-  else if (sym == MRC_OPSYM_2(neg)) {
-    n = ~n;
-  }
   else {
+    /* `~1` is a method call in CRuby too, and folding it would bypass a
+       redefined `Integer#~` */
     return FALSE;
   }
   s->pc = addr_pc(s, data.addr);
@@ -1453,50 +1308,7 @@ gen_binop(mrc_codegen_scope *s, mrc_sym op, uint16_t dst)
     return TRUE;
   }
   else {
-    struct mrc_insn_data data = mrc_last_insn(s);
-    mrc_int n, n0;
-    if (addr_pc(s, data.addr) == s->lastlabel || !get_int_operand(s, &data, &n)) {
-      /* not integer immediate */
-      return FALSE;
-    }
-    struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
-    if (!get_int_operand(s, &data0, &n0)) {
-      return FALSE;
-    }
-    if (op == MRC_OPSYM_2(lshift)) {
-      if (!mrc_num_shift(n0, n, &n)) return FALSE;
-    }
-    else if (op == MRC_OPSYM_2(rshift)) {
-      if (n == MRC_INT_MIN) return FALSE;
-      if (!mrc_num_shift(n0, -n, &n)) return FALSE;
-    }
-    else if (op == MRC_OPSYM_2(mod) && n != 0) {
-      if (n0 == MRC_INT_MIN && n == -1) {
-        n = 0;
-      }
-      else {
-        mrc_int n1 = n0 % n;
-        if ((n0 < 0) != (n < 0) && n1 != 0) {
-          n1 += n;
-        }
-        n = n1;
-      }
-    }
-    else if (op == MRC_OPSYM_2(and)) {
-      n = n0 & n;
-    }
-    else if (op == MRC_OPSYM_2(or)) {
-      n = n0 | n;
-    }
-    else if (op == MRC_OPSYM_2(xor)) {
-      n = n0 ^ n;
-    }
-    else {
-      return FALSE;
-    }
-    s->pc = addr_pc(s, data0.addr);
-    gen_int(s, dst, n);
-    return TRUE;
+    return FALSE;
   }
 }
 
@@ -2645,10 +2457,10 @@ gen_call(mrc_codegen_scope *s, mrc_node *tree, int val, int safe, int recv_ready
     gen_addsub(s, OP_SUB, cursp());
   }
   else if (!noop && sym == MRC_OPSYM_2(mul) && n == 1)  {
-    gen_muldiv(s, OP_MUL, cursp());
+    genop_1(s, OP_MUL, cursp());
   }
   else if (!noop && sym == MRC_OPSYM_2(div) && n == 1)  {
-    gen_muldiv(s, OP_DIV, cursp());
+    genop_1(s, OP_DIV, cursp());
   }
   else if (!noop && sym == MRC_OPSYM_2(lt) && n == 1)  {
     genop_1(s, OP_LT, cursp());
@@ -2669,10 +2481,10 @@ gen_call(mrc_codegen_scope *s, mrc_node *tree, int val, int safe, int recv_ready
     genop_1(s, OP_SETIDX, cursp());
   }
   else if (!noop && n == 0 && gen_uniop(s, sym, cursp())) {
-    /* constant folding succeeded */
+    /* a literal absorbed its sign */
   }
   else if (!noop && n == 1 && gen_binop(s, sym, cursp())) {
-    /* constant folding succeeded */
+    /* an index opcode was emitted */
   }
   else if (noself) {
     if (!blk && n == 0 && nk == 0) {

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -504,3 +504,23 @@ assert('Object#public_send visibility') do
   end.new
   assert_equal [:nope, [1]], mm.public_send(:nope, 1)
 end
+
+assert('Module#remove_method on a module prepended to Integer restores the builtin operator') do
+  # A module prepended to `Integer` changes what `-` resolves to without
+  # touching the method table of `Integer` itself, and `OP_SUB` honors that on
+  # the same terms as a redefinition on `Integer`: the operator resolves to
+  # something other than the builtin, so the opcode sends it. Removing the
+  # method again leaves the module in place but resolves `-` back to the
+  # builtin, which the opcode answers itself once more.
+  m = Module.new { def -(other) [:prepended, self, other] end }
+  Integer.prepend(m)
+  begin
+    a = 7
+    diff = a - 2
+  ensure
+    m.class_eval { remove_method :- }
+  end
+  assert_equal [:prepended, 7, 2], diff
+  a = 7
+  assert_equal 5, a - 2
+end

--- a/src/class.c
+++ b/src/class.c
@@ -2856,7 +2856,8 @@ mc_clear_by_id(mrb_state *mrb, mrb_sym id)
  * Guards for the inline index opcodes.
  *
  * `OP_GETIDX`, `OP_GETIDX0` and `OP_SETIDX` implement `[]` and `[]=` for an
- * Array, Hash or String receiver in C, without a method lookup.  They may only
+ * Array, Hash or String receiver in C, without a method lookup, and `OP_ADD`
+ * does the same for `+` on a String receiver.  They may only
  * do so while those classes still carry the builtin the opcode reimplements,
  * so each (class, operator) pair keeps a slot in `mrb->idx_class` that holds
  * the class while that is true and NULL once it is not.  The opcodes compare
@@ -2885,6 +2886,7 @@ idx_op_class(mrb_state *mrb, int slot)
 static mrb_sym
 idx_op_mid(int slot)
 {
+  if (slot == MRB_IDX_OP_STR_ADD) return MRB_OPSYM(add);
   return slot < MRB_IDX_OP_ARY_ASET ? MRB_OPSYM(aref) : MRB_OPSYM(aset);
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -1089,7 +1089,7 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
   mt_put(mrb, h, mid, flags, ptr);
   if (!mrb->bootstrapping) {
     mc_clear_by_id(mrb, mid);
-    mrb_idx_op_update(mrb, mid);
+    mrb_builtin_op_update(mrb, mid);
   }
   if (modfunc) {
     /* module_function scope: also define a public method on the singleton
@@ -2135,7 +2135,7 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, stru
     mrb_method_cache_clear(mrb);
     /* An included or prepended module can carry both operators, and it is not
        one method name that changed, so recheck every slot. */
-    mrb_idx_op_update(mrb, 0);
+    mrb_builtin_op_update(mrb, 0);
   }
   return 0;
 }
@@ -2539,7 +2539,7 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
       }
       mt_put(mrb, h, mid, m.flags, ptr);
       mc_clear_by_id(mrb, mid);
-      mrb_idx_op_update(mrb, mid);
+      mrb_builtin_op_update(mrb, mid);
     }
   }
 }
@@ -2919,16 +2919,6 @@ idx_op_arm(mrb_state *mrb, int slot)
   mrb->idx_class[slot] = base;
 }
 
-/* Records the builtin `[]` / `[]=` of each core class and arms its slot.
-   Called once, after core initialization has installed them. */
-void
-mrb_idx_op_init(mrb_state *mrb)
-{
-  for (int slot = 0; slot < MRB_IDX_OP_SLOT_COUNT; slot++) {
-    idx_op_arm(mrb, slot);
-  }
-}
-
 /* Arms `slot` for an implementation installed over the builtin.
  *
  * CALLER'S PROMISE: for every argument form the opcode answers itself, the
@@ -2949,22 +2939,100 @@ mrb_idx_op_rearm(mrb_state *mrb, enum mrb_idx_op_slot slot)
   idx_op_arm(mrb, (int)slot);
 }
 
-/* Rechecks the slots that `mid` can affect.  Call after any change to a method
-   table that could change what `[]` or `[]=` resolves to; pass 0 for `mid` when
-   the change is not tied to one name, as module inclusion is not. */
+/*
+ * Guards for the arithmetic and comparison opcodes.
+ *
+ * `OP_ADD`, `OP_LT`, `OP_EQ` and their kin answer an operator from C for an
+ * Integer, Float or Symbol receiver.  Those are immediate values whose type
+ * tag names the class, so there is no class pointer for a slot to disarm as
+ * `idx_class` does; each (class, operator) pair owns a bit of
+ * `mrb->bop_redefined` instead, clear while the operator still resolves to the
+ * builtin recorded in `mrb->bop_builtin` and set once it does not.  Validity
+ * is judged exactly as for the index slots above.
+ */
+
+static const mrb_sym bop_mids[MRB_BOP_COUNT] = {
+  MRB_OPSYM(add), MRB_OPSYM(sub), MRB_OPSYM(mul), MRB_OPSYM(div),
+  MRB_OPSYM(eq), MRB_OPSYM(lt), MRB_OPSYM(le), MRB_OPSYM(gt), MRB_OPSYM(ge),
+};
+
+/* NULL for a slot the build has no class for. */
+static struct RClass*
+bop_class(mrb_state *mrb, int slot)
+{
+  if (slot < MRB_BOP_COUNT) return mrb->integer_class;
+  if (slot == 2 * MRB_BOP_COUNT) return mrb->symbol_class;
+#ifdef MRB_NO_FLOAT
+  return NULL;
+#else
+  return mrb->float_class;
+#endif
+}
+
+static mrb_sym
+bop_mid(int slot)
+{
+  return slot == 2 * MRB_BOP_COUNT ? MRB_OPSYM(eq) : bop_mids[slot % MRB_BOP_COUNT];
+}
+
+static void
+bop_refresh(mrb_state *mrb, int slot)
+{
+  const mrb_method_t *builtin = &mrb->bop_builtin[slot];
+
+  if (builtin->as.func == NULL) return;
+
+  struct RClass *c = bop_class(mrb, slot);
+  mrb_method_t m = mrb_vm_find_method(mrb, c, &c, bop_mid(slot));
+  if (m.flags == builtin->flags && m.as.func == builtin->as.func) {
+    mrb->bop_redefined &= ~(1u << slot);
+  }
+  else {
+    mrb->bop_redefined |= 1u << slot;
+  }
+}
+
+static void
+bop_arm(mrb_state *mrb, int slot)
+{
+  struct RClass *c = bop_class(mrb, slot);
+
+  /* A slot the build has no class for keeps its bit clear: nothing can
+     redefine what does not exist, and a bit set here would never let the
+     Integer and Float bits of an operator read clear as a pair. */
+  if (c == NULL) return;
+  mrb->bop_redefined |= 1u << slot;
+  mrb_method_t m = mrb_vm_find_method(mrb, c, &c, bop_mid(slot));
+  if (MRB_METHOD_UNDEF_P(m) || !MRB_METHOD_FUNC_P(m)) return;
+  mrb->bop_builtin[slot] = m;
+  mrb->bop_redefined &= ~(1u << slot);
+}
+
+/* Records the builtin operators of each core class and arms their slots.
+   Called once, after core initialization has installed them. */
 void
-mrb_idx_op_update(mrb_state *mrb, mrb_sym mid)
+mrb_builtin_op_init(mrb_state *mrb)
+{
+  for (int slot = 0; slot < MRB_IDX_OP_SLOT_COUNT; slot++) {
+    idx_op_arm(mrb, slot);
+  }
+  for (int slot = 0; slot < MRB_BOP_SLOT_COUNT; slot++) {
+    bop_arm(mrb, slot);
+  }
+}
+
+/* Rechecks the slots that `mid` can affect.  Call after any change to a method
+   table that could change what a guarded operator resolves to; pass 0 for
+   `mid` when the change is not tied to one name, as module inclusion is not. */
+void
+mrb_builtin_op_update(mrb_state *mrb, mrb_sym mid)
 {
   if (mrb->bootstrapping) return;
-  if (mid == 0 || mid == MRB_OPSYM(aref)) {
-    idx_op_refresh(mrb, MRB_IDX_OP_ARY_AREF);
-    idx_op_refresh(mrb, MRB_IDX_OP_HASH_AREF);
-    idx_op_refresh(mrb, MRB_IDX_OP_STR_AREF);
+  for (int slot = 0; slot < MRB_IDX_OP_SLOT_COUNT; slot++) {
+    if (mid == 0 || mid == idx_op_mid(slot)) idx_op_refresh(mrb, slot);
   }
-  if (mid == 0 || mid == MRB_OPSYM(aset)) {
-    idx_op_refresh(mrb, MRB_IDX_OP_ARY_ASET);
-    idx_op_refresh(mrb, MRB_IDX_OP_HASH_ASET);
-    idx_op_refresh(mrb, MRB_IDX_OP_STR_ASET);
+  for (int slot = 0; slot < MRB_BOP_SLOT_COUNT; slot++) {
+    if (mid == 0 || mid == bop_mid(slot)) bop_refresh(mrb, slot);
   }
 }
 
@@ -3954,7 +4022,7 @@ mrb_remove_method(mrb_state *mrb, struct RClass *c0, mrb_sym mid)
     mrb_name_error(mrb, mid, "method '%n' not defined in %C", mid, c);
   }
   mc_clear_by_id(mrb, mid);
-  mrb_idx_op_update(mrb, mid);
+  mrb_builtin_op_update(mrb, mid);
   if (c0->tt == MRB_TT_SCLASS) {
     mrb_sym cb = MRB_SYM(singleton_method_removed);
     mrb_value recv = mrb_iv_get(mrb, mrb_obj_value(c0), MRB_SYM(__attached__));

--- a/src/state.c
+++ b/src/state.c
@@ -60,9 +60,9 @@ mrb_open_core(void)
 
   mrb_method_cache_clear(mrb);
   mrb->bootstrapping = FALSE;
-  /* After bootstrapping, so that a core `[]` replaced from mrblib is recorded
-     as replaced rather than as the builtin. */
-  mrb_idx_op_init(mrb);
+  /* After bootstrapping, so that a core operator replaced from mrblib is
+     recorded as replaced rather than as the builtin. */
+  mrb_builtin_op_init(mrb);
 
   return mrb;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -2928,7 +2928,13 @@ vm_op_div(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   mrb_float x, y, f;
 #endif
 
-  /* need to check if op is overridden */
+  /* While `Integer#/` or `Float#/` is redefined every pair is sent, the
+     redefined class's for the answer and the other's for the simplicity of
+     one test; see `bop_redefined` in `struct mrb_state`. */
+  if (mrb_unlikely(mrb->bop_redefined & MRB_BOP_NUMERIC(MRB_BOP_DIV))) {
+    *midp = MRB_OPSYM(div);
+    return VM_SEND_SYM;
+  }
   switch (TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]))) {
   case TYPES2(MRB_TT_INTEGER,MRB_TT_INTEGER):
     {
@@ -4054,15 +4060,19 @@ RETRY_TRY_BLOCK:
 #endif
 
 #define OP_MATH(op_name) do {                                               \
-  /* need to check if op is overridden */                                   \
   uint16_t tt = TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]));              \
-  if (mrb_likely(tt == TYPES2(MRB_TT_INTEGER, MRB_TT_INTEGER))) {           \
+  if (mrb_likely(tt == TYPES2(MRB_TT_INTEGER, MRB_TT_INTEGER) &&            \
+                 !(mrb->bop_redefined & MRB_BOP_INTEGER(OP_MATH_BOP_##op_name)))) { \
     mrb_int x = mrb_integer(regs[a]), y = mrb_integer(regs[a+1]), z;        \
     if (mrb_int_##op_name##_overflow(x, y, &z)) {                           \
       OP_MATH_OVERFLOW_INT(op_name,x,y);                                    \
     }                                                                       \
     else                                                                    \
       VM_SET_INT_VALUE(regs[a], z);                                         \
+  }                                                                         \
+  else if (mrb_unlikely(mrb->bop_redefined & MRB_BOP_NUMERIC(OP_MATH_BOP_##op_name))) { \
+    mid = MRB_OPSYM(op_name);                                               \
+    goto L_SEND_SYM;                                                        \
   }                                                                         \
   else switch (tt) {                                                        \
     OP_MATH_CASE_FLOAT(op_name, integer, float);                            \
@@ -4104,6 +4114,9 @@ RETRY_TRY_BLOCK:
 #define OP_MATH_OP_add +
 #define OP_MATH_OP_sub -
 #define OP_MATH_OP_mul *
+#define OP_MATH_BOP_add MRB_BOP_ADD
+#define OP_MATH_BOP_sub MRB_BOP_SUB
+#define OP_MATH_BOP_mul MRB_BOP_MUL
 #define OP_MATH_TT_integer MRB_TT_INTEGER
 #define OP_MATH_TT_float   MRB_TT_FLOAT
 
@@ -4127,8 +4140,8 @@ RETRY_TRY_BLOCK:
     }
 
 #define OP_MATHI(op_name) do {                                              \
-  /* need to check if op is overridden */                                   \
-  if (mrb_likely(mrb_integer_p(regs[a]))) {                                 \
+  if (mrb_likely(mrb_integer_p(regs[a]) &&                                  \
+                 !(mrb->bop_redefined & MRB_BOP_INTEGER(OP_MATH_BOP_##op_name)))) { \
     mrb_int x = mrb_integer(regs[a]), y = (mrb_int)b, z;                    \
     if (mrb_int_##op_name##_overflow(x, y, &z)) {                           \
       OP_MATH_OVERFLOW_INT(op_name,x,y);                                    \
@@ -4136,25 +4149,23 @@ RETRY_TRY_BLOCK:
     else                                                                    \
       VM_SET_INT_VALUE(regs[a], z);                                         \
   }                                                                         \
-  else switch (mrb_type(regs[a])) {                                         \
-    OP_MATHI_CASE_FLOAT(op_name);                                           \
-    default:                                                                \
-      SET_INT_VALUE(mrb,regs[a+1], b);                                      \
-      mid = MRB_OPSYM(op_name);                                             \
-      goto L_SEND_SYM;                                                      \
+  OP_MATHI_ELSE_FLOAT(op_name)                                              \
+  else {                                                                    \
+    SET_INT_VALUE(mrb,regs[a+1], b);                                        \
+    mid = MRB_OPSYM(op_name);                                               \
+    goto L_SEND_SYM;                                                        \
   }                                                                         \
 } while(0);                                                                 \
   NEXT;
 #ifdef MRB_NO_FLOAT
-#define OP_MATHI_CASE_FLOAT(op_name) (void)0
+#define OP_MATHI_ELSE_FLOAT(op_name)
 #else
-#define OP_MATHI_CASE_FLOAT(op_name)                                        \
-  case MRB_TT_FLOAT:                                                        \
-    {                                                                       \
-      mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name b;              \
-      VM_SET_FLOAT_VALUE(regs[a], z);                                       \
-    }                                                                       \
-    break
+#define OP_MATHI_ELSE_FLOAT(op_name)                                        \
+  else if (mrb_float_p(regs[a]) &&                                          \
+           !(mrb->bop_redefined & MRB_BOP_FLOAT(OP_MATH_BOP_##op_name))) {  \
+    mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name b;                \
+    VM_SET_FLOAT_VALUE(regs[a], z);                                         \
+  }
 #endif
 
     CASE(OP_ADDI, BB) {
@@ -4166,50 +4177,44 @@ RETRY_TRY_BLOCK:
     }
 
 #ifdef MRB_NO_FLOAT
-#define OP_MATHILV_CASE_FLOAT(op_name) (void)0
+#define OP_MATHILV_ELSE_FLOAT(op_name)
 #else
-#define OP_MATHILV_CASE_FLOAT(op_name)                                      \
-  case MRB_TT_FLOAT:                                                        \
-    {                                                                       \
-      mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name c;              \
-      VM_SET_FLOAT_VALUE(regs[a], z);                                       \
-    }                                                                       \
-    break
+#define OP_MATHILV_ELSE_FLOAT(op_name)                                      \
+  else if (mrb_float_p(regs[a]) &&                                          \
+           !(mrb->bop_redefined & MRB_BOP_FLOAT(OP_MATH_BOP_##op_name))) {  \
+    mrb_float z = mrb_float(regs[a]) OP_MATH_OP_##op_name c;                \
+    VM_SET_FLOAT_VALUE(regs[a], z);                                         \
+  }
 #endif
 #define OP_MATHILV(op_name)                                                 \
   /* a=local, b=working space, c=immediate */                               \
-  switch (mrb_type(regs[a])) {                                              \
-    case MRB_TT_INTEGER:                                                    \
-      {                                                                     \
-        mrb_int x = mrb_integer(regs[a]), y = (mrb_int)c, z;                \
-        if (mrb_int_##op_name##_overflow(x, y, &z)) {                       \
-          OP_MATH_OVERFLOW_INT(op_name,x,y);                                \
-        }                                                                   \
-        else {                                                              \
-          VM_SET_INT_VALUE(regs[a], z);                                     \
-        }                                                                   \
-      }                                                                     \
-      break;                                                                \
-    OP_MATHILV_CASE_FLOAT(op_name);                                         \
-    default:                                                                \
-      /* `a` is a local variable slot, not a temporary, so the L_SEND_SYM   \
-         path the other OP_MATH opcodes take cannot be used: it writes the  \
-         argument into regs[a+1] and lays the callee frame over the locals  \
-         from regs[a] on. `b` is the working space reserved for the call,   \
-         but a send set up there leaves its result in regs[b] and the       \
-         `MOVE local, temp` that used to copy it back is what the fusion    \
-         removed, so the call is made from C. It can move the stack, hence  \
-         the `ci` refresh before storing through `regs`. */                 \
-      {                                                                     \
-        int ai_ = mrb_gc_arena_save(mrb);                                   \
-        mrb_value arg_ = mrb_int_value(mrb, c);                             \
-        mrb_value v_ = mrb_funcall_argv(mrb, regs[a],                       \
-                                        MRB_OPSYM(op_name), 1, &arg_);      \
-        ci = mrb->c->ci;                                                    \
-        regs[a] = v_;                                                       \
-        mrb_gc_arena_restore(mrb, ai_);                                     \
-      }                                                                     \
-      break;                                                                \
+  if (mrb_likely(mrb_integer_p(regs[a]) &&                                  \
+                 !(mrb->bop_redefined & MRB_BOP_INTEGER(OP_MATH_BOP_##op_name)))) { \
+    mrb_int x = mrb_integer(regs[a]), y = (mrb_int)c, z;                    \
+    if (mrb_int_##op_name##_overflow(x, y, &z)) {                           \
+      OP_MATH_OVERFLOW_INT(op_name,x,y);                                    \
+    }                                                                       \
+    else {                                                                  \
+      VM_SET_INT_VALUE(regs[a], z);                                         \
+    }                                                                       \
+  }                                                                         \
+  OP_MATHILV_ELSE_FLOAT(op_name)                                            \
+  else {                                                                    \
+    /* `a` is a local variable slot, not a temporary, so the L_SEND_SYM     \
+       path the other OP_MATH opcodes take cannot be used: it writes the    \
+       argument into regs[a+1] and lays the callee frame over the locals    \
+       from regs[a] on. `b` is the working space reserved for the call,     \
+       but a send set up there leaves its result in regs[b] and the         \
+       `MOVE local, temp` that used to copy it back is what the fusion      \
+       removed, so the call is made from C. It can move the stack, hence    \
+       the `ci` refresh before storing through `regs`. */                   \
+    int ai_ = mrb_gc_arena_save(mrb);                                       \
+    mrb_value arg_ = mrb_int_value(mrb, c);                                 \
+    mrb_value v_ = mrb_funcall_argv(mrb, regs[a],                           \
+                                    MRB_OPSYM(op_name), 1, &arg_);          \
+    ci = mrb->c->ci;                                                        \
+    regs[a] = v_;                                                           \
+    mrb_gc_arena_restore(mrb, ai_);                                         \
   }                                                                         \
   NEXT
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -4321,13 +4321,15 @@ RETRY_TRY_BLOCK:
          in either. A Symbol is equal to nothing but itself, so it is answered
          here in full.
 
-         Neither answer may stand in for a redefined `==`: whether an Integer
-         or Float equals itself is then the redefinition's to say. While either
-         is redefined both shortcuts are skipped for every receiver, and the
-         comparison below sends `==` to whatever its type dispatch does not
-         answer. That costs a heap object its identity answer in that state
-         alone; the usual state pays one test. */
-      if (mrb_likely(!(mrb->bop_redefined & MRB_BOP_NUMERIC(MRB_BOP_EQ)))) {
+         Neither answer may stand in for a redefined `==`: whether an Integer,
+         Float or Symbol equals itself, or a Symbol anything else, is then the
+         redefinition's to say. While any of the three is redefined both
+         shortcuts are skipped for every receiver, and the comparison below
+         sends `==` to whatever its type dispatch does not answer. That costs
+         a heap object its identity answer in that state alone; the usual
+         state pays one test. */
+      if (mrb_likely(!(mrb->bop_redefined &
+                       (MRB_BOP_NUMERIC(MRB_BOP_EQ) | MRB_BOP_SYMBOL_EQ)))) {
         if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a])) {
           SET_TRUE_VALUE(regs[a]);
           NEXT;

--- a/src/vm.c
+++ b/src/vm.c
@@ -4227,14 +4227,19 @@ RETRY_TRY_BLOCK:
     }
 
 #define OP_CMP_BODY(op,v1,v2) (v1(regs[a]) op v2(regs[a+1]))
+#define OP_CMP_BOP_eq MRB_BOP_EQ
+#define OP_CMP_BOP_lt MRB_BOP_LT
+#define OP_CMP_BOP_le MRB_BOP_LE
+#define OP_CMP_BOP_gt MRB_BOP_GT
+#define OP_CMP_BOP_ge MRB_BOP_GE
 
 #ifdef MRB_NO_FLOAT
 #define value_nan_p(v) FALSE
 #define OP_CMP(op,sym) do {\
   int result;\
-  /* need to check if op is overridden */\
   if (mrb_likely(TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1])) == \
-                 TYPES2(MRB_TT_INTEGER,MRB_TT_INTEGER))) {\
+                 TYPES2(MRB_TT_INTEGER,MRB_TT_INTEGER) &&\
+                 !(mrb->bop_redefined & MRB_BOP_INTEGER(OP_CMP_BOP_##sym)))) {\
     result = OP_CMP_BODY(op,mrb_integer,mrb_integer);\
   }\
   else {\
@@ -4265,10 +4270,14 @@ RETRY_TRY_BLOCK:
 } while (0)
 #define OP_CMP(op, sym) do {\
   int result;\
-  /* need to check if op is overridden */\
   uint16_t tt = TYPES2(mrb_type(regs[a]),mrb_type(regs[a+1]));\
-  if (mrb_likely(tt == TYPES2(MRB_TT_INTEGER,MRB_TT_INTEGER))) {\
+  if (mrb_likely(tt == TYPES2(MRB_TT_INTEGER,MRB_TT_INTEGER) &&\
+                 !(mrb->bop_redefined & MRB_BOP_INTEGER(OP_CMP_BOP_##sym)))) {\
     result = OP_CMP_BODY(op,mrb_integer,mrb_integer);\
+  }\
+  else if (mrb_unlikely(mrb->bop_redefined & MRB_BOP_NUMERIC(OP_CMP_BOP_##sym))) {\
+    mid = MRB_OPSYM(sym);\
+    goto L_SEND_SYM;\
   }\
   else switch (tt) {\
   case TYPES2(MRB_TT_INTEGER,MRB_TT_FLOAT):\
@@ -4302,16 +4311,26 @@ RETRY_TRY_BLOCK:
          without the test below `Float::NAN == Float::NAN` answered true in a
          boxed build and false in `MRB_NO_BOXING`. The pair falls through to
          the comparison instead, which reads it as numbers and answers false
-         in either. */
-      if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a])) {
-        SET_TRUE_VALUE(regs[a]);
+         in either. A Symbol is equal to nothing but itself, so it is answered
+         here in full.
+
+         Neither answer may stand in for a redefined `==`: whether an Integer
+         or Float equals itself is then the redefinition's to say. While either
+         is redefined both shortcuts are skipped for every receiver, and the
+         comparison below sends `==` to whatever its type dispatch does not
+         answer. That costs a heap object its identity answer in that state
+         alone; the usual state pays one test. */
+      if (mrb_likely(!(mrb->bop_redefined & MRB_BOP_NUMERIC(MRB_BOP_EQ)))) {
+        if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a])) {
+          SET_TRUE_VALUE(regs[a]);
+          NEXT;
+        }
+        if (mrb_symbol_p(regs[a])) {
+          SET_FALSE_VALUE(regs[a]);
+          NEXT;
+        }
       }
-      else if (mrb_symbol_p(regs[a])) {
-        SET_FALSE_VALUE(regs[a]);
-      }
-      else {
-        OP_CMP(==,eq);
-      }
+      OP_CMP(==,eq);
       NEXT;
     }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -4106,6 +4106,13 @@ RETRY_TRY_BLOCK:
 #endif
 #define OP_MATH_CASE_STRING_add()                                           \
   case TYPES2(MRB_TT_STRING, MRB_TT_STRING):                                \
+    /* only for String itself: a subclass or singleton may override `+`,    \
+       and the slot is NULL while `String#+` is redefined, so one compare   \
+       rejects all three */                                                 \
+    if (mrb_unlikely(mrb_str_ptr(regs[a])->c != mrb->idx_class[MRB_IDX_OP_STR_ADD])) { \
+      mid = MRB_OPSYM(add);                                                 \
+      goto L_SEND_SYM;                                                      \
+    }                                                                       \
     regs[a] = mrb_str_plus(mrb, regs[a], regs[a+1]);                        \
     mrb_gc_arena_restore(mrb, ai);                                          \
     break

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -373,3 +373,16 @@ assert('a discarded interpolation leaves the register pointer where it was') do
   end.new
   assert_equal [[1], 2, 3], worker.run([1], 2, 3)
 end
+
+assert('adding or subtracting a literal zero still sends the operator') do
+  # `x + 0` compiled to nothing at all: the peephole that turns `x + n` into
+  # `OP_ADDI` dropped the instruction for a zero, so the receiver was handed
+  # back untouched whatever it was, and neither its `+` nor a `TypeError` for
+  # a receiver that has none ever ran.
+  assert_raise(TypeError) { 'a' + 0 }
+  assert_raise(NoMethodError) { 'a' - 0 }
+  assert_raise(NoMethodError) { nil + 0 }
+  x = 5
+  assert_equal 5, x + 0
+  assert_equal 5, x - 0
+end

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -527,4 +527,61 @@ assert('Float arithmetic redefined on Float itself reaches the redefinition') do
   assert_float 8.5, a
 end
 
+assert('Float comparison redefined on Float itself reaches the redefinition') do
+  # `OP_EQ`, `OP_LT`, `OP_LE`, `OP_GT` and `OP_GE` answer `a < b` from C for
+  # a Float receiver on the same terms as the arithmetic opcodes above, and
+  # `a == a` is answered without any comparison whenever the two hold the
+  # same value; see the Integer test.
+  Float.class_eval do
+    alias_method :__eq_before_test, :==
+    alias_method :__lt_before_test, :<
+    alias_method :__le_before_test, :<=
+    alias_method :__gt_before_test, :>
+    alias_method :__ge_before_test, :>=
+    def ==(other) [:eq, self, other] end
+    def <(other) [:lt, self, other] end
+    def <=(other) [:le, self, other] end
+    def >(other) [:gt, self, other] end
+    def >=(other) [:ge, self, other] end
+  end
+  begin
+    a = 7.5
+    b = 2.0
+    eq = a == b
+    same = a == a
+    lt = a < b
+    le = a <= b
+    gt = a > b
+    ge = a >= b
+    int_arg = a < 2
+    int_recv = 2 < a
+  ensure
+    Float.class_eval do
+      alias_method :==, :__eq_before_test
+      alias_method :<, :__lt_before_test
+      alias_method :<=, :__le_before_test
+      alias_method :>, :__gt_before_test
+      alias_method :>=, :__ge_before_test
+      if respond_to?(:remove_method, true)
+        remove_method :__eq_before_test, :__lt_before_test, :__le_before_test,
+                      :__gt_before_test, :__ge_before_test
+      end
+    end
+  end
+  assert_equal [:eq, 7.5, 2.0], eq
+  assert_equal [:eq, 7.5, 7.5], same
+  assert_equal [:lt, 7.5, 2.0], lt
+  assert_equal [:le, 7.5, 2.0], le
+  assert_equal [:gt, 7.5, 2.0], gt
+  assert_equal [:ge, 7.5, 2.0], ge
+  assert_equal [:lt, 7.5, 2], int_arg
+  assert_true int_recv
+  a = 7.5
+  b = 2.0
+  assert_false a == b
+  assert_true a == a
+  assert_false a < b
+  assert_true a >= b
+end
+
 end # const_defined?(:Float)

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -465,4 +465,66 @@ assert('Float literal underflow') do
   assert_equal(-0.0, -92170141183460469231731687303715884105729e-383)
 end
 
+assert('Float arithmetic redefined on Float itself reaches the redefinition') do
+  # `OP_ADD`, `OP_SUB`, `OP_MUL` and `OP_DIV` answer `a + b` from C for a
+  # Float receiver, and `OP_ADDI`, `OP_SUBI`, `OP_ADDILV` and `OP_SUBILV` do
+  # the same for an Integer immediate operand; see the Integer test. A
+  # redefinition on `Float` leaves an Integer receiver with a Float argument
+  # to `Integer#+`, which is not the operator replaced.
+  Float.class_eval do
+    alias_method :__add_before_test, :+
+    alias_method :__sub_before_test, :-
+    alias_method :__mul_before_test, :*
+    alias_method :__div_before_test, :/
+    def +(other) [:add, self, other] end
+    def -(other) [:sub, self, other] end
+    def *(other) [:mul, self, other] end
+    def /(other) [:div, self, other] end
+  end
+  begin
+    a = 7.5
+    b = 2.0
+    sum = a + b
+    diff = a - b
+    prod = a * b
+    quot = a / b
+    int_arg = a + 2
+    imm_sum = a + 1
+    imm_diff = a - 1
+    lv = a
+    lv += 1
+    lv_sum = lv
+    lv = a
+    lv -= 1
+    lv_diff = lv
+    int_recv = 2 + a
+  ensure
+    Float.class_eval do
+      alias_method :+, :__add_before_test
+      alias_method :-, :__sub_before_test
+      alias_method :*, :__mul_before_test
+      alias_method :/, :__div_before_test
+      if respond_to?(:remove_method, true)
+        remove_method :__add_before_test, :__sub_before_test,
+                      :__mul_before_test, :__div_before_test
+      end
+    end
+  end
+  assert_equal [:add, 7.5, 2.0], sum
+  assert_equal [:sub, 7.5, 2.0], diff
+  assert_equal [:mul, 7.5, 2.0], prod
+  assert_equal [:div, 7.5, 2.0], quot
+  assert_equal [:add, 7.5, 2], int_arg
+  assert_equal [:add, 7.5, 1], imm_sum
+  assert_equal [:sub, 7.5, 1], imm_diff
+  assert_equal [:add, 7.5, 1], lv_sum
+  assert_equal [:sub, 7.5, 1], lv_diff
+  assert_float 9.5, int_recv
+  a = 7.5
+  assert_float 9.5, a + 2.0
+  assert_float 8.5, a + 1
+  a += 1
+  assert_float 8.5, a
+end
+
 end # const_defined?(:Float)

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -551,3 +551,58 @@ assert('Integer arithmetic redefined on Integer itself reaches the redefinition'
   a += 1
   assert_equal 8, a
 end
+
+assert('Integer comparison redefined on Integer itself reaches the redefinition') do
+  # `OP_EQ`, `OP_LT`, `OP_LE`, `OP_GT` and `OP_GE` answer `a < b` from C for
+  # an Integer receiver on the same terms as the arithmetic opcodes above.
+  # `a == a` is answered without any comparison whenever the two hold the
+  # same value, which a redefined `Integer#==` must still be asked about.
+  Integer.class_eval do
+    alias_method :__eq_before_test, :==
+    alias_method :__lt_before_test, :<
+    alias_method :__le_before_test, :<=
+    alias_method :__gt_before_test, :>
+    alias_method :__ge_before_test, :>=
+    def ==(other) [:eq, self, other] end
+    def <(other) [:lt, self, other] end
+    def <=(other) [:le, self, other] end
+    def >(other) [:gt, self, other] end
+    def >=(other) [:ge, self, other] end
+  end
+  begin
+    a = 7
+    b = 2
+    eq = a == b
+    same = a == a
+    lt = a < b
+    le = a <= b
+    gt = a > b
+    ge = a >= b
+    mixed = a < 2.5 if Object.const_defined?(:Float)
+  ensure
+    Integer.class_eval do
+      alias_method :==, :__eq_before_test
+      alias_method :<, :__lt_before_test
+      alias_method :<=, :__le_before_test
+      alias_method :>, :__gt_before_test
+      alias_method :>=, :__ge_before_test
+      if respond_to?(:remove_method, true)
+        remove_method :__eq_before_test, :__lt_before_test, :__le_before_test,
+                      :__gt_before_test, :__ge_before_test
+      end
+    end
+  end
+  assert_equal [:eq, 7, 2], eq
+  assert_equal [:eq, 7, 7], same
+  assert_equal [:lt, 7, 2], lt
+  assert_equal [:le, 7, 2], le
+  assert_equal [:gt, 7, 2], gt
+  assert_equal [:ge, 7, 2], ge
+  assert_equal [:lt, 7, 2.5], mixed if Object.const_defined?(:Float)
+  a = 7
+  b = 2
+  assert_false a == b
+  assert_true a == a
+  assert_false a < b
+  assert_true a >= b
+end

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -606,3 +606,73 @@ assert('Integer comparison redefined on Integer itself reaches the redefinition'
   assert_false a < b
   assert_true a >= b
 end
+
+assert('Integer operators on two literals reach a redefinition') do
+  # The compiler used to compute `1 + 2`, `1 << 2` and their kin on two
+  # Integer literals while compiling, as well as `~1` and `i = 7; i += 1`, so
+  # no opcode and no send were left for a redefined operator to reach; CRuby
+  # computes them when they run. A literal keeps absorbing its sign, `-1`
+  # being a literal in CRuby as well.
+  Integer.class_eval do
+    alias_method :__add_before_test, :+
+    alias_method :__sub_before_test, :-
+    alias_method :__mul_before_test, :*
+    alias_method :__div_before_test, :/
+    alias_method :__lshift_before_test, :<<
+    alias_method :__rshift_before_test, :>>
+    alias_method :__mod_before_test, :%
+    alias_method :__and_before_test, :&
+    alias_method :__or_before_test, :|
+    alias_method :__xor_before_test, :^
+    alias_method :__inv_before_test, :~
+    def +(other) [:add, self, other] end
+    def -(other) [:sub, self, other] end
+    def *(other) [:mul, self, other] end
+    def /(other) [:div, self, other] end
+    def <<(other) [:lshift, self, other] end
+    def >>(other) [:rshift, self, other] end
+    def %(other) [:mod, self, other] end
+    def &(other) [:and, self, other] end
+    def |(other) [:or, self, other] end
+    def ^(other) [:xor, self, other] end
+    def ~() [:inv, self] end
+  end
+  begin
+    got = [1 + 2, 5 - 3, 5 * 3, 6 / 3, 1 << 2, 8 >> 1, 7 % 3, 6 & 3, 6 | 3, 6 ^ 3, ~1]
+    i = 7
+    i += 1
+    incremented = i
+    negative = -1
+  ensure
+    Integer.class_eval do
+      alias_method :+, :__add_before_test
+      alias_method :-, :__sub_before_test
+      alias_method :*, :__mul_before_test
+      alias_method :/, :__div_before_test
+      alias_method :<<, :__lshift_before_test
+      alias_method :>>, :__rshift_before_test
+      alias_method :%, :__mod_before_test
+      alias_method :&, :__and_before_test
+      alias_method :|, :__or_before_test
+      alias_method :^, :__xor_before_test
+      alias_method :~, :__inv_before_test
+      if respond_to?(:remove_method, true)
+        remove_method :__add_before_test, :__sub_before_test, :__mul_before_test,
+                      :__div_before_test, :__lshift_before_test, :__rshift_before_test,
+                      :__mod_before_test, :__and_before_test, :__or_before_test,
+                      :__xor_before_test, :__inv_before_test
+      end
+    end
+  end
+  assert_equal [[:add, 1, 2], [:sub, 5, 3], [:mul, 5, 3], [:div, 6, 3],
+                [:lshift, 1, 2], [:rshift, 8, 1], [:mod, 7, 3],
+                [:and, 6, 3], [:or, 6, 3], [:xor, 6, 3], [:inv, 1]], got
+  assert_equal [:add, 7, 1], incremented
+  assert_equal(-1, negative)
+  assert_equal 3, 1 + 2
+  assert_equal 4, 1 << 2
+  assert_equal(-2, ~1)
+  i = 7
+  i += 1
+  assert_equal 8, i
+end

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -487,3 +487,67 @@ assert('Integer.__ensure converts its argument without dispatching') do
   assert_raise(TypeError) { Integer.__ensure("2") }
   assert_raise(TypeError) { Integer.__ensure(nil) }
 end
+
+assert('Integer arithmetic redefined on Integer itself reaches the redefinition') do
+  # `OP_ADD`, `OP_SUB`, `OP_MUL` and `OP_DIV` answer `a + b` from C for an
+  # Integer receiver, `OP_ADDI` and `OP_SUBI` answer `a + 1` and `OP_ADDILV`
+  # and `OP_SUBILV` answer `a += 1` on a local the same way. They may only do
+  # so while `Integer#+` and its kin are still the builtins they reimplement,
+  # which `mrb->bop_redefined` records the moment one is replaced, so a
+  # redefinition installed on `Integer` itself is honored as in CRuby. The
+  # results are read before the operators are put back because mrblib itself
+  # counts with them.
+  Integer.class_eval do
+    alias_method :__add_before_test, :+
+    alias_method :__sub_before_test, :-
+    alias_method :__mul_before_test, :*
+    alias_method :__div_before_test, :/
+    def +(other) [:add, self, other] end
+    def -(other) [:sub, self, other] end
+    def *(other) [:mul, self, other] end
+    def /(other) [:div, self, other] end
+  end
+  begin
+    a = 7
+    b = 2
+    sum = a + b
+    diff = a - b
+    prod = a * b
+    quot = a / b
+    imm_sum = a + 1
+    imm_diff = a - 1
+    lv = a
+    lv += 1
+    lv_sum = lv
+    lv = a
+    lv -= 1
+    lv_diff = lv
+    mixed = a + 2.5 if Object.const_defined?(:Float)
+  ensure
+    Integer.class_eval do
+      alias_method :+, :__add_before_test
+      alias_method :-, :__sub_before_test
+      alias_method :*, :__mul_before_test
+      alias_method :/, :__div_before_test
+      if respond_to?(:remove_method, true)
+        remove_method :__add_before_test, :__sub_before_test,
+                      :__mul_before_test, :__div_before_test
+      end
+    end
+  end
+  assert_equal [:add, 7, 2], sum
+  assert_equal [:sub, 7, 2], diff
+  assert_equal [:mul, 7, 2], prod
+  assert_equal [:div, 7, 2], quot
+  assert_equal [:add, 7, 1], imm_sum
+  assert_equal [:sub, 7, 1], imm_diff
+  assert_equal [:add, 7, 1], lv_sum
+  assert_equal [:sub, 7, 1], lv_diff
+  assert_equal [:add, 7, 2.5], mixed if Object.const_defined?(:Float)
+  a = 7
+  b = 2
+  assert_equal 9, a + b
+  assert_equal 8, a + 1
+  a += 1
+  assert_equal 8, a
+end

--- a/test/t/string.rb
+++ b/test/t/string.rb
@@ -191,6 +191,43 @@ assert('String#[] redefined on String itself reaches the redefinition') do
   assert_equal 'e', 'hello'[1]
 end
 
+assert('String#+ redefined on String itself reaches the redefinition') do
+  # `OP_ADD` answers `s + t` from C for two Strings, which it may only do
+  # while `String#+` is still the builtin it reimplements and the receiver's
+  # class is exactly `String`. It tests the receiver against `mrb->idx_class[]`
+  # on the same terms as the `[]` test above, so a redefinition installed on
+  # `String` itself is honored as in CRuby, and so is one on a subclass or a
+  # singleton, which the type tag alone could not tell from `String`. The
+  # results are read before the operator is put back because the assertions
+  # themselves build strings.
+  String.class_eval do
+    alias_method :__add_before_test, :+
+    def +(other)
+      [:overridden, self, other]
+    end
+  end
+  begin
+    s = 'hello'
+    sum = s + ' world'
+    literal = 'a' + 'b'
+  ensure
+    String.class_eval do
+      alias_method :+, :__add_before_test
+      remove_method :__add_before_test if respond_to?(:remove_method, true)
+    end
+  end
+  assert_equal [:overridden, 'hello', ' world'], sum
+  assert_equal [:overridden, 'a', 'b'], literal
+  assert_equal 'hello world', 'hello' + ' world'
+
+  sub = Class.new(String) { def +(other) [:subclass, self, other] end }.new('hi')
+  assert_equal [:subclass, 'hi', '!'], sub + '!'
+  single = 'hi'
+  def single.+(other) [:singleton, self, other] end
+  assert_equal [:singleton, 'hi', '!'], single + '!'
+  assert_equal 'hi!', 'hi' + '!'
+end
+
 assert('String#[]= redefined on String itself reaches the redefinition') do
   # `OP_SETIDX` answers `s[0] = 'X'` from C whenever the receiver's class is
   # exactly `String`, on the same terms as the `[]` test above: it tests the

--- a/test/t/symbol.rb
+++ b/test/t/symbol.rb
@@ -17,6 +17,36 @@ assert('Symbol#===', '15.2.11.3.1') do
   assert_false :abc === :cba
 end
 
+assert('Symbol#== redefined on Symbol itself reaches the redefinition') do
+  # `OP_EQ` answers `:a == x` from the identity of its two operands whenever
+  # the receiver is a Symbol, which it may only do while `Symbol#==` is still
+  # the builtin it stands in for; `mrb->bop_redefined` records the moment it
+  # is replaced, so a redefinition installed on `Symbol` is honored as in
+  # CRuby. The results are read before the operator is put back because the
+  # assertions themselves compare symbols.
+  Symbol.class_eval do
+    alias_method :__eq_before_test, :==
+    def ==(other) [:eq, self, other] end
+  end
+  begin
+    a = :abc
+    same = a == :abc
+    different = a == :xyz
+    string = a == 'abc'
+  ensure
+    Symbol.class_eval do
+      alias_method :==, :__eq_before_test
+      remove_method :__eq_before_test if respond_to?(:remove_method, true)
+    end
+  end
+  assert_equal [:eq, :abc, :abc], same
+  assert_equal [:eq, :abc, :xyz], different
+  assert_equal [:eq, :abc, 'abc'], string
+  assert_true :abc == :abc
+  assert_false :abc == :xyz
+  assert_false :abc == 'abc'
+end
+
 assert('Symbol#to_s', '15.2.11.3.3') do
   assert_equal  'abc', :abc.to_s
 end


### PR DESCRIPTION
## Summary

`OP_ADD`, `OP_LT`, `OP_EQ` and their kin answer `+`, `<`, `==` and the rest from C for an Integer, Float, String or Symbol receiver on the type tags alone, and the compiler computes `1 + 2` before any opcode exists, so a redefinition of the operator on those classes was silently ignored; `doc/limitations.md` listed it under "Operator modification". Each such (class, operator) pair now records whether the builtin still stands, on the terms `OP_GETIDX` already uses for `[]`, the opcodes send the operator once it does not, the compiler leaves two literals to the opcode, and the entry is gone.

## Changes

| File | What |
| --- | --- |
| `include/mruby.h` | `enum mrb_bop` and the `MRB_BOP_*` bit macros; `bop_redefined` and `bop_builtin[]` at the end of `mrb_state`; a `MRB_IDX_OP_STR_ADD` slot for `String#+` |
| `include/mruby/internal.h` | `mrb_idx_op_init()` / `mrb_idx_op_update()` renamed `mrb_builtin_op_init()` / `mrb_builtin_op_update()`, since they serve both kinds of slot now |
| `src/class.c` | records the builtin of each pair after core initialization and rechecks every slot whose name changed at the four method-table changes that already recheck the index slots |
| `src/state.c` | the renamed init call |
| `src/vm.c` | `OP_ADD` / `OP_SUB` / `OP_MUL` / `OP_DIV`, `OP_ADDI` / `OP_SUBI`, `OP_ADDILV` / `OP_SUBILV`, `OP_LT` / `OP_LE` / `OP_GT` / `OP_GE` and `OP_EQ` consult the bits; `OP_ADD` compares a String receiver's class against the new slot |
| `mrbgems/mruby-compiler/src/codegen.c` | `x + 0` is emitted rather than dropped; an operator on two Integer literals, `~` on one, and the `LOADI`, `ADDI` pair are no longer computed at compile time |
| `doc/limitations.md` | the "Operator modification" entry is removed |
| `test/t/integer.rb`, `test/t/float.rb`, `test/t/string.rb`, `test/t/symbol.rb`, `test/t/codegen.rb`, `mrbgems/mruby-metaprog/test/metaprog.rb` | one test per class and operator group, the literal forms, `x + 0`, and the `prepend` form |

### A bit per pair for the immediates, a slot for String

An Integer, Float or Symbol is an immediate value whose type tag is its class, so there is no class pointer for an `idx_class` slot to disarm. Each (class, operator) pair owns a bit of `mrb->bop_redefined` instead: clear while the operator resolves, from the core class, to the `mrb_method_t` recorded after core initialization, set once it does not. Validity is the resolved method rather than a "was assigned" flag, exactly as for the index slots, so `def`, `alias_method`, `undef_method`, `remove_method`, visibility changes and `prepend` are covered without being enumerated, and aliasing the original back re-arms the bit.

A String is a heap object whose subclass instances and singletons carry the same type tag, so the numeric bits cannot tell them apart; `String#+` gets a slot in `mrb->idx_class[]` like `String#[]`, and one compare of the receiver's class pointer rejects the redefinition, the subclass and the singleton alike.

### What the hot paths pay

The Integer/Integer path tests its own bit next to the type pair it already tested, so a redefinition on `Float` costs it nothing. Every other path tests the Integer and Float bits together and sends while either is set, which hands the other numeric class a send it did not need for as long as the redefinition stands. Asking which receiver it has before sending was tried and measured: gcc threads that type test into the dispatch that follows and duplicates it, at 2.5 KB of `mrb_vm_exec` for the comparison opcodes alone, and the exactness bought nothing outside that state. `OP_EQ` withholds its identity and Symbol answers from every receiver while `Integer#==`, `Float#==` or `Symbol#==` is redefined, which sends `obj == obj` for a heap object in that state alone; the usual state pays one test.

### The compiler leaves two literals alone

`1 + 2`, `1 << 2` and their kin on two Integer literals, `~1`, and `i = 7; i += 1` were computed while compiling, so no opcode and no send was left for a redefined operator to reach; CRuby computes all of them when they run. The tree already declined to flip `x + -1` into `x - 1` because that would change the method sent on user override (#2557), and folding the expression away changes it into no send at all. The bytecode generated for mrblib and for every gem's mrblib is byte for byte the same with and without the folding, so nothing shipped depended on it. A literal still absorbs a leading `-` or `+`, which is a literal in CRuby's parser as well, and `x + n` still becomes `OP_ADDI`.

The same peephole emitted nothing for `x + 0`, so `"a" + 0` answered `"a"` and `nil + 0` answered `nil`; it now emits the `OP_ADDI`, and the receiver is sent the operator it was owed.

## Behaviour

```ruby
class Integer
  def +(other) :hooked end
end
a = 1
a + 2   # CRuby: :hooked, mruby: :hooked (was 3)
1 + 2   # CRuby: :hooked, mruby: :hooked (was 3)
"a" + 0 # CRuby: TypeError, mruby: TypeError (was "a")
```

Every form the tests cover (`a + b`, `a + 1`, `a += 1`, a Float argument, the five comparisons, `a == a`, `String#+` on the class, a subclass and a singleton, `Symbol#==`, the ten binary operators and `~` on literals, and a module prepended to `Integer`) answers as CRuby does. Core methods that mruby implements in Ruby, `Kernel#p` and `Array#each` among them, count with these operators too, so a redefinition that changes what they return breaks them where CRuby's C implementations are unaffected; the tests put each operator back before asserting.

Out of scope but different from CRuby: a heap object is still taken for equal to itself by `OP_EQ` before its `==` is asked, which is what `rb_equal()` does and what `Enumerable#count` has a test pinning, so a `==` that denies its own receiver is overruled by `obj == obj` where CRuby's `opt_eq` would call it.

## Speed

callgrind instructions per iteration, `Ir(2N) - Ir(N)` over `N`, gcc 13.3 at the default `-O3`, host config. Each body sits in `while i < n; ...; i += 1; end`, so every row includes the loop's own `OP_ADDILV`, `OP_LT` and `OP_JMPNOT`.

```ruby
n = ARGV[0].to_i
i = 0
x = 0
while i < n
  x = i + i        # one of the bodies below
  i += 1
end
```

| body | master | this PR | delta |
| --- | --- | --- | --- |
| `x = i + i` | 320 | 316 | -4 |
| `x = i + 3` | 276 | 272 | -4 |
| `i += 1` alone | 196 | 188 | -8 |
| `x = f + f` (Floats) | 355 | 348 | -7 |
| `x = i - i` | 320 | 316 | -4 |
| `x = i / 3` | 346 | 341 | -5 |
| `x = i < n` | 304 | 298 | -6 |
| `x = i == n` | 326 | 324 | -2 |
| `x = i == i` | 291 | 282 | -9 |
| `x = f == g` (Floats) | 359 | 360 | +1 |
| `x = s == :b` (Symbol) | 292 | 281 | -11 |
| `x = o == o` (Object) | 295 | 286 | -9 |
| `x = a + b` (Strings) | 557 | 556 | -1 |

The immediate and local forms used to dispatch on the receiver's type through a `switch` after the Integer test; the if/else chain that the bit test turned them into lays out better under gcc, which is where the decreases come from. An operator on two Integer literals now executes an `OP_ADDI` or a send where it used to load a constant; no shipped code had one.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,987,958 | 1,988,902 | +944 |
| bintest | 1,395,014 | 1,393,974 | -1,040 |
| cxx_abi | 1,428,681 | 1,427,257 | -1,424 |
| byte-string | 1,357,894 | 1,357,094 | -800 |
| ascii-ctype | 1,380,502 | 1,379,702 | -800 |
| no-float | 1,320,062 | 1,318,846 | -1,216 |
| no-bigint | 1,279,446 | 1,278,486 | -960 |

In the bintest build `vm.o` grows by 624 bytes and `class.o` by 1,024, while `codegen.o` loses 2,704 with the folding and its overflow, division and shift helpers.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2699 | 2625 | 74 | 0 | 0 | 0 |
| full-debug | 2947 | 2936 | 11 | 0 | 0 | 0 |
| bintest | 2947 | 2927 | 20 | 0 | 0 | 0 |
| cxx_abi | 2947 | 2927 | 20 | 0 | 0 | 0 |
| byte-string | 2859 | 2785 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2931 | 2909 | 22 | 0 | 0 | 0 |
| no-float | 2680 | 2583 | 97 | 0 | 0 | 0 |
| no-bigint | 2899 | 2866 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO. The same seven builds under `i686-linux-gnu-gcc` (`MRB_INT32`, with and without bigint) pass with 0 KO and 0 Crash as well.

Every commit builds and passes the host suite on its own. The new tests redefine each operator on the core class, read the results, and put the operator back before asserting, because mrblib itself counts with them. The `prepend` form needs `remove_method` to be undone, so it lives with mruby-metaprog.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/string.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Redefining arithmetic and comparison operators on Integer, Float, Symbol, or String now consistently takes effect during execution.
  - Operator overrides added through inheritance, modules, subclasses, or singleton classes are correctly honored and restored after removal.
  - Expressions involving literal values now preserve normal operator dispatch, including zero operands and redefined methods.

- **Documentation**
  - Updated operator behavior documentation to reflect current runtime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->