### PR TITLE
class.c: spell the `Symbol#==` slot of `bop_redefined` once

### DIFF
--- a/include/mruby.h
+++ b/include/mruby.h
@@ -347,8 +347,9 @@ enum mrb_bop {
 #define MRB_BOP_INTEGER(op) (1u << (op))                  /* Integer#op */
 #define MRB_BOP_FLOAT(op)   (1u << (MRB_BOP_COUNT + (op))) /* Float#op   */
 #define MRB_BOP_NUMERIC(op) (MRB_BOP_INTEGER(op) | MRB_BOP_FLOAT(op))
-#define MRB_BOP_SYMBOL_EQ   (1u << (2 * MRB_BOP_COUNT))    /* Symbol#==  */
-#define MRB_BOP_SLOT_COUNT  (2 * MRB_BOP_COUNT + 1)
+#define MRB_BOP_SYMBOL_EQ_SLOT (2 * MRB_BOP_COUNT)         /* Symbol#==  */
+#define MRB_BOP_SYMBOL_EQ   (1u << MRB_BOP_SYMBOL_EQ_SLOT)
+#define MRB_BOP_SLOT_COUNT  (MRB_BOP_SYMBOL_EQ_SLOT + 1)
 
 #ifdef MRB_USE_TASK_SCHEDULER
 struct mrb_task;

--- a/src/class.c
+++ b/src/class.c
@@ -2963,7 +2963,7 @@ static struct RClass*
 bop_class(mrb_state *mrb, int slot)
 {
   if (slot < MRB_BOP_COUNT) return mrb->integer_class;
-  if (slot == 2 * MRB_BOP_COUNT) return mrb->symbol_class;
+  if (slot == MRB_BOP_SYMBOL_EQ_SLOT) return mrb->symbol_class;
 #ifdef MRB_NO_FLOAT
   return NULL;
 #else
@@ -2974,7 +2974,7 @@ bop_class(mrb_state *mrb, int slot)
 static mrb_sym
 bop_mid(int slot)
 {
-  return slot == 2 * MRB_BOP_COUNT ? MRB_OPSYM(eq) : bop_mids[slot % MRB_BOP_COUNT];
+  return slot == MRB_BOP_SYMBOL_EQ_SLOT ? MRB_OPSYM(eq) : bop_mids[slot % MRB_BOP_COUNT];
 }
 
 static void


### PR DESCRIPTION
## Summary

The `Symbol#==` slot of `bop_redefined` sits after the Integer and Float blocks, and #7526 wrote that position out as `2 * MRB_BOP_COUNT` in four places. This names it once.

## Changes

| File | What |
| --- | --- |
| `include/mruby.h` | Add `MRB_BOP_SYMBOL_EQ_SLOT`; define `MRB_BOP_SYMBOL_EQ` and `MRB_BOP_SLOT_COUNT` from it |
| `src/class.c` | `bop_class()` and `bop_mid()` test the slot by name |

### Why a name

The layout of the slots is a fact about `mrb_state.bop_redefined`, so it belongs next to the other `MRB_BOP_*` macros in `mruby.h`. With the position stated there, `class.c` no longer repeats the arithmetic, and adding a fourth block later means editing one line.

The object code is unchanged: `class.o`, `vm.o` and `state.o` compile to the same `.text` before and after.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,988,966 | 1,988,966 | 0 |
| bintest | 1,394,230 | 1,394,230 | 0 |
| cxx_abi | 1,426,953 | 1,426,953 | 0 |
| byte-string | 1,357,350 | 1,357,350 | 0 |
| ascii-ctype | 1,379,958 | 1,379,958 | 0 |
| no-float | 1,318,798 | 1,318,798 | 0 |
| no-bigint | 1,278,486 | 1,278,486 | 0 |

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2,700 | 2,626 | 74 | 0 | 0 | 0 |
| full-debug | 2,948 | 2,937 | 11 | 0 | 0 | 0 |
| bintest | 2,948 | 2,928 | 20 | 0 | 0 | 0 |
| cxx_abi | 2,948 | 2,928 | 20 | 0 | 0 | 0 |
| byte-string | 2,860 | 2,786 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2,932 | 2,910 | 22 | 0 | 0 | 0 |
| no-float | 2,681 | 2,584 | 97 | 0 | 0 | 0 |
| no-bigint | 2,899 | 2,866 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skipped (the `MRB_NO_FLOAT` literal case, as this build has a Float).

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/string.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Clarified internal operator slot handling by introducing a named constant.
  - Preserved existing behavior and values without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->