### PR TITLE
ci: split the Windows matrix rows across lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,16 @@ jobs:
           # a minute together while the seven builds take ten of the job's
           # fifteen, so this runner is asked for its ABI and not for what
           # reads the same everywhere.  See build_config/ci/gcc-clang.rb.
-          - {os: windows-2025, cc: gcc, cxx: g++, altname: "mingw-gcc", abi_only: "1"}
-          - {os: windows-2022, cc: gcc, cxx: g++, altname: "mingw-gcc", abi_only: "1"}
+          - os: windows-2025
+            cc: gcc
+            cxx: g++
+            altname: "mingw-gcc"
+            abi_only: "1"
+          - os: windows-2022
+            cc: gcc
+            cxx: g++
+            altname: "mingw-gcc"
+            abi_only: "1"
     env:
       MRUBY_CONFIG: ci/gcc-clang
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
## Summary

The two Windows rows added to the `gcc-clang` matrix in 0efb6f0fd are longer than prettier's print width, so the manual hook stage rewrites them and `pre-commit-manual` fails on master. This writes them the way the long rows above them are already written.

## Changes

| File | What |
| --- | --- |
| `.github/workflows/build.yml` | the two mingw rows of the `gcc-clang` matrix become block mappings |

### Why a block mapping and not the wrapping prettier picks

Left to itself the hook keeps the flow mapping and breaks it over six lines, one key per line between the braces. The `i686-gcc` and `armhf-gcc` rows a few lines above are block mappings, so the file already answers the question of what a row that outgrows its line should look like, and this follows that answer instead of adding a second shape. The workflow GitHub reads is untouched: `YAML.load_file` on the file before and after this commit compares equal.

## Testing

| Stage | Command | Result |
| --- | --- | --- |
| default | `prek run --from-ref HEAD^ --to-ref HEAD` | all hooks pass, `actionlint`, `check-yaml` and `yamllint` among them |
| manual | `prek run --all-files --hook-stage manual` | all hooks pass, the working tree left clean |

The manual run is the one that fails on master today, on `run prettier`. No build or test suite is involved: the commit touches a workflow file only, and the parsed workflow is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted Windows GCC build matrix configuration for improved readability.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->