### PR TITLE
ci: lint what lands on master, not only what is proposed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,16 @@ jobs:
           # a minute together while the seven builds take ten of the job's
           # fifteen, so this runner is asked for its ABI and not for what
           # reads the same everywhere.  See build_config/ci/gcc-clang.rb.
-          - {os: windows-2025, cc: gcc, cxx: g++, altname: "mingw-gcc", abi_only: "1"}
-          - {os: windows-2022, cc: gcc, cxx: g++, altname: "mingw-gcc", abi_only: "1"}
+          - os: windows-2025
+            cc: gcc
+            cxx: g++
+            altname: "mingw-gcc"
+            abi_only: "1"
+          - os: windows-2022
+            cc: gcc
+            cxx: g++
+            altname: "mingw-gcc"
+            abi_only: "1"
     env:
       MRUBY_CONFIG: ci/gcc-clang
       CC: ${{ matrix.cc }}

--- a/.github/workflows/pre-commit-manual.yml
+++ b/.github/workflows/pre-commit-manual.yml
@@ -1,7 +1,11 @@
 # https://github.com/j178/prek
 name: Manual hooks
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,7 +1,11 @@
 # https://github.com/j178/prek
 name: pre-commit
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Both prek workflows answer to `pull_request` alone, so nothing lints a commit that is pushed straight to master. 0efb6f0fd went in that way and left `Manual hooks` failing on master until the next pull request happened to report it. Naming master under `push` closes that gap.

This branches on top of #7531 and contains its diff, which is what makes `Manual hooks` green here; the tip commit is the `on:` block of each workflow and nothing else.

## Changes

| File | What |
| --- | --- |
| `.github/workflows/pre-commit.yml` | runs on pushes to master as well as on pull requests |
| `.github/workflows/pre-commit-manual.yml` | the same |

### Why master appears under `pull_request` too

`codeql-analysis.yml` names master under both events, and these two now read the same way, so every workflow that watches master says so in the same words. A pull request never comes from master, so the two events do not both fire for one run.

### What this leaves alone

`super-linter.yml` and `ls-lint.yml` still answer to `pull_request` alone. They can follow later if this is the shape you want; this keeps the change to the two workflows that run prek, the ones the failure showed up in.

## Testing

| Stage | Command | Result |
| --- | --- | --- |
| default | `prek run --from-ref HEAD^ --to-ref HEAD` | all hooks pass, `actionlint`, `check-yaml` and `yamllint` among them |
| manual | `prek run --all-files --hook-stage manual` | all hooks pass, the working tree left clean |

Whether a push to master starts the workflows is not something a fork can show, since the branch that would carry the change is not master; `actionlint` and `check-yaml` cover the syntax, and the trigger is the one `codeql-analysis.yml` has been using.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build configuration formatting without changing Windows compiler settings.
  * Updated pre-commit checks to run for pushes to and pull requests targeting the `master` branch.
  * Updated manual pre-commit checks to use the same branch-specific triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->