### PR TITLE
mruby-compiler: tie a string given to `eval` to the method that called it

### DIFF
--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -94,7 +94,10 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
      carries the special-variable slot past its one local from the start
      (MRB_ENV_SET_SVAR below; see internal.h). */
   mrb_value *stacks = (mrb_value*)mrb_malloc(mrb, MRB_ENV_SVAR_STACK_SIZE(1));
-  env->mid = 0;
+  /* The space stands in for the frame the binding was taken from, so it
+     answers for the method that frame was called by: that is the name a
+     string evaluated in the binding is named for. */
+  env->mid = e ? e->mid : 0;
   env->stack = stacks;
   if (e && e->stack && MRB_ENV_LEN(e) > 0) {
     env->stack[0] = e->stack[0];

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1589,6 +1589,25 @@ gen_blkmove(mrc_codegen_scope *s, uint16_t ainfo, int lv)
   push();
 }
 
+/* Whether a `return` here leaves a method that is not part of this compile
+   unit.  A string compiled for `eval` holds no method scope of its own, and
+   `return` in it leaves the method that encloses the `eval` call, which is
+   the frame the proc chain reaches and the one `OP_RETURN_BLK` unwinds to. */
+static mrc_bool
+return_leaves_upper_p(mrc_codegen_scope *s)
+{
+#if defined(MRC_TARGET_MRUBY)
+  if (!s->c->upper) return FALSE;
+  for (mrc_codegen_scope *s2 = s; s2; s2 = s2->prev) {
+    if (s2->mscope) return FALSE;
+  }
+  return TRUE;
+#else
+  (void)s;
+  return FALSE;
+#endif
+}
+
 /* Find the method scope that a `super`, a `zsuper` or a `yield` belongs to.
    Answers its `ainfo`, the argument layout that the forwarded arguments and
    the block are read by, and sets `lvp` to the number of levels between it
@@ -6332,7 +6351,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       else {
         genop_1(s, OP_LOADNIL, cursp());
       }
-      if (s->loop) {
+      if (s->loop || return_leaves_upper_p(s)) {
         gen_return(s, OP_RETURN_BLK, cursp());
       }
       else {

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1589,6 +1589,55 @@ gen_blkmove(mrc_codegen_scope *s, uint16_t ainfo, int lv)
   push();
 }
 
+/* Find the method scope that a `super`, a `zsuper` or a `yield` belongs to.
+   Answers its `ainfo`, the argument layout that the forwarded arguments and
+   the block are read by, and sets `lvp` to the number of levels between it
+   and `s`.  Answers -1 when there is no method scope to find. */
+static int
+search_mscope(mrc_codegen_scope *s, int *lvp)
+{
+  mrc_codegen_scope *s2 = s;
+  int lv = 0;
+
+  while (!s2->mscope) {
+    lv++;
+    s2 = s2->prev;
+    if (!s2) break;
+  }
+  *lvp = lv;
+  if (s2) return (int)s2->ainfo;
+
+#if defined(MRC_TARGET_MRUBY)
+  /* A string compiled for `eval` has a scope chain of its own, and the method
+     that encloses the `eval` call is not on it: it is on the proc chain the
+     context carries.  The walk above ended on the scope `generate_code()`
+     wraps a compile unit in, which is one level more than the string's own
+     scope and stands for no frame, so `c->upper` is the proc the level count
+     has now reached.  Restate the `OP_ENTER` that the method scope emitted
+     for itself as the `ainfo` it would have answered. */
+  const struct RProc *u = s->c->upper;
+
+  (*lvp)--;
+
+  while (u && !MRC_PROC_CFUNC_P(u)) {
+    if (MRC_PROC_SCOPE_P(u)) {
+      const struct mrc_irep *ir = (const struct mrc_irep *)u->body.irep;
+      if (!ir || ir->ilen == 0 || ir->iseq[0] != OP_ENTER) break;
+      uint32_t a = PEEK_W(ir->iseq + 1);
+      uint32_t ma = MRC_ASPEC_REQ(a) + MRC_ASPEC_OPT(a);
+      return (int)(((ma & 0x3f) << 7)
+                   | (MRC_ASPEC_REST(a) << 6)
+                   | ((MRC_ASPEC_POST(a) & 0x1f) << 1)
+                   | ((MRC_ASPEC_KEY(a) || MRC_ASPEC_KDICT(a)) ? 1 : 0));
+    }
+    u = u->upper;
+    (*lvp)++;
+  }
+#endif
+
+  return -1;
+}
+
 static void
 gen_setxv(mrc_codegen_scope *s, uint8_t op, uint16_t dst, mrc_sym sym, int val)
 {
@@ -6179,16 +6228,11 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_SUPER_NODE:
     {
       CAST(super);
-      mrc_codegen_scope *s2 = s;
-      int lv = 0;
+      int lv;
+      int ainfo = search_mscope(s, &lv);
       int n = 0, nk = 0, st = 0;
 
       push();
-      while (!s2->mscope) {
-        lv++;
-        s2 = s2->prev;
-        if (!s2) break;
-      }
       CAST3(arguments, cast->arguments, arguments);
       if (arguments) {
         st = n = gen_values(s, (mrc_node *)arguments, VAL, 14);
@@ -6210,7 +6254,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (s2) gen_blkmove(s, s2->ainfo, lv);
+        else if (ainfo >= 0) gen_blkmove(s, (uint16_t)ainfo, lv);
         else {
           genop_1(s, OP_LOADNIL, cursp());
           push();
@@ -6221,7 +6265,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (s2) gen_blkmove(s, s2->ainfo, lv);
+        else if (ainfo >= 0) gen_blkmove(s, (uint16_t)ainfo, lv);
         else {
           genop_1(s, OP_LOADNIL, cursp());
           push();
@@ -6236,21 +6280,12 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_FORWARDING_SUPER_NODE:
     {
       CAST(forwarding_super);
-      mrc_codegen_scope *s2 = s;
-      int lv = 0;
-      uint16_t ainfo = 0;
+      int lv;
+      int ainfo = search_mscope(s, &lv);
       int n = CALL_MAXARGS;
       int sp = cursp();
 
       push();        /* room for receiver */
-      while (!s2->mscope) {
-        lv++;
-        s2 = s2->prev;
-        if (!s2) break;
-      }
-      if (s2 && s2->ainfo > 0) {
-        ainfo = s2->ainfo;
-      }
       if (ainfo > 0) {
         genop_2S(s, OP_ARGARY, cursp(), (ainfo<<4)|(lv & 0xf));
         push(); push(); push();   /* ARGARY pushes 3 values at most */
@@ -6271,13 +6306,13 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (s2) {
+        else if (ainfo >= 0) {
           gen_blkmove(s, 0, lv);
         }
         else {
-          /* The walk above found no method scope, so `lv` counts past the
-             outermost one and there is no block to forward: a `super` here
-             raises rather than call anything. PM_SUPER_NODE says the same. */
+          /* There is no method scope to belong to, so there is no block to
+             forward: a `super` here raises rather than call anything.
+             PM_SUPER_NODE says the same. */
           genop_1(s, OP_LOADNIL, cursp());
           push();
         }
@@ -6309,18 +6344,10 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_YIELD_NODE:
     {
       CAST(yield);
-      mrc_codegen_scope *s2 = s;
-      int lv = 0, ainfo = -1;
+      int lv;
+      int ainfo = search_mscope(s, &lv);
       int n = 0, nk = 0, st = 0;
 
-      while (!s2->mscope) {
-        lv++;
-        s2 = s2->prev;
-        if (!s2) break;
-      }
-      if (s2) {
-        ainfo = (int)s2->ainfo;
-      }
       if (ainfo < 0) codegen_error(s, "invalid yield (SyntaxError)");
       push();
       CAST3(arguments, cast->arguments, arguments);

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1581,7 +1581,10 @@ gen_blkmove(mrc_codegen_scope *s, uint16_t ainfo, int lv)
     gen_move(s, cursp(), off, 0);
   }
   else {
-    genop_3(s, OP_GETUPVAR, cursp(), off, lv);
+    /* `lv` counts the scopes between here and the method, while `OP_GETUPVAR`
+       counts the envs above this frame's own, and the method's env is the
+       first of those: one level fewer. */
+    genop_3(s, OP_GETUPVAR, cursp(), off, lv-1);
   }
   push();
 }

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -344,9 +344,6 @@ object_eval(mrb_state *mrb, mrb_value self, mrb_bool class_eval)
   mrb_value binding = mrb_nil_value();
   if (env) {
     binding = mrb_binding_new(mrb, caller, self, env);
-    /* The binding's own env starts with no method name; keep the caller's
-       so `__method__` and `super` inside the string see the caller. */
-    mrb_binding_extract_env(mrb, binding)->mid = env->mid;
   }
   struct RProc *proc = create_proc_from_string(mrb, s, len, binding, file, line);
   MRB_PROC_SET_TARGET_CLASS(proc, c);

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -292,6 +292,14 @@ f_eval(mrb_state *mrb, mrb_value self)
     self = mrb_iv_get(mrb, binding, MRB_SYM(recv));
   }
   mrb_assert(!MRB_PROC_CFUNC_P(proc));
+  /* The string runs on a frame of its own, and `mrb_exec_irep()` copies this
+     frame's `mid` to it. Left as `eval`, a `super` in the string looks for
+     the superclass method of `eval` itself; the env the string shares with
+     the caller carries the name the caller was called by, which is the one
+     the string's `super` and `defined?(super)` must answer for. A caller
+     with no env is a C function, which has no such name to lend. */
+  struct REnv *e = MRB_PROC_ENV(proc);
+  if (e) mrb->c->ci->mid = e->mid;
   return eval_irep(mrb, self, proc);
 }
 
@@ -349,6 +357,10 @@ object_eval(mrb_state *mrb, mrb_value self, mrb_bool class_eval)
   MRB_PROC_SET_TARGET_CLASS(proc, c);
   mrb_assert(!MRB_PROC_CFUNC_P(proc));
   mrb_vm_ci_target_class_set(mrb->c->ci, c);
+  /* The frame carries one class, and it is given to `c` here so that a `def`
+     in the string lands on the receiver. A `super` reads that same field for
+     the class the method was found in, so there is no answer for it to give
+     from this frame; the name the frame carries is left alone. */
   return eval_irep(mrb, self, proc);
 }
 

--- a/mrbgems/mruby-eval/test/binding.rb
+++ b/mrbgems/mruby-eval/test/binding.rb
@@ -79,3 +79,12 @@ assert "Binding#eval on another target class" do
   assert_equal :m1, obj.m1
   assert_equal :m2, obj.m2
 end
+
+assert "a binding answers for the method it was taken from" do
+  # The space a binding keeps its own locals in stands in for the frame the
+  # binding was taken from, so it carries that frame's method name too.
+  def binding_named_probe(x); binding; end
+  b = binding_named_probe(1)
+  assert_equal :binding_named_probe, b.eval("__method__")
+  assert_equal :binding_named_probe, eval("__method__", b)
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -370,3 +370,30 @@ assert('a string given to eval is named for the method that called eval') do
   assert_nil binding.eval("__method__")
   assert_raise(NoMethodError) { eval("super") }
 end
+
+assert('`super` and `yield` in a string given to eval belong to the caller') do
+  # The string's own scope chain holds no method scope, so the argument
+  # layout that a bare `super` forwards and that `yield` finds the block by
+  # comes from the method on the proc chain the compile context carries.
+  base = Class.new do
+    def m(x); [:base, x]; end
+    def blk; block_given? ? yield(:b) : :noblk; end
+  end
+  sub = Class.new(base) do
+    def m(x); eval("super"); end
+    def blk; eval("super"); end
+    def y; eval("yield 21"); end
+    def y_nested; eval("[1].map { yield 2 }"); end
+    def y_args(a, b = 1, *r, c, d: 4, &e); eval("yield a"); end
+  end
+  o = sub.new
+
+  assert_equal [:base, 1], o.m(1)
+  assert_equal [:blk, :b], o.blk { |v| [:blk, v] }
+  assert_equal 42, o.y { |v| v * 2 }
+  assert_equal [4], o.y_nested { |v| v * 2 }
+  assert_equal 35, o.y_args(7, 8) { |v| v * 5 }
+
+  # Outside a method there is still no block to reach.
+  assert_raise(SyntaxError) { eval("yield") }
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -397,3 +397,21 @@ assert('`super` and `yield` in a string given to eval belong to the caller') do
   # Outside a method there is still no block to reach.
   assert_raise(SyntaxError) { eval("yield") }
 end
+
+assert('`return` in a string given to eval leaves the calling method') do
+  # `OP_RETURN` returns to the string's own frame, whose caller is the C
+  # function `eval`, so the value became `eval`'s and the method carried on.
+  # A `return` here leaves the method the way one from a block does.
+  k = Class.new do
+    def ret; eval("return :from_string"); :after_eval; end
+    def ret_nested; eval("eval('return :from_nested')"); :after_eval; end
+    def ret_def; eval("def inner; return :inner; end"); inner; end
+    def ret_lambda; eval("-> { return :lambda }.call"); end
+  end
+  o = k.new
+
+  assert_equal :from_string, o.ret
+  assert_equal :from_nested, o.ret_nested
+  assert_equal :inner, o.ret_def
+  assert_equal :lambda, o.ret_lambda
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -340,3 +340,33 @@ assert('a string class_eval still runs inside the caller\'s scope') do
   c.method(:class_eval).call("def from_c_caller; end")
   assert_true c.method_defined?(:from_c_caller)
 end
+
+assert('a string given to eval is named for the method that called eval') do
+  # The string runs on a frame of its own, pushed on top of the C frame of
+  # `eval`, and that frame used to carry `eval` as its method name: a `super`
+  # in the string looked for the superclass method of `eval` itself, and
+  # `defined?(super)` answered `"super"` in a method that has no superclass
+  # method to call.
+  base = Class.new do
+    def m(x); [:base, x]; end
+    def has_super(x); end
+  end
+  sub = Class.new(base) do
+    def m(x); eval("super(x + 10)"); end
+    def has_super(x); eval("defined?(super)"); end
+    def no_super; eval("defined?(super)"); end
+    def named; eval("__method__"); end
+  end
+  o = sub.new
+
+  assert_equal [:base, 11], o.m(1)
+  assert_equal 'super', o.has_super(1)
+  assert_nil o.no_super
+  assert_equal :named, o.named
+
+  # Outside a method there is no name to carry, and `eval`'s own must not
+  # stand in for one.
+  assert_nil eval("__method__")
+  assert_nil binding.eval("__method__")
+  assert_raise(NoMethodError) { eval("super") }
+end

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -34,6 +34,19 @@ assert('super', '11.3.4') do
   assert_equal [1,2,3], bar.bar(1,2,3)
 end
 
+assert('super forwards the caller\'s block from inside a block') do
+  # `super` reads the block from the frame of the method it belongs to.  From
+  # inside a block that frame is reached through an env, and the level the
+  # instruction carries counts the envs above this frame's own, one fewer
+  # than the scopes the compiler walked to find the method.
+  base = Class.new { def m; block_given? ? yield(:b) : :noblk; end }
+  sub = Class.new(base) { def m; r = nil; [1].each { r = super }; r; end }
+  assert_equal [:blk, :b], sub.new.m { |v| [:blk, v] }
+
+  deep = Class.new(base) { def m; r = nil; [1].each { [2].each { r = super } }; r; end }
+  assert_equal [:blk, :b], deep.new.m { |v| [:blk, v] }
+end
+
 assert('yield', '11.3.5') do
 # it's syntax error now
 #  assert_raise LocalJumpError do


### PR DESCRIPTION
## Summary

A string handed to `eval` runs on a frame of its own, so `return` left only the string, `super` looked for the superclass method of `Kernel#eval`, and `yield` was refused at compile time. All three now name the method that called `eval`, as CRuby does.

## Changes

| File                                   | What                                                                                                                                                                                           |
| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | Count a forwarded block's level from the running frame; find the enclosing method on the proc chain when the scope chain has none; compile `return` at a string's top level to `OP_RETURN_BLK` |
| `mrbgems/mruby-binding/src/binding.c`  | Carry the method name of the frame the binding was taken from                                                                                                                                  |
| `mrbgems/mruby-eval/src/eval.c`        | Give the string's frame the method name its caller was called by                                                                                                                               |
| `test/t/syntax.rb`                     | `super` forwards the caller's block from inside a block                                                                                                                                        |
| `mrbgems/mruby-eval/test/binding.rb`   | The method a binding answers for                                                                                                                                                               |
| `mrbgems/mruby-eval/test/eval.rb`      | What `return`, `super`, `yield`, `defined?(super)` and `__method__` answer in a string                                                                                                         |

### The level a forwarded block is read at

`gen_blkmove()` emitted `OP_GETUPVAR` with the number of scopes the compiler walked to reach the method the `super` belongs to, while the instruction counts the environments above the running frame's own, of which the method's is the first: one fewer. A `super` written inside a block therefore read one level too far out, found no environment there and forwarded `nil`.

Only the `ainfo == 0` path reached this. A method that declares positional arguments forwards its block through `OP_ARGARY`, which reads the level the way the compiler counts it. This is a bug of its own, fixed first because a string's `super` runs into it too.

### The method name a binding answers for

A binding keeps its own top-level locals in a space of its own, and that space stands in for the frame the binding was taken from. It started with no method name, so a string evaluated in the binding had none to read. A string `instance_eval` reaches the caller's frame through a binding of it and had to write the name in by hand for that reason; the space carries it now.

### The method name on the string's frame

`mrb_exec_irep()` copies onto the string's frame the `mid` of the C frame it is pushed over, which is `eval`. Everything that reads a frame's method name off the callinfo answered for `eval`: `super` looked for the superclass method of `Kernel#eval`, `defined?(super)` answered `"super"` in a method that has no superclass method to call, and `__method__` outside any method answered `:eval` instead of `nil`. The environment the string shares with its caller carries the name the caller was called by, which is where `__method__` has been reading it from all along.

A string `instance_eval` or `class_eval` keeps the name it had. Its frame carries one class, given to the receiver so that a `def` in the string lands there, and `super` reads that same field for the class the method was found in, so the frame has no answer to give it either way.

### The argument layout `super` and `yield` need

`super`, a bare `super` and `yield` all need the argument layout of the method they belong to: it says where the forwarded arguments and the block sit in that method's frame. The compiler read it off the scope chain, which for a string ends at the string's own scope, so the walk found nothing: a bare `super` forwarded no arguments and `yield` was a `SyntaxError`. The method that encloses the `eval` call is on the proc chain the compile context carries, and the layout it emitted for itself is in the `OP_ENTER` its irep opens with, which is what `mrb_proc_arity()` already reads an arity out of. The scope that `generate_code()` wraps a compile unit in stands for no frame, so the level count drops it before the walk moves on to the proc chain.

### Where `return` returns to

`OP_RETURN` returns to the frame it runs on, which for a string is the string's own, pushed over the C frame of `eval`. The value became `eval`'s and the method carried on to its next statement. A string's proc has an environment and an `upper` the way a block's does, so `OP_RETURN_BLK` already walks to the right frame: it is what a `return` inside a loop or a block in the same string has been compiled to all along, and those two already left the method. A `def` or a lambda written in the string brings a scope of its own to return from, and keeps `OP_RETURN`.

## Behaviour

```ruby
class Base; def m(x); [:base, x]; end; end
class Sub < Base
  def m(x); eval("super"); end
  def r; eval("return :from_string"); :after_eval; end
  def y; eval("yield 21"); end
  def ds; eval("defined?(super)"); end
end

Sub.new.r                        # CRuby: :from_string, mruby: :after_eval
Sub.new.m(1)                     # CRuby: [:base, 1], mruby: ArgumentError
Sub.new.y { |v| v * 2 }          # CRuby: 42, mruby: SyntaxError
Sub.new.ds                       # CRuby: nil, mruby: "super"
eval("__method__")               # CRuby: nil, mruby: :eval

def bound(x); binding; end
eval("__method__", bound(1))     # CRuby: :bound, mruby: :eval
```

A `return` in a string at the top level ends the program, as it does in CRuby; it used to fall through to the next statement.

Outside a string, a `super` written inside a block now forwards the block its method was given instead of `nil`:

```ruby
base = Class.new { def m; block_given? ? yield(:b) : :noblk; end }
sub = Class.new(base) { def m; r = nil; [1].each { r = super }; r; end }
sub.new.m { |v| [:blk, v] }      # CRuby: [:blk, :b], mruby: :noblk
```

Two differences are out of scope and unchanged here. A `super` in a string `instance_eval` still cannot reach the superclass method, because the frame's one class field is the receiver, and a bare `super` from a method with keyword arguments still forwards the keyword dictionary that `OP_KARG` has already drained, so `Class.new(Class.new { def kw(a:); a; end }) { def kw(a:); super; end }.new.kw(a: 1)` raises `ArgumentError: missing keyword: a` whether or not an `eval` is involved.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, gcc 13.3.0.

| Build            |    master |   This PR | Delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 1,991,110 | 1,991,462 |  +352 |
| bintest          | 1,397,030 | 1,397,446 |  +416 |
| cxx_abi          | 1,429,369 | 1,429,513 |  +144 |
| byte-string      | 1,359,910 | 1,360,326 |  +416 |
| ascii-ctype      | 1,382,518 | 1,382,934 |  +416 |
| no-float         | 1,322,574 | 1,323,038 |  +464 |
| no-bigint        | 1,281,062 | 1,281,478 |  +416 |

In `bintest` the growth is the two new walks in `codegen.o` (+144) and `eval.o` (+272), which is more than the four lines there account for: dropping a call out of `object_eval()` changes what the compiler inlines into it. `binding.o` is unchanged.

## Testing

| Build       | Total |    OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ----: | ---: | --: | ----: | ------: |
| host        | 2,714 | 2,640 |   74 |   0 |     0 |       0 |
| full-debug  | 2,962 | 2,951 |   11 |   0 |     0 |       0 |
| bintest     | 2,962 | 2,942 |   20 |   0 |     0 |       0 |
| cxx_abi     | 2,962 | 2,942 |   20 |   0 |     0 |       0 |
| byte-string | 2,874 | 2,800 |   74 |   0 |     0 |       0 |
| ascii-ctype | 2,946 | 2,924 |   22 |   0 |     0 |       0 |
| no-float    | 2,695 | 2,598 |   97 |   0 |     0 |       0 |
| no-bigint   | 2,911 | 2,878 |   33 |   0 |     0 |       0 |

`bintest` also runs the command binary tests, which pass. The same seven builds pass as `i686-linux-gnu-gcc` builds, where `mrb_int` is 32 bits.

A differential run of 62 cases against CRuby 4.0.6 covers `super` and a bare `super` for every parameter shape, `yield` with positional, splat and keyword arguments and at three block depths, `return` from a string under `ensure`, `rescue`, a `def`, a lambda, a proc, a block and a nested `eval`, and what `__method__` answers from a method, a block, a proc, a lambda, a `define_method` body, a binding and the top level. All 62 match except the string `instance_eval` `super` named above.

The new tests pin what a string answers for the method that called `eval`: the name it carries, the superclass method a `super` in it finds and the arguments it forwards, the block a `yield` in it reaches at any depth, and the frame a `return` in it leaves, along with a `def` and a lambda in the string keeping their own. `mrbgems/mruby-eval/test/binding.rb` pins the method a binding answers for, and `test/t/syntax.rb` the block that a `super` inside one and two blocks forwards.

## Environment

<details>

|          |                                        |
| -------- | -------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                     |
| Kernel   | Linux 7.0.0-31-generic x86_64          |
| CPU      | AMD Ryzen 9 5950X                      |
| Compiler | gcc 13.3.0                             |
| binutils | GNU ld 2.47.20260726                   |
| CRuby    | 4.0.6 (2026-07-14 revision 03b6d3f889) |

```
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method-name reporting for code evaluated through bindings and `eval`.
  * Corrected `super`, `yield`, and `return` behavior in evaluated code, including forwarding methods, arguments, and blocks from the calling context.
  * Fixed behavior for nested evaluations and evaluated code inside methods or blocks.
  * Updated `instance_eval` and `class_eval` method-context handling for more accurate `__method__` and `super` results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->