### PR TITLE
mruby-regexp: read every group a `\k` name was given

### DIFF
--- a/mrbgems/mruby-regexp/src/re_compile.c
+++ b/mrbgems/mruby-regexp/src/re_compile.c
@@ -2783,10 +2783,18 @@ add_pending_call(re_compiler *c, uint8_t kind, const char *at, uint32_t len,
    group written later may still satisfy, `-n` counts back over the groups
    already open, and a nest level is refused. A number that names no group
    is caught by mrb_re_compile() once the whole pattern is read; see
-   `max_backref`. */
+   `max_backref`.
+
+   A name the pattern has given to several groups answers the first of them,
+   which is the group a conditional tests, and `set` collects all of them,
+   one bit per group number, for the backreference that reads them all (see
+   emit_multi_backref()). A caller with no use for the set passes NULL, and
+   the numeric spellings leave it empty: those name one group, which the
+   answer carries, and the group a forward `\k<n>` names is not open yet. */
 static int
-parse_group_ref(re_compiler *c)
+parse_group_ref(re_compiler *c, uint32_t *set)
 {
+  if (set) *set = 0;
   int close = (peek(c) == '<') ? '>' : '\'';
   next_char(c);  /* skip < or ' */
   const char *name = c->p;
@@ -2917,8 +2925,9 @@ parse_group_ref(re_compiler *c)
     for (uint16_t i = 0; i < c->num_named; i++) {
       if (c->pat->named_captures[i].name_len == name_len &&
           memcmp(c->pat->named_captures[i].name, name, name_len) == 0) {
-        group = c->pat->named_captures[i].group;
-        break;
+        uint16_t g = c->pat->named_captures[i].group;
+        if (group < 0) group = g;
+        if (set) *set |= (uint32_t)1 << g;
       }
     }
     if (group < 1) {
@@ -3185,7 +3194,12 @@ open_group(re_compiler *c, uint32_t begin, uint32_t outer_atom_start)
         compile_error(c, "undefined group option");
       }
       if (cond == '<' || cond == '\'') {
-        group = parse_group_ref(c);
+        /* A name given to several groups tests the first of them, as in
+           CRuby: `(?<x>a)?(?<x>b)(?(<x>)y|z)` reads `z` against "b", the
+           group that matched not being the one the condition names. That
+           is where the condition parts from the backreference, which
+           reads every group of the name. */
+        group = parse_group_ref(c, NULL);
         /* A name closed by its delimiter and then something other than
            the ')': CRuby's answer is the prefix's, as above. */
         if (peek(c) != ')') compile_error(c, "undefined group option");
@@ -3293,6 +3307,55 @@ open_group(re_compiler *c, uint32_t begin, uint32_t outer_atom_start)
   re_level *lv = open_level(c, RE_LEVEL_GROUP, begin, outer_atom_start);
   lv->state = capturing;
   lv->num = group;
+}
+
+/* Emit the backreference to a name the pattern has given to several groups:
+   `set` holds them, one bit per group number, and the reference matches
+   where any of them does. CRuby reads such a name that way and this engine
+   used to read one group of it, so a subject only another group could vouch
+   for did not match.
+
+   The groups are tried from the last defined to the first, which is the
+   order CRuby takes them in: `(?<x>ab)(?<x>a)\k<x>` matches "abaa" rather
+   than the "abaab" the first group would reach. A group that took no part
+   in the match holds no text and matches nothing, so it falls through to
+   the next like a group whose text is not there; where none of them
+   matches, the whole reference fails, as `(?:(?<x>a))?\k<x>` does against
+   "".
+
+   The first group that matches is the one the reference takes, and a
+   failure after it does not come back for another: CRuby refuses
+   `\A(?<x>a)(?<x>ab)\k<x>b\z` against "aabab", where taking "a" instead of
+   "ab" would have matched. That is what the atomic group around the
+   alternatives says, and it is why this is not the plain alternation the
+   same groups would spell. */
+static void
+emit_multi_backref(re_compiler *c, uint32_t set, uint8_t fold)
+{
+  uint32_t taken[RE_MAX_CAPTURES];  /* the arms' jumps to the join point */
+  uint32_t num_taken = 0;
+  uint16_t cut = (uint16_t)++c->num_cuts;
+
+  emit(c, RE_ATOMIC, 0, cut);
+  for (int g = RE_MAX_CAPTURES - 1; g > 0; g--) {
+    if (!((set >> g) & 1)) continue;
+    set &= ~((uint32_t)1 << g);
+    if (set == 0) {
+      /* The last arm: nothing follows it to fall through to, so it fails
+         the reference itself rather than forking first. */
+      emit(c, RE_BACKREF, (uint8_t)g, fold);
+      break;
+    }
+    uint32_t fork = emit(c, RE_SPLIT, 0, 0);
+    emit(c, RE_BACKREF, (uint8_t)g, fold);
+    taken[num_taken++] = emit(c, RE_JMP, 0, 0);
+    patch(c, fork, (uint16_t)c->code_len);
+  }
+  for (uint32_t i = 0; i < num_taken; i++) {
+    patch(c, taken[i], (uint16_t)c->code_len);
+  }
+  emit(c, RE_ATOMIC_END, 0, cut);
+  c->needs_backtrack = TRUE;  /* the Pike VM cannot cut a thread */
 }
 
 /* Compile a single atom (character, class, anchor, escape). Returns whether
@@ -3406,10 +3469,19 @@ compile_atom(re_compiler *c)
              (c->p[1] == '<' || c->p[1] == '\'')) {
       /* \k<name> / \k'name': backreference to a named group. Numeric forms
          \k<2> (absolute) and \k<-1> (relative to the groups seen so far) are
-         also accepted, like the \g/\k family in Onigmo. */
+         also accepted, like the \g/\k family in Onigmo. A name the pattern
+         has given to several groups reaches every one of them, which takes
+         more than the one instruction; see emit_multi_backref(). */
       next_char(c);  /* skip k */
-      int group = parse_group_ref(c);
-      emit(c, RE_BACKREF, (uint8_t)group, (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0);
+      uint32_t set;
+      int group = parse_group_ref(c, &set);
+      uint8_t fold = (c->flags & RE_FLAG_IGNORECASE) ? 1 : 0;
+      if (set & (set - 1)) {
+        emit_multi_backref(c, set, fold);
+      }
+      else {
+        emit(c, RE_BACKREF, (uint8_t)group, fold);
+      }
       c->has_backref = TRUE;
     }
     else if (ch == 'g' && c->p + 1 < c->src_end &&

--- a/mrbgems/mruby-regexp/test/regexp_syntax.rb
+++ b/mrbgems/mruby-regexp/test/regexp_syntax.rb
@@ -2362,6 +2362,62 @@ assert("Regexp - named backreference \\k") do
   assert_nil "ab".match(/(?<n>a)\k<n>/i)
 end
 
+assert("Regexp - \\k on a name given to several groups") do
+  need_backtracking_stack
+  # a name the pattern gives to several groups is a reference to all of
+  # them: the reference matches where any one of them does, and the group
+  # that vouches for the text need not be the first the name was given to
+  assert_equal "abb", /(?<x>a)(?<x>b)\k<x>/.match("abb")[0]
+  assert_equal "aba", /(?<x>a)(?<x>b)\k<x>/.match("aba")[0]
+  assert_nil /(?<x>a)(?<x>b)\k<x>/.match("ab")
+  # a group that took no part in the match vouches for nothing, so the
+  # reference falls through to the ones that did
+  assert_equal "bb", /(?<x>a)|(?<x>b)\k<x>/.match("bb")[0]
+  assert_equal "bb", Regexp.new("(?<x>a)?(?<x>b)\\k<x>").match("bb")[0]
+  assert_equal "aa", Regexp.new("(?<x>a)(?:(?<x>b))?\\k<x>").match("aa")[0]
+  # and where none of them did the reference matches nothing
+  assert_nil Regexp.new("(?:(?<x>a))?\\k<x>").match("")
+  # a name given to more than two groups reads the ones between the last and
+  # the first as well, and passes over one of them that took no part
+  assert_equal "abcc", /(?<x>a)(?<x>b)(?<x>c)\k<x>/.match("abcc")[0]
+  assert_equal "abcb", /(?<x>a)(?<x>b)(?<x>c)\k<x>/.match("abcb")[0]
+  assert_equal "abca", /(?<x>a)(?<x>b)(?<x>c)\k<x>/.match("abca")[0]
+  assert_equal "aca", /(?<x>a)(?:(?<x>b))?(?<x>c)\k<x>/.match("aca")[0]
+  # both spellings of the reference reach the same groups
+  assert_equal "abb", /(?<x>a)(?<x>b)\k'x'/.match("abb")[0]
+
+  # the groups are tried from the last defined to the first, so where two of
+  # them match at the position the later one is the reference's
+  assert_equal "abaa", /(?<x>ab)(?<x>a)\k<x>/.match("abaab")[0]
+  assert_equal "aabab", /(?<x>a)(?<x>ab)\k<x>/.match("aabab")[0]
+  # the first that matches is the reference's for good: a failure after it
+  # never comes back for another, so this refuses "aabab" although the
+  # shorter group would have carried it
+  assert_nil /\A(?<x>a)(?<x>ab)\k<x>b\z/.match("aabab")
+
+  # the reference reaches the groups the name has been given where it
+  # stands, not the ones written after it
+  assert_equal "aab", /(?<x>a)\k<x>(?<x>b)/.match("aab")[0]
+  # the group the reference stands inside is one of them, and holds no text
+  # where the reference reads it, so the reference passes over it
+  assert_equal "aba", /(?<x>a)(?<x>b\k<x>)/.match("aba")[0]
+  # each group is compared as the reference's own case reading asks
+  assert_equal "abB", /(?<x>a)(?<x>b)\k<x>/i.match("abB")[0]
+  assert_nil Regexp.new("(?i:(?<x>A)(?<x>b))\\k<x>").match("AbB")
+  # a quantifier repeats the whole reference
+  assert_equal "abbb", /\A(?<x>a)(?<x>b)\k<x>{2}\z/.match("abbb")[0]
+  # a look-behind refuses a body that reads a capture, this reference among
+  # them, and says so the way it does of the one that reads a single group
+  src = "(?<=(?<x>a)(?<x>b)\\k<x>)"
+  assert_raise_with_message(RegexpError, "invalid pattern in look-behind: /#{src}/") do
+    Regexp.new(src)
+  end
+  # a conditional on the same name is not this: it tests the first group of
+  # the name and no other
+  assert_nil Regexp.new("(?<x>a)?(?<x>b)(?(<x>)y|z)").match("by")
+  assert_equal "bz", Regexp.new("(?<x>a)?(?<x>b)(?(<x>)y|z)").match("bz")[0]
+end
+
 assert("Regexp - a \\k reference names a group the pattern has") do
   # an unknown name is an error
   assert_raise(RegexpError) { Regexp.new("\\k<missing>") }


### PR DESCRIPTION
## Summary

A name a pattern gives to several groups is one reference to all of them in CRuby: `\k<name>` tries the capture of each group the name was given to and matches where any of them does. This engine resolved the name to a single group as it parsed the reference, so a subject only another group could vouch for did not match.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-regexp/src/re_compile.c` | `parse_group_ref()` answers the whole set of groups a name was given, and `\k` on a name with more than one of them emits `emit_multi_backref()`'s alternatives instead of one `RE_BACKREF` |
| `mrbgems/mruby-regexp/test/regexp_syntax.rb` | what such a reference reads, in what order, and what it does not go back to |

### What the reference reads

The groups the name has been given where the reference stands, and not the ones written after it: the table `parse_group_ref()` walks holds a group from the point it is opened, so `(?<x>a)\k<x>(?<x>b)` reads group 1 alone, as it does in CRuby. A group that took no part in the match vouches for nothing and the reference falls through to the next; where none of them took part it matches nothing at all.

They are tried from the last group of the name to the first, which is the order CRuby takes them in and the one its readers already agree with, `MatchData#[]` answering the last group of the name that matched. Where two of them match at the position, the later one is the reference's:

```ruby
/(?<x>ab)(?<x>a)\k<x>/.match("abaab")   # => #<MatchData "abaa" x:"ab" x:"a">
```

### Why the alternatives stand in an atomic group

The first group that matches is the one the reference takes, and a failure after it does not come back for another. That is CRuby's rule as well:

```ruby
/\A(?<x>a)(?<x>ab)\k<x>b\z/.match("aabab")   # => nil
```

The subject is there for the reference to take `a` and go on to the `b`, and neither engine takes it. A plain alternation over the groups would, so what is emitted is that alternation inside an atomic group, whose cut is exactly the rule above. Nothing else is needed: `RE_ATOMIC`, `RE_SPLIT` and `RE_BACKREF` already carry it, and the reference costs no new opcode and no new state on the pattern.

### What is left alone

The condition of a conditional reads the same spellings through the same function and keeps naming one group, the first of the name, which is what CRuby answers there:

```ruby
Regexp.new("(?<x>a)?(?<x>b)(?(<x>)y|z)").match("bz")   # => #<MatchData "bz" x:nil x:"b">
```

A `\g` call to such a name stays refused, as it is in CRuby, and the numeric spellings `\k<n>` and `\k<-n>` name the one group they always did.

## Behaviour

```ruby
/(?<x>a)(?<x>b)\k<x>/.match("abb")
# CRuby: #<MatchData "abb" x:"a" x:"b">, mruby: nil
/(?<x>a)|(?<x>b)\k<x>/.match("bb")
# CRuby: #<MatchData "bb" x:nil x:"b">,  mruby: nil
Regexp.new("(?<x>a)?(?<x>b)\\k<x>").match("bb")
# CRuby: #<MatchData "bb" x:nil x:"b">,  mruby: nil
```

Only a pattern that gives one name to several groups is affected; every other reference compiles to the instruction it did before. Such a reference now does the work of the groups it reads rather than of one, so a pattern standing just under `MRB_REGEXP_STEP_LIMIT` through one of them may reach it.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,991,110 | 1,991,830 | +720 |
| bintest | 1,397,030 | 1,398,070 | +1,040 |
| cxx_abi | 1,429,369 | 1,430,793 | +1,424 |
| byte-string | 1,359,910 | 1,359,350 | -560 |
| ascii-ctype | 1,382,518 | 1,382,374 | -144 |
| no-float | 1,322,574 | 1,323,614 | +1,040 |
| no-bigint | 1,281,062 | 1,282,102 | +1,040 |

The delta is `re_compile.o` alone, and inside it `compile_atom()` and `parse_group_ref()`. `emit_multi_backref()` has one call site and is inlined into `compile_atom()` wherever the compiler optimises, whose own size it then decides differently from build to build: the same source is 864 bytes larger there in the bintest build and 736 bytes smaller in the byte-string one, which is where the two negative rows come from. `parse_group_ref()` grows 173 bytes in every optimised build. The `-O0` row is the one that shows the function itself, 588 bytes of it, with `compile_atom()` growing 51 and `parse_group_ref()` 73.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2710 | 2636 | 74 | 0 | 0 | 0 |
| full-debug | 2958 | 2947 | 11 | 0 | 0 | 0 |
| bintest | 2958 | 2938 | 20 | 0 | 0 | 0 |
| cxx_abi | 2958 | 2938 | 20 | 0 | 0 | 0 |
| byte-string | 2870 | 2796 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2942 | 2920 | 22 | 0 | 0 | 0 |
| no-float | 2691 | 2594 | 97 | 0 | 0 | 0 |
| no-bigint | 2907 | 2874 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO.

The new test pins what the reference reads, which of the groups it reads first, that a group that took no part in the match is passed over and that a reference whose groups all did fails, that the group it took is not given back to a failure after it, that a name given to more than two groups reads the ones between the last and the first as well, that `\k<x>` and `\k'x'` reach the same groups, that the group the reference stands inside is one of them and holds no text there, that the reference is compared under the case reading where it stands rather than where the groups were written, that a quantifier repeats the whole of it, that a look-behind refuses it the way it refuses a reference to a single group, and that the conditional on the same name still names one group.

The suite was run again with `MRB_REGEXP_STEP_LIMIT` at 32, 64, 128, 256, 512 and 1024. The outcome is master's at every one of them, the same tests giving up at 32 and 64 for reasons of their own, and the new test passes down to 32.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/string.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Named backreferences can now resolve against multiple capture groups sharing the same name.
  * Matching tries eligible captures in reverse definition order and supports backtracking.
  * Case sensitivity, quantifiers, look-behind, and conditionals behave consistently with named multi-group references.

* **Tests**
  * Added coverage for duplicate-name backreferences, matching order, scope, case handling, quantifiers, look-behind restrictions, and conditional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->