### PR TITLE
numeric.c: read back the C integer mrb_int64_value() writes

### DIFF
--- a/include/mruby/numeric.h
+++ b/include/mruby/numeric.h
@@ -47,6 +47,18 @@ MRB_API mrb_value mrb_num_mul(mrb_state *mrb, mrb_value x, mrb_value y);
 MRB_API mrb_value mrb_uint64_value(mrb_state *mrb, uint64_t v);
 MRB_API mrb_value mrb_int64_value(mrb_state *mrb, int64_t v);
 
+/* The same boundary read from the other side: the C integer an Integer holds.
+   A value inside the width answers itself however it is stored, a Fixnum and
+   a Bignum alike, and one outside it raises RangeError, so what went through
+   the calls above comes back through these.  A Float or a Rational is taken
+   as mrb_ensure_integer_type() takes it, and what has no integer to give
+   raises TypeError.
+
+   Spelled `as` because that is what this direction is called here, as in
+   mrb_as_int(), mrb_as_float() and mrb_bint_as_int64(). */
+MRB_API uint64_t mrb_as_uint64(mrb_state *mrb, mrb_value x);
+MRB_API int64_t mrb_as_int64(mrb_state *mrb, mrb_value x);
+
 /* The same, spelled for the C types a library counts in, whose own width
    varies by platform: a size_t is 32 bits where the time_t beside it is 64.
    A caller passes what it holds and does not have to know which of the two

--- a/mrbgems/mruby-bigint/test/bigint.c
+++ b/mrbgems/mruby-bigint/test/bigint.c
@@ -1,7 +1,6 @@
 #include <mruby.h>
 #include <mruby/array.h>
 #include <mruby/class.h>
-#include <mruby/internal.h>
 #include <mruby/numeric.h>
 #include <string.h>
 
@@ -10,33 +9,32 @@
  * Sends an Integer through the int64_t conversion a C extension uses to read
  * one, then builds an Integer back from the result.  A value the conversion
  * carries intact therefore comes back equal to itself, and one it refuses
- * raises RangeError instead.  Whether the argument arrives as a Bignum
- * depends on the width of mrb_int, so both representations are accepted.
+ * raises RangeError instead.  Whether the argument arrives as a Fixnum or as
+ * a Bignum depends on the width of mrb_int, and neither the reading nor the
+ * writing call here has to know which it is.
  */
 static mrb_value
 test_int64_roundtrip(mrb_state *mrb, mrb_value self)
 {
   mrb_value v;
-  int64_t n;
 
   mrb_get_args(mrb, "o", &v);
-  if (mrb_integer_p(v)) {
-    n = (int64_t)mrb_integer(v);
-  }
-  else if (mrb_bigint_p(v)) {
-    n = mrb_bint_as_int64(mrb, v);
-  }
-  else {
-    mrb_raisef(mrb, E_TYPE_ERROR, "%Y is not an Integer", v);
-    return mrb_nil_value();
-  }
+  return mrb_int64_value(mrb, mrb_as_int64(mrb, v));
+}
 
-#ifdef MRB_INT32
-  if (n < MRB_INT_MIN || n > MRB_INT_MAX) {
-    return mrb_bint_new_int64(mrb, n);
-  }
-#endif
-  return mrb_int_value(mrb, (mrb_int)n);
+/* BigintTest.uint64_roundtrip(integer) -> Integer
+ *
+ * The unsigned counterpart.  The range it carries reaches one bit further up
+ * and stops at zero, so a negative value raises RangeError however narrow it
+ * is.
+ */
+static mrb_value
+test_uint64_roundtrip(mrb_state *mrb, mrb_value self)
+{
+  mrb_value v;
+
+  mrb_get_args(mrb, "o", &v);
+  return mrb_uint64_value(mrb, mrb_as_uint64(mrb, v));
 }
 
 
@@ -122,6 +120,8 @@ mrb_mruby_bigint_gem_test(mrb_state *mrb)
   struct RClass *test = mrb_define_module(mrb, "BigintTest");
 
   mrb_define_module_function(mrb, test, "int64_roundtrip", test_int64_roundtrip,
+                             MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, test, "uint64_roundtrip", test_uint64_roundtrip,
                              MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, test, "to_bytes", test_to_bytes, MRB_ARGS_REQ(1));
   mrb_define_module_function(mrb, test, "from_bytes", test_from_bytes, MRB_ARGS_REQ(2));

--- a/mrbgems/mruby-bigint/test/bigint.rb
+++ b/mrbgems/mruby-bigint/test/bigint.rb
@@ -546,6 +546,27 @@ assert('Bigint int64 conversion refuses what int64_t cannot hold') do
   assert_raise(RangeError) { BigintTest.int64_roundtrip(-(10 ** 25)) }
 end
 
+assert('Bigint uint64 conversion covers the whole unsigned 64-bit range') do
+  uint64_max = 18446744073709551615
+
+  assert_equal 0, BigintTest.uint64_roundtrip(0)
+  assert_equal 1, BigintTest.uint64_roundtrip(1)
+  assert_equal uint64_max - 1, BigintTest.uint64_roundtrip(uint64_max - 1)
+  assert_equal uint64_max, BigintTest.uint64_roundtrip(uint64_max)
+
+  # The bit int64_t spends on the sign, which the signed side refuses.
+  assert_equal 9223372036854775808, BigintTest.uint64_roundtrip(9223372036854775808)
+end
+
+assert('Bigint uint64 conversion refuses what uint64_t cannot hold') do
+  assert_raise(RangeError) { BigintTest.uint64_roundtrip(18446744073709551616) }
+  assert_raise(RangeError) { BigintTest.uint64_roundtrip(10 ** 25) }
+
+  # Negative at either width: one that fits mrb_int and one that does not.
+  assert_raise(RangeError) { BigintTest.uint64_roundtrip(-1) }
+  assert_raise(RangeError) { BigintTest.uint64_roundtrip(-(10 ** 25)) }
+end
+
 assert('mrb_integer_to_bytes and mrb_integer_from_bytes') do
   # Zero needs no bytes, and its sign is neither of the other two.
   assert_equal [0, []], BigintTest.to_bytes(0)

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -79,6 +79,55 @@ mrb_int64_value(mrb_state *mrb, int64_t v)
 }
 
 /**
+ * Answer with the C integer `x` holds, whatever width the Integer is stored
+ * in.  A Fixnum answers what it holds, a Bignum that suits `uint64_t` answers
+ * that, and one that does not raises RangeError.  This reads what
+ * mrb_uint64_value() writes: a value that went through that call comes back
+ * out of this one.
+ *
+ * `x` that is not an Integer is taken as mrb_ensure_integer_type() takes it,
+ * so a Float truncates and an object with no integer to give raises TypeError.
+ * A negative Integer has no `uint64_t` to answer with, however it is stored,
+ * and raises RangeError.
+ *
+ * A caller reaching for this has a C integer to fill that mrb_int may be too
+ * narrow for, and reaches for it rather than mrb_bint_* so it needs neither
+ * the gem's headers nor an #ifdef of its own.
+ */
+MRB_API uint64_t
+mrb_as_uint64(mrb_state *mrb, mrb_value x)
+{
+  mrb_int i;
+
+  x = mrb_ensure_integer_type(mrb, x);
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(x)) {
+    return mrb_bint_as_uint64(mrb, x);
+  }
+#endif
+  i = mrb_integer(x);
+  if (i < 0) {
+    mrb_raise(mrb, E_RANGE_ERROR, "integer out of range");
+  }
+  return (uint64_t)i;
+}
+
+/**
+ * The signed counterpart of mrb_as_uint64().  See its comment.
+ */
+MRB_API int64_t
+mrb_as_int64(mrb_state *mrb, mrb_value x)
+{
+  x = mrb_ensure_integer_type(mrb, x);
+#ifdef MRB_USE_BIGINT
+  if (mrb_bigint_p(x)) {
+    return mrb_bint_as_int64(mrb, x);
+  }
+#endif
+  return (int64_t)mrb_integer(x);
+}
+
+/**
  * This function is called to raise a ZeroDivisionError. It's marked
  * mrb_noreturn as it always raises an exception and does not return.
  *


### PR DESCRIPTION
## Summary

`mrb_uint64_value()` and `mrb_int64_value()` build an Integer out of a C integer that `mrb_int` may be too narrow for, but nothing read one back, so an extension that takes a `time_t` or a `size_t` as an argument still had to decide for itself what an Integer wider than `mrb_int` is: switch on the representation, reach into `mruby/internal.h` for `mrb_bint_as_int64()`, and carry an `#ifdef MRB_USE_BIGINT` for the build that has no such gem. `mrb_as_int64()` and `mrb_as_uint64()` answer the reading direction on the same terms. This is the reading half of #7493, whose writing half the two calls above answered.

## Changes

| File | What |
| --- | --- |
| `include/mruby/numeric.h` | `mrb_as_uint64()` and `mrb_as_int64()`, declared beside the two calls they read back |
| `src/numeric.c` | the two definitions: `mrb_ensure_integer_type()`, then the Bignum branch under the one `#ifdef`, then the `mrb_int` the value fits |
| `mrbgems/mruby-bigint/test/bigint.c` | `BigintTest.int64_roundtrip` was written as exactly that switch and now goes through the new calls; `BigintTest.uint64_roundtrip` added |
| `mrbgems/mruby-bigint/test/bigint.rb` | the unsigned range, both ends, and what it refuses |

### What the pair answers

A value inside the width answers itself however it is stored, a Fixnum and a Bignum alike, and one outside it raises `RangeError`, so what went through `mrb_int64_value()` comes back out of `mrb_as_int64()`. A negative Integer has no `uint64_t` to answer with and raises `RangeError` at either width, which is what `mrb_bint_as_uint64()` already answers for the wide half.

An argument that is not an Integer is taken as `mrb_ensure_integer_type()` takes it, which is what `mrb_as_int()` and `mrb_as_float()` do, so a Float truncates and an object with no integer to give raises `TypeError`. No `to_int` is dispatched.

They are spelled `as` because that is what this direction is already called in the tree: `mrb_as_int()`, `mrb_as_float()`, `mrb_bint_as_int64()`. `mrb_int64_value()` reads as "the value from an int64", so its inverse cannot keep the same name; `mrb_integer()` is the unchecked boxing accessor and cannot lend its shape either.

### Why in core rather than at each caller

The same reason the writing half sits here: the `#ifdef MRB_USE_BIGINT` is written once instead of once per caller, and the builds disagree about nothing. Without mruby-bigint the definitions still stand and answer a Fixnum, so a caller needs neither the gem's headers nor a build-time question of its own.

The reader in `mrbgems/mruby-time/src/time.c` is left alone: it raises `ArgumentError` for a time outside `time_t` rather than `RangeError`, and folding it in here would change what `Time.at` raises.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,988,966 | 1,989,206 | +240 |
| bintest | 1,394,230 | 1,394,550 | +320 |
| cxx_abi | 1,426,953 | 1,427,273 | +320 |
| byte-string | 1,357,350 | 1,357,670 | +320 |
| ascii-ctype | 1,379,958 | 1,380,278 | +320 |
| no-float | 1,318,798 | 1,319,134 | +336 |
| no-bigint | 1,278,486 | 1,278,630 | +144 |

The delta is `numeric.o` alone, which is the two definitions themselves: 320 bytes where the Bignum branch is compiled in (28,444 to 28,764 in the bintest build) and 144 bytes where it is not (21,212 to 21,356). Nothing calls them yet outside the test harness, and being `MRB_API` they are kept.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2702 | 2628 | 74 | 0 | 0 | 0 |
| full-debug | 2950 | 2939 | 11 | 0 | 0 | 0 |
| bintest | 2950 | 2930 | 20 | 0 | 0 | 0 |
| cxx_abi | 2950 | 2930 | 20 | 0 | 0 | 0 |
| byte-string | 2862 | 2788 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2934 | 2912 | 22 | 0 | 0 | 0 |
| no-float | 2683 | 2586 | 97 | 0 | 0 | 0 |
| no-bigint | 2899 | 2866 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO. The same seven builds under `i686-linux-gnu-gcc` (`MRB_INT32`, with and without bigint) pass with 0 KO and 0 Crash as well, which is where `mrb_bint_as_int64()` is a function rather than an alias of `mrb_bint_as_int()`.

The signed round trip already had tests, and they now exercise the new call. The unsigned ones cover 0, both ends of `uint64_t`, and `2 ** 63`, the bit `int64_t` spends on the sign; the refusals cover `2 ** 64`, `10 ** 25`, and a negative value at both widths, `-1` and `-(10 ** 25)`.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/string.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public conversions from Integer values to signed and unsigned 64-bit integers.
  * Conversions support both regular integers and arbitrary-size integers.
  * Invalid types raise `TypeError`; values outside the supported range raise `RangeError`.
* **Tests**
  * Added coverage for unsigned 64-bit round trips, including the maximum value and out-of-range inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->