### PR TITLE
vm.c: ask a class's own `==` about the receiver itself

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -350,6 +350,13 @@ enum mrb_bop {
 #define MRB_BOP_SYMBOL_EQ_SLOT (2 * MRB_BOP_COUNT)         /* Symbol#==  */
 #define MRB_BOP_SYMBOL_EQ   (1u << MRB_BOP_SYMBOL_EQ_SLOT)
 #define MRB_BOP_SLOT_COUNT  (MRB_BOP_SYMBOL_EQ_SLOT + 1)
+/* `nil`, `true` and `false` are immediate as well, so `OP_EQ` reads no class
+   of theirs, but their classes are ordinary heap ones whose own `==` is
+   recorded by `MRB_FL_CLASS_EQ_DEFINED`.  This bit carries that flag of the
+   three into the mask the opcode already tests.  It is not a slot: nothing
+   records a builtin for it and nothing rechecks it, since nothing clears the
+   flag it mirrors. */
+#define MRB_BOP_NIL_TRUE_FALSE_EQ (1u << MRB_BOP_SLOT_COUNT)
 
 #ifdef MRB_USE_TASK_SCHEDULER
 struct mrb_task;
@@ -498,7 +505,9 @@ struct mrb_state {
      slot to disarm; each (class, operator) pair owns a bit here instead, clear
      while the operator still resolves to the builtin recorded in
      `bop_builtin` and set once it does not.  Bit numbers are the `MRB_BOP_*`
-     macros, which also index `bop_builtin`. */
+     macros, which also index `bop_builtin`; the one bit above them,
+     `MRB_BOP_NIL_TRUE_FALSE_EQ`, mirrors a class flag instead of a builtin
+     and indexes nothing. */
   uint32_t bop_redefined;
   mrb_method_t bop_builtin[MRB_BOP_SLOT_COUNT];
 

--- a/include/mruby/class.h
+++ b/include/mruby/class.h
@@ -57,7 +57,8 @@ mrb_class(mrb_state *mrb, mrb_value v)
    19:   is_prepended
    18:   is_origin
    17:   is_inherited (used by method cache)
-   7-16: unused
+   16:   eq_defined (a class among the ancestors defines its own `==`)
+   7-15: unused
    6:    prohibit Class#allocate
    0-5:  instance type
 */
@@ -72,6 +73,15 @@ mrb_class(mrb_state *mrb, mrb_value v)
   }\
 } while (0)
 #define MRB_FL_CLASS_IS_INHERITED (1 << 17)
+/* A class among the ancestors defines a `==` that is not the builtin one.
+   `OP_EQ` answers `obj == obj` from the identity of the operands only for a
+   class without it; with it the class's own `==` is asked, as CRuby asks it.
+   Set by `mrb_define_method_raw()` and carried to subclasses, singleton
+   classes and includers; never cleared, since a stale flag only costs a
+   send whose answer is the same. `OP_EQ` reads the flag itself for a heap
+   receiver; for `nil`, `true` and `false`, which carry no class pointer, it
+   reads `MRB_BOP_NIL_TRUE_FALSE_EQ`, which the flag of the three sets. */
+#define MRB_FL_CLASS_EQ_DEFINED (1 << 16)
 #define MRB_INSTANCE_TT_MASK (0x1F)
 #define MRB_SET_INSTANCE_TT(c, tt) ((c)->flags = (((c)->flags & ~MRB_INSTANCE_TT_MASK) | (char)(tt)))
 #define MRB_INSTANCE_TT(c) (enum mrb_vtype)((c)->flags & MRB_INSTANCE_TT_MASK)

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -111,6 +111,7 @@ struct mrb_backtrace_location {
 /* gc */
 size_t mrb_gc_mark_mt(mrb_state*, struct RClass*);
 int mrb_equal_in_c(mrb_state*, mrb_value, mrb_value);
+void mrb_gc_each_live_object(mrb_state*, int (*)(mrb_state*, struct RBasic*, void*), void*);
 void mrb_gc_free_mt(mrb_state*, struct RClass*);
 
 /* hash */

--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -110,6 +110,7 @@ struct mrb_backtrace_location {
 
 /* gc */
 size_t mrb_gc_mark_mt(mrb_state*, struct RClass*);
+int mrb_equal_in_c(mrb_state*, mrb_value, mrb_value);
 void mrb_gc_free_mt(mrb_state*, struct RClass*);
 
 /* hash */

--- a/mrbgems/mruby-enum-ext/mrbgem.rake
+++ b/mrbgems/mruby-enum-ext/mrbgem.rake
@@ -2,4 +2,5 @@ MRuby::Gem::Specification.new('mruby-enum-ext') do |spec|
   spec.license = 'MIT'
   spec.author  = 'mruby developers'
   spec.summary = 'Enumerable module extension'
+  spec.add_test_dependency 'mruby-fiber', core: 'mruby-fiber'
 end

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -249,7 +249,10 @@ module Enumerable
       end
     else
       self.each do |*val|
-        count += 1 if val.__svalue == v
+        if r = val.__svalue_eq(v)
+          r = val.__svalue == v if :send == r
+          count += 1 if r
+        end
       end
     end
     count
@@ -752,7 +755,10 @@ module Enumerable
       end
     else
       self.each do |*e|
-        return idx if e.__svalue == val
+        if r = e.__svalue_eq(val)
+          r = e.__svalue == val if :send == r
+          return idx if r
+        end
         idx += 1
       end
     end

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -378,13 +378,48 @@ assert('Enumerable#count - an argument decides over a block') do
   assert_equal 1, (1..4).count(2) {|x| true }
   assert_equal 1, ({a: 1, b: 2}).count([:a, 1]) {|x| true }
 
-  # an element is taken for equal to itself, `==` reaching it through OP_EQ
+  # an element is taken for equal to itself, as `rb_equal()` takes it
   never = Class.new { def ==(other); false; end }.new
   one = Class.new do
     include Enumerable
     define_method(:each) {|&b| b.call(never) }
   end.new
   assert_equal 1, one.count(never)
+end
+
+assert('Enumerable#count and #find_index take an element for equal to itself') do
+  # CRuby compares an element with `rb_equal()`, which answers for an object
+  # and itself before it asks `==`, so a `==` that denies its own receiver does
+  # not hide it, and a `==` that accepts anything is still asked about another
+  # object. `Array#count` walks in C and compares the same way; the walk made
+  # in Ruby compares through `Array#__svalue_eq`, which answers what
+  # `mrb_equal()` answers in C and hands a `==` written in Ruby back.
+  never = Class.new { def ==(other); false; end }.new
+  always = Class.new { def ==(other); true; end }.new
+  e = Class.new do
+    include Enumerable
+    define_method(:each) {|&b| b.call(never); b.call(always) }
+  end.new
+  assert_equal 2, e.count(never)        # itself, and `always` accepts it too
+  assert_equal 1, e.count(always)
+  assert_equal 1, e.count(Object.new)
+  assert_equal 0, e.find_index(never)
+  assert_equal 1, e.find_index(always)
+  assert_equal 1, e.find_index(Object.new)
+  assert_nil [never].find_index(Object.new)
+end
+
+assert('Enumerable#count sends a `==` written in Ruby in the VM it runs in') do
+  # `Array#__svalue_eq` answers `:send` for such a `==` instead of calling it
+  # from C, so a `Fiber.yield` inside it has no C frame to cross, as in CRuby.
+  yielder = Class.new { def ==(other); Fiber.yield(:asked); true; end }.new
+  e = Class.new do
+    include Enumerable
+    define_method(:each) {|&b| b.call(yielder) }
+  end.new
+  f = Fiber.new { e.count(Object.new) }
+  assert_equal :asked, f.resume
+  assert_equal 1, f.resume
 end
 
 assert("Array#count with a NaN") do

--- a/mrbgems/mruby-hash-ext/mrbgem.rake
+++ b/mrbgems/mruby-hash-ext/mrbgem.rake
@@ -3,4 +3,5 @@ MRuby::Gem::Specification.new('mruby-hash-ext') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'Hash class extension'
   spec.add_dependency 'mruby-array-ext', core: 'mruby-array-ext'
+  spec.add_test_dependency 'mruby-fiber', core: 'mruby-fiber'
 end

--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -233,7 +233,8 @@ class Hash
   def <(hash)
     raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size < hash.size and all? {|key, val|
-      hash.key?(key) and hash[key] == val
+      r = hash.__value_eq(key, val)
+      :send == r ? val == hash[key] : r
     }
   end
 
@@ -253,7 +254,8 @@ class Hash
   def <=(hash)
     raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size <= hash.size and all? {|key, val|
-      hash.key?(key) and hash[key] == val
+      r = hash.__value_eq(key, val)
+      :send == r ? val == hash[key] : r
     }
   end
 
@@ -273,7 +275,8 @@ class Hash
   def >(hash)
     raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size > hash.size and hash.all? {|key, val|
-      key?(key) and self[key] == val
+      r = __value_eq(key, val)
+      :send == r ? val == self[key] : r
     }
   end
 
@@ -293,7 +296,8 @@ class Hash
   def >=(hash)
     raise TypeError, "can't convert #{hash.class} to Hash" unless Hash === hash
     size >= hash.size and hash.all? {|key, val|
-      key?(key) and self[key] == val
+      r = __value_eq(key, val)
+      :send == r ? val == self[key] : r
     }
   end
 

--- a/mrbgems/mruby-hash-ext/src/hash_ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash_ext.c
@@ -333,6 +333,30 @@ hash_key(mrb_state *mrb, mrb_value hash)
 
 /*
  *  call-seq:
+ *     hsh.__value_eq(key, value) -> true, false or :send
+ *
+ *  Internal method: whether `value` is equal to what `hsh` holds under `key`,
+ *  with `value` as the receiver of `==`, answered as `mrb_equal_in_c()`
+ *  answers it, and `false` when `hsh` has no such key. `Hash#<` and its three
+ *  siblings compare each pair through it, so a value is taken for equal to
+ *  itself before its `==` is asked, as CRuby's `rb_equal()` takes it, and a
+ *  `==` written in Ruby is sent by the caller in the VM it is already in.
+ */
+static mrb_value
+hash_value_eq(mrb_state *mrb, mrb_value hash)
+{
+  mrb_value key, val;
+
+  mrb_get_args(mrb, "oo", &key, &val);
+  mrb_value v = mrb_hash_fetch(mrb, hash, key, mrb_undef_value());
+  if (mrb_undef_p(v)) return mrb_false_value();
+  int r = mrb_equal_in_c(mrb, val, v);
+  if (r < 0) return mrb_symbol_value(MRB_SYM(send));
+  return mrb_bool_value(r);
+}
+
+/*
+ *  call-seq:
  *     hsh.__merge(*others) -> hsh
  *
  *  Merges multiple hashes into hsh. This is an internal method
@@ -376,6 +400,7 @@ static const mrb_mt_entry hash_ext_rom_entries[] = {
   MRB_MT_ENTRY(hash_except,    MRB_SYM(except), MRB_ARGS_ANY()),
   MRB_MT_ENTRY(hash_key,       MRB_SYM(key), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(hash_merge,     MRB_SYM(__merge), MRB_ARGS_ANY()),
+  MRB_MT_ENTRY(hash_value_eq,  MRB_SYM(__value_eq), MRB_ARGS_REQ(2)),
 };
 
 void

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -217,6 +217,37 @@ assert('Hash#<') do
   assert_false(h2 < h2)
 end
 
+assert('Hash#< and its siblings take a value for equal to itself') do
+  # CRuby compares the two values with `rb_equal()`, the subset's value as the
+  # receiver, which answers for an object and itself before it asks `==`. The
+  # four operators compare each pair through `Hash#__value_eq`, which answers
+  # what `mrb_equal()` answers in C and hands a `==` written in Ruby back.
+  never = Class.new { def ==(other); false; end }.new
+  always = Class.new { def ==(other); true; end }.new
+  h1 = {a: never}
+  h2 = {a: never, b: always}
+
+  assert_true(h1 < h2)
+  assert_true(h1 <= h2)
+  assert_true(h2 > h1)
+  assert_true(h2 >= h1)
+  assert_true(h1 <= h1)
+  assert_true(h1 >= h1)
+  assert_false(h1 <= {a: Object.new})
+  assert_true({a: always} <= {a: Object.new})
+  assert_false({a: Object.new} <= {a: always})
+  assert_false({a: never} <= {b: never})
+end
+
+assert('Hash#<= sends a `==` written in Ruby in the VM it runs in') do
+  # `Hash#__value_eq` answers `:send` for such a `==` instead of calling it
+  # from C, so a `Fiber.yield` inside it has no C frame to cross, as in CRuby.
+  yielder = Class.new { def ==(other); Fiber.yield(:asked); true; end }.new
+  f = Fiber.new { {a: yielder} <= {a: Object.new} }
+  assert_equal :asked, f.resume
+  assert_true f.resume
+end
+
 assert('Hash#<=') do
   h1 = {a:1, b:2}
   h2 = {a:1, b:2, c:3}

--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -166,7 +166,10 @@ module Enumerable
   # ISO 15.3.2.2.10
   def include?(obj)
     self.each {|*val|
-      return true if val.__svalue == obj
+      if r = val.__svalue_eq(obj)
+        r = val.__svalue == obj if :send == r
+        return true if r
+      end
     }
     false
   end

--- a/src/array.c
+++ b/src/array.c
@@ -2073,6 +2073,21 @@ mrb_ary_svalue(mrb_state *mrb, mrb_value ary)
   }
 }
 
+/* internal method: whether the value `__svalue` reads off this array is equal
+   to `other`, as `mrb_equal_in_c()` answers it: `true`, `false`, or `:send`
+   when the element's `==` is written in Ruby, for the caller, which is Ruby,
+   to send in the VM it is already in. The Enumerable methods written in Ruby
+   compare an element through it, so they take it for equal to itself before
+   its `==` is asked, as CRuby's `rb_equal()` does and as `Array#count` does
+   in C, and nest no VM for a `==` a class defines. */
+static mrb_value
+mrb_ary_svalue_eq(mrb_state *mrb, mrb_value ary)
+{
+  int r = mrb_equal_in_c(mrb, mrb_ary_svalue(mrb, ary), mrb_get_arg1(mrb));
+  if (r < 0) return mrb_symbol_value(MRB_SYM(send));
+  return mrb_bool_value(r);
+}
+
 /*
  * call-seq:
  *   array.delete(obj) -> deleted_object
@@ -2622,6 +2637,7 @@ static const mrb_mt_entry array_rom_entries[] = {
   MRB_MT_ENTRY(mrb_ary_to_s,         MRB_SYM(inspect),         MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_ary_sort_bang,    MRB_SYM_B(sort),          MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_ary_svalue,       MRB_SYM(__svalue),        MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(mrb_ary_svalue_eq,    MRB_SYM(__svalue_eq),     MRB_ARGS_REQ(1)),
 };
 
 void

--- a/src/class.c
+++ b/src/class.c
@@ -380,6 +380,7 @@ prepare_singleton_class(mrb_state *mrb, struct RBasic *o)
     sc->super = o->c;
     prepare_singleton_class(mrb, (struct RBasic*)sc);
   }
+  sc->flags |= sc->super->flags & MRB_FL_CLASS_EQ_DEFINED;
   o->c = sc;
   mrb_field_write_barrier(mrb, (struct RBasic*)o, (struct RBasic*)sc);
   mrb_obj_iv_set(mrb, (struct RObject*)sc, MRB_SYM(__attached__), mrb_obj_value(o));
@@ -1030,6 +1031,50 @@ mt_writable(mrb_state *mrb, struct RClass *frozen, struct RClass *table)
   return h;
 }
 
+static int
+eq_defined_walk(mrb_state *mrb, struct RBasic *obj, void *data)
+{
+  switch (obj->tt) {
+  case MRB_TT_CLASS: case MRB_TT_SCLASS: case MRB_TT_MODULE: {
+    struct RClass *k = (struct RClass*)obj;
+    if (k->flags & MRB_FL_CLASS_EQ_DEFINED) break;
+    for (struct RClass *s = k->super; s; s = s->super) {
+      struct RClass *r = (s->tt == MRB_TT_ICLASS) ? s->c : s;
+      if (r->flags & MRB_FL_CLASS_EQ_DEFINED) {
+        k->flags |= MRB_FL_CLASS_EQ_DEFINED;
+        break;
+      }
+    }
+    break;
+  }
+  default:
+    break;
+  }
+  return MRB_EACH_OBJ_OK;
+}
+
+/* `c` answers `==` by a method of its own from now on, so every class that
+   has `c` among its ancestors loses the identity answer of `OP_EQ`. A class
+   or singleton class made later copies the flag from its superclass and an
+   includer takes it from the module, so the heap is walked only for a class
+   that already has subclasses or a module that may already be included.
+   `nil`, `true` and `false` are immediate, so `OP_EQ` has no class of theirs
+   to read the flag from; the flag of the three is mirrored into a bit of
+   `bop_redefined`, which the opcode tests for every receiver anyway. */
+static void
+eq_defined_mark(mrb_state *mrb, struct RClass *c)
+{
+  if (c->flags & MRB_FL_CLASS_EQ_DEFINED) return;
+  c->flags |= MRB_FL_CLASS_EQ_DEFINED;
+  if ((c->flags & MRB_FL_CLASS_IS_INHERITED) || c->tt == MRB_TT_MODULE) {
+    mrb_gc_each_live_object(mrb, eq_defined_walk, NULL);
+  }
+  if ((mrb->nil_class->flags | mrb->true_class->flags |
+       mrb->false_class->flags) & MRB_FL_CLASS_EQ_DEFINED) {
+    mrb->bop_redefined |= MRB_BOP_NIL_TRUE_FALSE_EQ;
+  }
+}
+
 MRB_API void
 mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_t m)
 {
@@ -1090,6 +1135,7 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
   if (!mrb->bootstrapping) {
     mc_clear_by_id(mrb, mid);
     mrb_builtin_op_update(mrb, mid);
+    if (mid == MRB_OPSYM(eq)) eq_defined_mark(mrb, named);
   }
   if (modfunc) {
     /* module_function scope: also define a public method on the singleton
@@ -2053,6 +2099,7 @@ boot_defclass(mrb_state *mrb, struct RClass *super, enum mrb_vtype tt)
     c->super = super;
     mrb_field_write_barrier(mrb, (struct RBasic*)c, (struct RBasic*)super);
     c->flags |= MRB_FL_CLASS_IS_INHERITED;
+    c->flags |= super->flags & MRB_FL_CLASS_EQ_DEFINED;
   }
   else {
     // limited to cases where BasicObject class is defined during mruby initialization
@@ -2093,6 +2140,7 @@ static int
 include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, struct RClass *m, int search_super)
 {
   struct RClass *ic;
+  struct RClass *m0 = m;
   void *klass_mt = find_origin(c)->mt;
 
   while (m) {
@@ -2136,6 +2184,9 @@ include_module_at(mrb_state *mrb, struct RClass *c, struct RClass *ins_pos, stru
     /* An included or prepended module can carry both operators, and it is not
        one method name that changed, so recheck every slot. */
     mrb_builtin_op_update(mrb, 0);
+    /* and it can carry a `==` of its own, or of a module it includes, which
+       marked it in turn */
+    if (m0->flags & MRB_FL_CLASS_EQ_DEFINED) eq_defined_mark(mrb, c);
   }
   return 0;
 }
@@ -2951,6 +3002,12 @@ mrb_idx_op_rearm(mrb_state *mrb, enum mrb_idx_op_slot slot)
  * `mrb->bop_redefined` instead, clear while the operator still resolves to the
  * builtin recorded in `mrb->bop_builtin` and set once it does not.  Validity
  * is judged exactly as for the index slots above.
+ *
+ * `nil`, `true` and `false` are immediate too, but their classes are ordinary
+ * heap ones, so `eq_defined_mark()` above records a `==` of their own as it
+ * does for any other class and mirrors the flag into
+ * `MRB_BOP_NIL_TRUE_FALSE_EQ`, the one bit past the slots.  Nothing here
+ * arms or rechecks it.
  */
 
 static const mrb_sym bop_mids[MRB_BOP_COUNT] = {

--- a/src/gc.c
+++ b/src/gc.c
@@ -2363,6 +2363,28 @@ gc_each_objects(mrb_state *mrb, mrb_gc *gc, mrb_each_object_callback *callback, 
   }
 }
 
+/* Walks the heap without collecting first and hands the callback the objects
+   the collector has not condemned. `mrb_objspace_each_objects()` runs a full
+   GC so that no dead object is handed out, which a caller that only reads
+   class headers and allocates nothing has no use for; a dead object the
+   sweep has not reached can hold a pointer into a page already freed, and
+   `is_dead()` is what tells it from a live one during the sweep. */
+void
+mrb_gc_each_live_object(mrb_state *mrb, mrb_each_object_callback *callback, void *data)
+{
+  mrb_gc *gc = &mrb->gc;
+
+  for (mrb_heap_page *page = gc->heaps; page != NULL; page = page->next) {
+    RVALUE *p = page->objects;
+    for (int i = 0; i < MRB_HEAP_PAGE_SIZE; i++) {
+      struct RBasic *obj = &p[i].as.basic;
+      if (is_dead(gc, obj)) continue;
+      if ((*callback)(mrb, obj, data) == MRB_EACH_OBJ_BREAK)
+        return;
+    }
+  }
+}
+
 void
 mrb_objspace_each_objects(mrb_state *mrb, mrb_each_object_callback *callback, void *data)
 {

--- a/src/object.c
+++ b/src/object.c
@@ -8,6 +8,7 @@
 #include <mruby/class.h>
 #include <mruby/numeric.h>
 #include <mruby/string.h>
+#include <mruby/proc.h>
 #include <mruby/class.h>
 #include <mruby/internal.h>
 #include <string.h>
@@ -71,43 +72,65 @@ mrb_obj_equal(mrb_state *mrb, mrb_value v1, mrb_value v2)
 }
 
 /*
- * Checks for equality between `obj1` and `obj2`.
+ * What `mrb_equal()` answers without entering the VM: TRUE or FALSE once the
+ * pair is answered here or by a `==` written in C, and -1 when the `==` of
+ * `obj1` is written in Ruby, which only the VM can run. A C method that the
+ * VM called hands such a pair back to Ruby, which sends `==` in the VM it is
+ * already in rather than nesting one, as `Array#__svalue_eq` does.
  *
- * It first uses `mrb_obj_eq` for an identity check. If that fails,
- * it handles cases like mixed integer/float comparisons.
- * If `MRB_USE_BIGINT` is defined, it also considers comparisons
- * involving BigInts against Integers, other BigInts, or Floats.
- * Finally, if none of the above apply, it attempts to call the
- * `==` operator (MRB_OPSYM(eq)) on `obj1` with `obj2` as an argument,
- * unless `obj1`'s `==` method is the default `mrb_obj_equal_m`.
+ * An object is equal to itself before `==` is asked, as `rb_equal()` takes
+ * it in CRuby. A pair of Integers or of Symbols is answered from the values
+ * while the builtin `==` of the class stands, which `mrb->bop_redefined`
+ * records as it does for `OP_EQ`; a mixed Integer and Float pair, and a
+ * BigInt against a number, are compared as numbers; and an `obj1` whose `==`
+ * is the default `mrb_obj_equal_m` is unequal to whatever it is not identical
+ * to.
+ */
+int
+mrb_equal_in_c(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
+{
+  if (mrb_obj_eq(mrb, obj1, obj2)) return TRUE;
+  if (mrb_integer_p(obj1) && mrb_integer_p(obj2)) {
+    if (!(mrb->bop_redefined & MRB_BOP_INTEGER(MRB_BOP_EQ))) return FALSE;
+  }
+#ifndef MRB_NO_FLOAT
+  /* value mixing with integer and float */
+  else if (mrb_integer_p(obj1) && mrb_float_p(obj2)) {
+    return mrb_int_float_cmp(mrb_integer(obj1), mrb_float(obj2)) == 0;
+  }
+  else if (mrb_float_p(obj1) && mrb_integer_p(obj2)) {
+    return mrb_int_float_cmp(mrb_integer(obj2), mrb_float(obj1)) == 0;
+  }
+#endif
+  else if (mrb_symbol_p(obj1) && mrb_symbol_p(obj2)) {
+    if (!(mrb->bop_redefined & MRB_BOP_SYMBOL_EQ)) return FALSE;
+  }
+#ifdef MRB_USE_BIGINT
+  else if (mrb_bigint_p(obj1) &&
+      (mrb_integer_p(obj2) || mrb_bigint_p(obj2) || mrb_float_p(obj2))) {
+    return mrb_bint_cmp(mrb, obj1, obj2) == 0;
+  }
+#endif
+  struct RClass *c = mrb_class(mrb, obj1);
+  mrb_method_t m = mrb_method_search_vm(mrb, &c, MRB_OPSYM(eq));
+  if (MRB_METHOD_UNDEF_P(m) || !MRB_METHOD_CFUNC_P(m)) return -1;
+  if (MRB_METHOD_CFUNC(m) == mrb_obj_equal_m) return FALSE;
+  mrb_value result = mrb_funcall_argv(mrb, obj1, MRB_OPSYM(eq), 1, &obj2);
+  return mrb_test(result);
+}
+
+/*
+ * Checks for equality between `obj1` and `obj2` as `rb_equal()` does in
+ * CRuby: what `mrb_equal_in_c()` answers, and otherwise the answer of the
+ * `==` written in Ruby, called from here.
  */
 MRB_API mrb_bool
 mrb_equal(mrb_state *mrb, mrb_value obj1, mrb_value obj2)
 {
-  if (mrb_obj_eq(mrb, obj1, obj2)) return TRUE;
-#ifndef MRB_NO_FLOAT
-  /* value mixing with integer and float */
-  else if (mrb_integer_p(obj1) && mrb_float_p(obj2)) {
-    if (mrb_int_float_cmp(mrb_integer(obj1), mrb_float(obj2)) == 0)
-      return TRUE;
-  }
-  else if (mrb_float_p(obj1) && mrb_integer_p(obj2)) {
-    if (mrb_int_float_cmp(mrb_integer(obj2), mrb_float(obj1)) == 0)
-      return TRUE;
-  }
-#endif
-#ifdef MRB_USE_BIGINT
-  else if (mrb_bigint_p(obj1) &&
-      (mrb_integer_p(obj2) || mrb_bigint_p(obj2) || mrb_float_p(obj2))) {
-    if (mrb_bint_cmp(mrb, obj1, obj2) == 0)
-      return TRUE;
-  }
-#endif
-  else if (!mrb_func_basic_p(mrb, obj1, MRB_OPSYM(eq), mrb_obj_equal_m)) {
-    mrb_value result = mrb_funcall_argv(mrb, obj1, MRB_OPSYM(eq), 1, &obj2);
-    if (mrb_test(result)) return TRUE;
-  }
-  return FALSE;
+  int r = mrb_equal_in_c(mrb, obj1, obj2);
+  if (r >= 0) return (mrb_bool)r;
+  mrb_value result = mrb_funcall_argv(mrb, obj1, MRB_OPSYM(eq), 1, &obj2);
+  return mrb_test(result);
 }
 
 /*

--- a/src/vm.c
+++ b/src/vm.c
@@ -4321,16 +4321,25 @@ RETRY_TRY_BLOCK:
          in either. A Symbol is equal to nothing but itself, so it is answered
          here in full.
 
-         Neither answer may stand in for a redefined `==`: whether an Integer,
-         Float or Symbol equals itself, or a Symbol anything else, is then the
-         redefinition's to say. While any of the three is redefined both
-         shortcuts are skipped for every receiver, and the comparison below
-         sends `==` to whatever its type dispatch does not answer. That costs
-         a heap object its identity answer in that state alone; the usual
-         state pays one test. */
+         Neither answer may stand in for a `==` that is not the builtin one.
+         Whether an Integer, Float or Symbol equals itself, or a Symbol
+         anything else, is a redefinition's to say: while any of the three is
+         redefined both shortcuts are skipped for every receiver, and the
+         comparison below sends `==` to whatever its type dispatch does not
+         answer. `nil`, `true` and `false` are read from the same mask, by the
+         bit `MRB_FL_CLASS_EQ_DEFINED` on their classes is mirrored into.
+         Whether a heap object equals itself is its own class's to say once a
+         class among its ancestors defines a `==`, which that flag on the
+         class records: the identity answer is withheld from that object
+         alone, and `obj == obj` sends `==` as CRuby's `opt_eq` calls it. The
+         usual state pays one mask test and, for a heap object, one flag
+         test. */
       if (mrb_likely(!(mrb->bop_redefined &
-                       (MRB_BOP_NUMERIC(MRB_BOP_EQ) | MRB_BOP_SYMBOL_EQ)))) {
-        if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a])) {
+                       (MRB_BOP_NUMERIC(MRB_BOP_EQ) | MRB_BOP_SYMBOL_EQ |
+                        MRB_BOP_NIL_TRUE_FALSE_EQ)))) {
+        if (mrb_obj_eq(mrb, regs[a], regs[a+1]) && !value_nan_p(regs[a]) &&
+            (mrb_immediate_p(regs[a]) ||
+             !(mrb_obj_ptr(regs[a])->c->flags & MRB_FL_CLASS_EQ_DEFINED))) {
           SET_TRUE_VALUE(regs[a]);
           NEXT;
         }

--- a/test/t/basicobject.rb
+++ b/test/t/basicobject.rb
@@ -8,3 +8,87 @@ end
 assert('BasicObject superclass') do
   assert_nil(BasicObject.superclass)
 end
+
+assert('BasicObject#== defined by a class is asked about the receiver itself') do
+  # `OP_EQ` answers `obj == obj` from the identity of its operands, which it
+  # may only do while the builtin `==` is what would be asked: CRuby's `opt_eq`
+  # calls a `==` a class defines, for the receiver itself included.
+  # `MRB_FL_CLASS_EQ_DEFINED` on a class records that a class among its
+  # ancestors defines one. It is set when the method is defined and carried to
+  # the subclasses, singleton classes and includers made afterwards, and to
+  # those that exist already.
+  plain = Object.new
+  assert_true plain == plain
+
+  own = Class.new { def ==(other); :own; end }
+  o = own.new
+  assert_equal :own, o == o
+  assert_false o != o
+  after = Class.new(own).new
+  assert_equal :own, after == after
+
+  base = Class.new
+  before = Class.new(base).new
+  base.class_eval { def ==(other); :base; end }
+  assert_equal :base, before == before
+
+  single = Object.new
+  def single.==(other); :single; end
+  assert_equal :single, single == single
+
+  aliased = Class.new { def same?(other); :aliased; end; alias_method :==, :same? }.new
+  assert_equal :aliased, aliased == aliased
+
+  defined = Class.new { define_method(:==) {|other| :defined } }.new
+  assert_equal :defined, defined == defined
+
+  mod = Module.new { def ==(other); :mod; end }
+  included = Class.new { include mod }.new
+  assert_equal :mod, included == included
+  prepended = Class.new { prepend mod }.new
+  assert_equal :mod, prepended == prepended
+
+  late = Module.new
+  with_late = Class.new { include late }
+  early = with_late.new
+  late.module_eval { def ==(other); :late; end }
+  assert_equal :late, early == early
+  via_sub = Class.new(with_late).new
+  assert_equal :late, via_sub == via_sub
+
+  # a builtin `==` keeps the identity answer, Comparable's among them, which
+  # CRuby answers for the receiver itself before it asks `<=>`
+  cmp = Class.new { include Comparable; def <=>(other); nil; end }.new
+  assert_true cmp == cmp
+end
+
+assert('BasicObject#== defined on NilClass, TrueClass or FalseClass') do
+  # `nil`, `true` and `false` are immediate values, so `OP_EQ` has no class
+  # pointer of theirs to read `MRB_FL_CLASS_EQ_DEFINED` from. The flag of the
+  # three classes is mirrored into a bit of the mask the opcode tests for
+  # every receiver, so a `==` they define is asked about the receiver itself,
+  # as CRuby's `opt_eq` asks it, while the answer an Integer or a Symbol gives
+  # itself is left to the bit of its own.
+  assert_true nil == nil
+  assert_true true == true
+  assert_true false == false
+
+  # every answer is taken while the redefinition stands and checked once it is
+  # put back, so that no assertion runs under a `==` of this test's own
+  answers = []
+  [[NilClass, nil, :nil_eq], [TrueClass, true, :true_eq],
+   [FalseClass, false, :false_eq]].each do |klass, value, answer|
+    klass.class_eval { alias_method :__eq_before_test, :== }
+    begin
+      klass.class_eval { define_method(:==) {|other| answer } }
+      answers << (value == value) << (value == 1)
+      answers << (1 == 1) << (:a == :a) << (:a == :b)
+    ensure
+      klass.class_eval { alias_method :==, :__eq_before_test }
+    end
+    answers << (value == value)
+  end
+  assert_equal [:nil_eq, :nil_eq, true, true, false, true,
+                :true_eq, :true_eq, true, true, false, true,
+                :false_eq, :false_eq, true, true, false, true], answers
+end

--- a/test/t/enumerable.rb
+++ b/test/t/enumerable.rb
@@ -80,6 +80,25 @@ assert('Enumerable#include?', '15.3.2.2.10') do
   assert_false [1,2,3,4,5,6,7,8,9].include?(0)
 end
 
+assert('Enumerable#include? takes an element for equal to itself') do
+  # CRuby compares an element with `rb_equal()`, which answers for an object
+  # and itself before it asks `==`; the walk made in Ruby compares through
+  # `Array#__svalue_eq`, which answers what `mrb_equal()` answers in C and
+  # hands a `==` written in Ruby back to be sent here.
+  never = Class.new { def ==(other); false; end }.new
+  always = Class.new { def ==(other); true; end }.new
+  e = Class.new do
+    include Enumerable
+    define_method(:each) {|&b| b.call(never); b.call(always) }
+  end.new
+  assert_true e.include?(never)
+  assert_true e.include?(Object.new)
+  assert_false Class.new {
+    include Enumerable
+    define_method(:each) {|&b| b.call(never) }
+  }.new.include?(Object.new)
+end
+
 assert('Enumerable#inject', '15.3.2.2.11') do
   assert_equal 21, [1,2,3,4,5,6].inject() {|s, n| s + n}
   assert_equal 22, [1,2,3,4,5,6].inject(1) {|s, n| s + n}

--- a/test/t/float.rb
+++ b/test/t/float.rb
@@ -555,6 +555,7 @@ assert('Float comparison redefined on Float itself reaches the redefinition') do
     ge = a >= b
     int_arg = a < 2
     int_recv = 2 < a
+    index = [a, b].index(b)    # `mrb_equal()` asks the redefinition
   ensure
     Float.class_eval do
       alias_method :==, :__eq_before_test
@@ -569,6 +570,7 @@ assert('Float comparison redefined on Float itself reaches the redefinition') do
     end
   end
   assert_equal [:eq, 7.5, 2.0], eq
+  assert_equal 0, index
   assert_equal [:eq, 7.5, 7.5], same
   assert_equal [:lt, 7.5, 2.0], lt
   assert_equal [:le, 7.5, 2.0], le

--- a/test/t/integer.rb
+++ b/test/t/integer.rb
@@ -579,6 +579,9 @@ assert('Integer comparison redefined on Integer itself reaches the redefinition'
     gt = a > b
     ge = a >= b
     mixed = a < 2.5 if Object.const_defined?(:Float)
+    # `Array#index` compares through `mrb_equal()`, which answers an Integer
+    # pair from the values only while the builtin stands
+    index = [a].index(b)
   ensure
     Integer.class_eval do
       alias_method :==, :__eq_before_test
@@ -598,6 +601,7 @@ assert('Integer comparison redefined on Integer itself reaches the redefinition'
   assert_equal [:le, 7, 2], le
   assert_equal [:gt, 7, 2], gt
   assert_equal [:ge, 7, 2], ge
+  assert_equal 0, index
   assert_equal [:lt, 7, 2.5], mixed if Object.const_defined?(:Float)
   a = 7
   b = 2

--- a/test/t/symbol.rb
+++ b/test/t/symbol.rb
@@ -33,6 +33,7 @@ assert('Symbol#== redefined on Symbol itself reaches the redefinition') do
     same = a == :abc
     different = a == :xyz
     string = a == 'abc'
+    index = [:abc, :xyz].index(:xyz)    # `mrb_equal()` asks the redefinition
   ensure
     Symbol.class_eval do
       alias_method :==, :__eq_before_test
@@ -42,6 +43,7 @@ assert('Symbol#== redefined on Symbol itself reaches the redefinition') do
   assert_equal [:eq, :abc, :abc], same
   assert_equal [:eq, :abc, :xyz], different
   assert_equal [:eq, :abc, 'abc'], string
+  assert_equal 0, index
   assert_true :abc == :abc
   assert_false :abc == :xyz
   assert_false :abc == 'abc'


### PR DESCRIPTION
## Summary

`OP_EQ` takes an object for equal to itself before its `==` is asked, so a `==` that a class defines is never asked about its own receiver, where CRuby's `opt_eq` calls it; #7526 lists it as the one difference from CRuby it leaves. A class now records that a class among its ancestors defines a `==`, and `OP_EQ` withholds the identity answer from that class alone, at no cost to any other. A heap receiver reads that flag off its class; `nil`, `true` and `false` carry no class pointer to read it from, so the flag of their three classes is mirrored into the mask the opcode tests already.

## Changes

| File | What |
| --- | --- |
| `include/mruby/class.h` | `MRB_FL_CLASS_EQ_DEFINED`: a class among the ancestors defines a `==` of its own |
| `include/mruby.h` | `MRB_BOP_NIL_TRUE_FALSE_EQ`: the one bit past the `bop_redefined` slots, which the flag of `NilClass`, `TrueClass` and `FalseClass` is mirrored into |
| `src/class.c` | sets the flag where a `==` lands, copies it to a subclass and a singleton class at creation and to an includer at inclusion, walks the live classes for a class that already has subclasses or a module that may already be included, and mirrors the flag of the three immediate classes into `bop_redefined` |
| `include/mruby/internal.h`, `src/gc.c` | `mrb_gc_each_live_object()`, the walk without the full GC that `mrb_objspace_each_objects()` runs first; `mrb_equal_in_c()` declared |
| `src/vm.c` | `OP_EQ` reads the flag off a heap receiver's class after the identity test it already passed, and answers `nil`, `true` and `false` from the mask it tests already |
| `src/object.c` | `mrb_equal_in_c()`, what `mrb_equal()` answers without entering the VM: the identity, an Integer or Symbol pair from the values while the builtin `==` stands, a `==` written in C; `mrb_equal()` calls a `==` written in Ruby itself, as before |
| `src/array.c` | `Array#__svalue_eq`: the block value read as `__svalue` reads it, answered by `mrb_equal_in_c()`, `:send` for a `==` written in Ruby |
| `mrblib/enum.rb`, `mrbgems/mruby-enum-ext/mrblib/enum.rb` | `Enumerable#include?`, `#count` and `#find_index` compare through it |
| `mrbgems/mruby-enum-ext/mrbgem.rake`, `mrbgems/mruby-hash-ext/mrbgem.rake` | mruby-fiber as a test dependency, for the test that no VM is nested |
| `mrbgems/mruby-hash-ext/src/hash_ext.c`, `mrbgems/mruby-hash-ext/mrblib/hash.rb` | `Hash#__value_eq`: a value against what the other hash holds under a key, answered the same way; `<`, `<=`, `>` and `>=` compare each pair through it |
| `test/t/basicobject.rb`, `test/t/enumerable.rb`, `test/t/integer.rb`, `test/t/float.rb`, `test/t/symbol.rb`, `mrbgems/mruby-enum-ext/test/enum.rb`, `mrbgems/mruby-hash-ext/test/hash.rb` | every way a `==` reaches a class, the walks that take an element for equal to itself, and the redefinition reaching `mrb_equal()` |

### A flag on the class, read after the identity test

The identity answer is what makes `obj == obj` free of a send, and it is the right answer for every class whose `==` is a builtin, since every builtin `==` is reflexive apart from a NaN's. Asking the method table whether the receiver's `==` is the builtin would cost the usual object a cache lookup on every identical pair; a bit in the class's `flags` costs it two loads and a test, after the identity test it has already passed, and an immediate value never reads it at all. `MRB_FL_CLASS_EQ_DEFINED` means "a class among the ancestors defines a `==`", so it is conservative: it is never cleared, because a stale flag costs a send whose answer is the same, and a `==` defined and then removed is the one case that pays it.

### Carrying the flag

`mrb_define_method_raw()` sets it on the class the method lands on, which covers `def`, `define_method`, `alias_method` and a C definition alike, and only after bootstrapping, so the `==` methods of the core classes and of mrblib do not count. A subclass and a singleton class copy it from their superclass at creation, and an includer takes it from the module at inclusion, so the usual order of events never walks anything. A `==` defined on a class that already has subclasses, or on a module, which may already be included, is the case that does: the live classes are walked once and each that finds a flagged class among its ancestors is flagged. `mrb_objspace_each_objects()` runs a full GC before it walks so that no dead object is handed out; `mrb_gc_each_live_object()` skips instead what the sweep has not reached, which is where a pointer into a page already freed can sit, and hands out nothing else, since the walk reads class headers and allocates nothing.

### The three immediate receivers

`nil`, `true` and `false` carry no class pointer, so `OP_EQ` has nothing to read the flag from, and CRuby's `opt_eq` calls a `==` they define about the receiver itself as it does for any other object. Their classes are ordinary heap classes, so `eq_defined_mark()` records a `==` of their own as it does for every class and mirrors the flag of the three into `MRB_BOP_NIL_TRUE_FALSE_EQ`, the one bit past the `bop_redefined` slots. `OP_EQ` tests that mask for every receiver already, so the three cost the opcode nothing and are answered the way the slots answer an Integer, Float or Symbol: while one of them has a `==` of its own the shortcuts are skipped for every receiver, and the comparison below sends `==` to what its type dispatch does not answer. A Symbol keeps the identity answer while `Symbol#==` is the builtin, as CRuby keeps it, and so does an Integer or a Float.

The bit mirrors a class flag rather than a builtin, so it has no `bop_builtin` entry and nothing arms or rechecks it, as nothing clears the flag it mirrors.

### The walks written in Ruby

CRuby compares an element with `rb_equal()`, which takes an object for equal to itself before it asks `==`, so a `==` that denies its own receiver does not hide it from `Enumerable#count`, `#include?` or `#find_index`, and `Hash#<` and its siblings compare two values the same way. The mruby walks written in Ruby compared with `==` and relied on `OP_EQ` answering the identical pair before the method was reached.

They compare through `Array#__svalue_eq` now, which reads the block value as `__svalue` does and answers what `mrb_equal()` answers without entering the VM: `true` or `false` from the identity, from the values of an Integer or Symbol pair while the builtin `==` stands, or from a `==` written in C, and `:send` for a `==` written in Ruby, which the walk then sends in the VM it is already in. The walk tests the answer for truth first, so a miss costs the send and one register move, and only a hit asks `:send == r`, which `OP_EQ` answers for a Symbol receiver without a send; a `Fiber.yield` inside such a `==` has no C frame to cross, as it had none before and has none in CRuby. `Hash#__value_eq` answers the same for a value and what the other hash holds under its key, the subset's value as the receiver as in CRuby, in place of the `key?` and `[]` sends of each pair.

`mrb_equal()` sent `==` to a pair of Integers that was not the same value, a call per element for `Array#count` and every other C walk; `mrb_equal_in_c()` answers a pair of Integers or of Symbols from the values while the builtin `==` stands, which `mrb->bop_redefined` records as it does for `OP_EQ`. Two Floats are still sent it, since unboxing them here costs more code than the send.

## Behaviour

```ruby
class Foo
  def ==(other) :foo end
end
foo = Foo.new
foo == foo                     # CRuby: :foo, mruby: :foo (was true)

class NilClass
  def ==(other) :nil end
end
nil == nil                     # CRuby: :nil, mruby: :nil (was true)
1 == 1                         # CRuby: true, mruby: true
:a == :a                       # CRuby: true, mruby: true

never = Class.new { def ==(other) false end }.new
e = Class.new { include Enumerable; define_method(:each) {|&b| b.call(never) } }.new
e.count(never)                 # CRuby: 1, mruby: 1 (now through mrb_equal(), as Array#count)
{a: never} <= {a: never}       # CRuby: true, mruby: true
```

The flag reaches the receiver through a subclass made before or after the definition, a singleton class, `define_method`, `alias_method`, a module included or prepended, and a `==` added to a module after its inclusion; the test walks each, for a `NilClass`, `TrueClass` or `FalseClass` receiver as well. A class whose `==` is a builtin keeps the identity answer, Comparable's among them, which CRuby answers for the receiver itself before it asks `<=>`.

Out of scope but different from CRuby: `Comparable#==` itself, reached by an explicit send, asks `<=>` about the receiver and itself where CRuby's `cmp_equal()` answers `true` first.

## Speed

callgrind instructions per iteration, `Ir(2N) - Ir(N)` over `N`, gcc 13.3 at the default `-O3`, host config. Each body sits in `while i < n; ...; i += 1; end`, so every row includes the loop's own `OP_ADDILV`, `OP_LT` and `OP_JMPNOT`.

```ruby
n = ARGV[0].to_i
i = 0
x = 0
while i < n
  x = o == o       # one of the bodies below
  i += 1
end
```

| body | master | this PR | delta |
| --- | --- | --- | --- |
| `x = o == o` (Object) | 286 | 286 | +0 |
| `x = i == n` | 324 | 323 | -1 |
| `x = i == i` | 282 | 279 | -3 |
| `x = f == g` (Floats) | 360 | 359 | -1 |
| `x = s == :b` (Symbol) | 281 | 279 | -2 |
| `x = o == o` (`nil`) | 284 | 281 | -3 |
| `x = o == o` (`true`) | 282 | 279 | -3 |
| `x = i + i` | 316 | 316 | +0 |
| `x = i < n` | 298 | 298 | +0 |
| `x = a + b` (Strings) | 556 | 556 | +0 |
| `x = e.count(3)` (ten Integers) | 12,023 | 12,414 | +391 |
| `x = e.count(v)` (ten objects, `v` one of them) | 21,576 | 20,538 | -1,037 |
| `x = e.include?(10)` (ten Integers) | 11,404 | 11,775 | +371 |

The Enumerable rows use a class that includes Enumerable and yields ten Integers, or ten distinct objects, from `each`; `count(3)` and `include?(10)` scan all ten. `Array#__svalue_eq` replaces the `__svalue` send and the `OP_EQ` that followed, answers two different Integers without a send, and keeps its answer in a local for the hit path, which is the register move a miss pays.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,988,966 | 1,990,870 | +1,904 |
| bintest | 1,394,230 | 1,396,710 | +2,480 |
| cxx_abi | 1,426,953 | 1,429,049 | +2,096 |
| byte-string | 1,357,350 | 1,359,590 | +2,240 |
| ascii-ctype | 1,379,958 | 1,382,198 | +2,240 |
| no-float | 1,318,798 | 1,322,238 | +3,440 |
| no-bigint | 1,278,486 | 1,280,918 | +2,432 |

In the bintest build `class.o` grows by 1,072 bytes with the flag's setting, carrying and mirroring, `object.o` by 672 with `mrb_equal_in_c()`, which looks the `==` up itself where `mrb_func_basic_p()` did it out of line, `vm.o` by 272 with the test in `OP_EQ`, `gc.o` by 160 with the walk, and `hash_ext.o` by 160 and `array.o` by 144 with the two helpers; the bytecode of the walks adds 288 bytes of `.rodata` over mrblib and the two gems. The mirrored bit is a wider constant in a mask the opcode already tests, so `vm.o` is what it was without it.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2707 | 2633 | 74 | 0 | 0 | 0 |
| full-debug | 2955 | 2944 | 11 | 0 | 0 | 0 |
| bintest | 2955 | 2935 | 20 | 0 | 0 | 0 |
| cxx_abi | 2955 | 2935 | 20 | 0 | 0 | 0 |
| byte-string | 2867 | 2793 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2939 | 2917 | 22 | 0 | 0 | 0 |
| no-float | 2688 | 2591 | 97 | 0 | 0 | 0 |
| no-bigint | 2906 | 2873 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO. The same seven builds under `i686-linux-gnu-gcc` (`MRB_INT32`, with and without bigint) pass with 0 KO and 0 Crash as well.

Both commits build and pass the host suite on their own. The first makes the walks compare through `mrb_equal_in_c()` while `OP_EQ` still answers the identical pair, and the second withholds that answer; the `Enumerable#count` test that pinned the identity answer through `OP_EQ` pins it through `mrb_equal()` now, and a `Fiber.yield` inside a `==` written in Ruby, reached through `Enumerable#count` and through `Hash#<=`, pins that no VM is nested. The `basicobject.rb` test defines `==` in every way a class can acquire one and reads `obj == obj` for each, and a second one defines it on `NilClass`, `TrueClass` and `FalseClass` in turn: it collects the answers while the definition stands and checks them once the builtin is aliased back, so that no assertion of the suite runs under a `==` of the test's own, and it reads `1 == 1` and `:a == :a` under each to pin that the other immediate receivers keep their own answers.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/string.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Equality comparisons now consistently honor user-defined `==` methods, including self-comparisons.
  - Improved equality handling for `Enumerable#include?`, `count`, and `find_index`.
  - Improved Hash subset and superset comparisons for custom equality behavior.
  - Numeric, symbol, and boolean comparisons now correctly respect redefined equality methods.

- **Tests**
  - Added coverage across arrays, enumerables, hashes, classes, modules, singleton classes, fibers, and built-in numeric types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->