### PR TITLE
proc.c: let the walks for local variables pass a `define_method` scope

### DIFF
--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -121,6 +121,13 @@ struct RProc {
 } while (0)
 #define MRB_PROC_SCOPE 2048
 #define MRB_PROC_SCOPE_P(p) (((p)->flags & MRB_PROC_SCOPE) != 0)
+/* Where a walk up the `upper` chain looking for local variables has to
+   stop.  A proc `def` made carries no env, and the locals of the scope it
+   was written in are not its own.  `define_method` marks the block it
+   installs a scope too, but that block keeps the closure it was made with:
+   its `upper` chain is that closure chain, which is what the runtime walk
+   (`uvenv()`) follows, so its locals go on up. */
+#define MRB_PROC_LVAR_BOUNDARY_P(p) (MRB_PROC_SCOPE_P(p) && !MRB_PROC_ENV_P(p))
 #define MRB_PROC_NOARG 4096 /* for MRB_PROC_CFUNC_FL, aspec == MRB_ARGS_NONE() */
 #define MRB_PROC_NOARG_P(p) (((p)->flags & MRB_PROC_NOARG) != 0)
 #define MRB_PROC_ALIAS 8192

--- a/mrbgems/mruby-binding/mrbgem.rake
+++ b/mrbgems/mruby-binding/mrbgem.rake
@@ -4,4 +4,5 @@ MRuby::Gem::Specification.new('mruby-binding') do |spec|
   spec.summary = 'Binding class (core features only)'
 
   spec.add_test_dependency('mruby-proc-ext', :core => 'mruby-proc-ext')
+  spec.add_test_dependency('mruby-metaprog', :core => 'mruby-metaprog')
 end

--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -121,7 +121,7 @@ binding_check_proc_upper_count(mrb_state *mrb, const struct RProc *proc)
       mrb_raise(mrb, E_RUNTIME_ERROR,
                 "too many upper procs for local variables (mruby limitation; maximum is " MRB_STRINGIZE(BINDING_UPPER_MAX) ")");
     }
-    if (MRB_PROC_SCOPE_P(proc)) break;
+    if (MRB_PROC_LVAR_BOUNDARY_P(proc)) break;
   }
 }
 
@@ -242,7 +242,7 @@ binding_local_variable_search(mrb_state *mrb, const struct RProc *proc, struct R
       }
     }
 
-    if (MRB_PROC_SCOPE_P(proc)) break;
+    if (MRB_PROC_LVAR_BOUNDARY_P(proc)) break;
     env = MRB_PROC_ENV(proc);
     proc = proc->upper;
   }

--- a/mrbgems/mruby-binding/test/binding.rb
+++ b/mrbgems/mruby-binding/test/binding.rb
@@ -100,3 +100,36 @@ assert "Binding#local_variable_set over an env without the slot" do
   GC.start
   assert_equal 42, b.local_variable_get(:merged_lvar)
 end
+
+assert "a binding taken in a `define_method` block sees the block's closure" do
+  # `define_method` marks the block it installs a scope, the way `def` marks
+  # a method body, but the block keeps the closure it was made with: the
+  # locals a direct reference reaches from inside it are the binding's too.
+  factory = Object.new
+  def factory.build
+    x = 10
+    k = Class.new
+    k.send(:define_method, :direct) { x }
+    k.send(:define_method, :names) { binding.local_variables.sort }
+    k.send(:define_method, :get) { binding.local_variable_get(:x) }
+    k.send(:define_method, :set) { binding.local_variable_set(:x, 20) }
+    k.send(:define_method, :own) { |a| b = 1; binding.local_variables.sort }
+    k
+  end
+  k = factory.build
+  o = k.new
+
+  assert_equal [:k, :x], o.names
+  assert_equal 10, o.get
+  assert_equal [:a, :b, :k, :x], o.own(0)
+
+  # The store reaches the captured local itself, so the direct reference and
+  # the next instance both see it.
+  assert_equal 20, o.set
+  assert_equal 20, o.direct
+  assert_equal 20, k.new.get
+
+  # A `def` body carries no closure, and the locals around it are not its own.
+  c = Class.new { def m; binding.local_variables; end }
+  assert_equal [], c.new.m
+end

--- a/mrbgems/mruby-compiler/include/mrc_proc.h
+++ b/mrbgems/mruby-compiler/include/mrc_proc.h
@@ -32,8 +32,12 @@ struct RProc {
 /* The flags of that struct, mirrored the same way. */
 #define MRC_PROC_CFUNC_FL 128
 #define MRC_PROC_CFUNC_P(p) (((p)->flags & MRC_PROC_CFUNC_FL) != 0)
+#define MRC_PROC_ENVSET 1024
+#define MRC_PROC_ENV_P(p) (((p)->flags & MRC_PROC_ENVSET) != 0)
 #define MRC_PROC_SCOPE 2048
 #define MRC_PROC_SCOPE_P(p) (((p)->flags & MRC_PROC_SCOPE) != 0)
+/* MRB_PROC_LVAR_BOUNDARY_P() in mruby/proc.h */
+#define MRC_PROC_LVAR_BOUNDARY_P(p) (MRC_PROC_SCOPE_P(p) && !MRC_PROC_ENV_P(p))
 
 MRC_END_DECL
 

--- a/mrbgems/mruby-compiler/include/mrc_proc.h
+++ b/mrbgems/mruby-compiler/include/mrc_proc.h
@@ -29,6 +29,12 @@ struct RProc {
 };
 #endif /* !MRUBY_PROC_H */
 
+/* The flags of that struct, mirrored the same way. */
+#define MRC_PROC_CFUNC_FL 128
+#define MRC_PROC_CFUNC_P(p) (((p)->flags & MRC_PROC_CFUNC_FL) != 0)
+#define MRC_PROC_SCOPE 2048
+#define MRC_PROC_SCOPE_P(p) (((p)->flags & MRC_PROC_SCOPE) != 0)
+
 MRC_END_DECL
 
 #endif // MRC_PROC_H

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1005,7 +1005,7 @@ search_upvar(mrc_codegen_scope *s, mrc_sym id, int *idx)
           }
         }
       }
-      if (MRC_PROC_SCOPE_P(u)) break;
+      if (MRC_PROC_LVAR_BOUNDARY_P(u)) break;
       u = u->upper;
       lv++;
     }

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -969,11 +969,6 @@ lv_idx(mrc_codegen_scope *s, mrc_sym id)
 }
 
 
-#define MRC_PROC_CFUNC_FL 128
-#define MRC_PROC_CFUNC_P(p) (((p)->flags & MRC_PROC_CFUNC_FL) != 0)
-#define MRC_PROC_SCOPE 2048
-#define MRC_PROC_SCOPE_P(p) (((p)->flags & MRC_PROC_SCOPE) != 0)
-
 static int
 search_upvar(mrc_codegen_scope *s, mrc_sym id, int *idx)
 {

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -2312,48 +2312,6 @@ gen_hash(mrc_codegen_scope *s, mrc_node *tree, int val, int limit)
   return len;
 }
 
-#if defined(MRC_TARGET_MRUBY)
-static mrc_bool
-mrc_mruby_numbered_parameter_upvar(mrc_codegen_scope *s, mrc_sym id, int *lv, int *idx)
-{
-  if (id == PM_CONSTANT_ID_UNSET || id > s->c->p->constant_pool.size) {
-    return FALSE;
-  }
-
-  pm_constant_t *constant = pm_constant_pool_id_to_constant(&s->c->p->constant_pool, id);
-  if (constant->length != 2 || constant->start[0] != '_' ||
-      constant->start[1] < '1' || constant->start[1] > '9') {
-    return FALSE;
-  }
-
-  mrc_sym intern = mrb_intern(s->c->mrb, (const char *)constant->start, constant->length);
-  const struct RProc *u = s->c->upper;
-  *lv = 0;
-  while (u && !MRC_PROC_CFUNC_P(u)) {
-    const struct mrc_irep *ir = (const struct mrc_irep *)u->body.irep;
-    uint_fast16_t n = ir->nlocals;
-    const mrc_sym *v = ir->lv;
-    int number = constant->start[1] - '0';
-    if (v) {
-      for (int i = 1; n > 1; n--, v++, i++) {
-        if (*v == intern) {
-          *idx = i;
-          return TRUE;
-        }
-      }
-    }
-    else if (number < ir->nlocals) {
-      *idx = number;
-      return TRUE;
-    }
-    if (MRC_PROC_SCOPE_P(u)) break;
-    u = u->upper;
-    (*lv)++;
-  }
-  return FALSE;
-}
-#endif
-
 /* Attribute assignment (`recv.attr = v`, `recv[i] = v`) as an expression.
    Prism bundles the RHS as the last positional argument of the call node.
    The whole expression must evaluate to that RHS, not to the setter's
@@ -2479,19 +2437,6 @@ gen_call(mrc_codegen_scope *s, mrc_node *tree, int val, int safe, int recv_ready
   }
   int skip = 0, n = 0, nk = 0, noop = no_optimize(s), noself = 0, blk = 0;
   int sp_save = recv_ready ? cursp()-1 : cursp();
-
-#if defined(MRC_TARGET_MRUBY)
-  if (cast->receiver == NULL && cast->arguments == NULL && cast->block == NULL) {
-    int lv, idx;
-    if (mrc_mruby_numbered_parameter_upvar(s, sym, &lv, &idx)) {
-      if (val) {
-        genop_3(s, OP_GETUPVAR, cursp(), idx, lv);
-        push();
-      }
-      return;
-    }
-  }
-#endif
 
   if (recv_ready) {
     /* the receiver has been evaluated already and sits at cursp()-1 */

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -78,9 +78,6 @@ partial_hook(void *data, pm_parser_t *p, pm_token_t *token)
 }
 
 #if defined(MRC_TARGET_MRUBY)
-#define MRC_PROC_CFUNC_FL 128
-#define MRC_PROC_CFUNC_P(p) (((p)->flags & MRC_PROC_CFUNC_FL) != 0)
-
 static mrc_bool
 mrc_mruby_lvspace_proc_p(const struct RProc *proc)
 {

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -132,11 +132,20 @@ mrc_pm_options_init(mrc_ccontext *cc)
   pm_string_t *encoding = &options->encoding;
   pm_string_constant_init(encoding, "UTF-8", 5);
 
+  /* The scopes the string is compiled against are the ones codegen can reach
+     from here, so this walk ends where the chain of local variables does
+     (MRB_PROC_LVAR_BOUNDARY_P() in mruby/proc.h). A scope past that end
+     resolves a name in the parser that codegen would then have nowhere to
+     put. Both loops below ask the question of every proc, including one whose
+     scope is left out: an empty scope is indistinguishable from a binding's
+     local-variable space, and the two have to end on the same proc for the
+     index the second one counts down to hold. */
   size_t scopes_count = 0;
   for (u = (struct RProc *)cc->upper; u && !MRC_PROC_CFUNC_P(u); u = (struct RProc *)u->upper) {
     if (!mrc_mruby_lvspace_proc_p(u)) {
       scopes_count++;
     }
+    if (MRC_PROC_LVAR_BOUNDARY_P(u)) break;
   }
 
   pm_options_scopes_init(options, scopes_count + 1); // Prism requires one more scope
@@ -145,26 +154,26 @@ mrc_pm_options_init(mrc_ccontext *cc)
   pm_options_scope_t *scope;
   size_t scope_index = scopes_count;
   for (; u && !MRC_PROC_CFUNC_P(u); u = (struct RProc *)u->upper) {
-    if (mrc_mruby_lvspace_proc_p(u)) {
-      continue;
-    }
-    const struct mrc_irep *ir = (const struct mrc_irep *)u->body.irep;
-    size_t lv_count = ir->nlocals > 0 ? ir->nlocals - 1 : 0;
-    const mrc_sym *v = ir->lv;
-    size_t locals_count = mrc_mruby_irep_local_count(cc->mrb, ir);
+    if (!mrc_mruby_lvspace_proc_p(u)) {
+      const struct mrc_irep *ir = (const struct mrc_irep *)u->body.irep;
+      size_t lv_count = ir->nlocals > 0 ? ir->nlocals - 1 : 0;
+      const mrc_sym *v = ir->lv;
+      size_t locals_count = mrc_mruby_irep_local_count(cc->mrb, ir);
 
-    scope = &options->scopes[--scope_index];
-    pm_options_scope_init(scope, locals_count);
-    if (v) {
-      const char *name;
-      size_t local_index = 0;
-      for (size_t j = 0; j < lv_count; j++) {
-        name = mrb_sym_name(cc->mrb, v[j]);
-        if (name) {
-          mrc_mruby_options_scope_local_init(cc, &scope->locals[local_index++], v[j]);
+      scope = &options->scopes[--scope_index];
+      pm_options_scope_init(scope, locals_count);
+      if (v) {
+        const char *name;
+        size_t local_index = 0;
+        for (size_t j = 0; j < lv_count; j++) {
+          name = mrb_sym_name(cc->mrb, v[j]);
+          if (name) {
+            mrc_mruby_options_scope_local_init(cc, &scope->locals[local_index++], v[j]);
+          }
         }
       }
     }
+    if (MRC_PROC_LVAR_BOUNDARY_P(u)) break;
   }
 
   cc->options = options;

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -462,3 +462,22 @@ assert('a string given to eval in a `define_method` block sees the closure') do
   assert_equal 20, o.direct
   assert_equal 20, k.new.read
 end
+
+assert('a string given to eval in a `def` body has no scope around it') do
+  # A method body carries no closure, so a local of the scope it was written
+  # in is not a name it can reach: it is a method call there.
+  class TestEvalDefScope
+    x = 10
+    def hidden; eval("x"); end
+    def self.hidden_singleton; eval("x"); end
+
+    class << self
+      y = 30
+      def hidden_sclass; eval("y"); end
+    end
+  end
+
+  assert_raise(NameError) { TestEvalDefScope.new.hidden }
+  assert_raise(NameError) { TestEvalDefScope.hidden_singleton }
+  assert_raise(NameError) { TestEvalDefScope.hidden_sclass }
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -415,3 +415,50 @@ assert('`return` in a string given to eval leaves the calling method') do
   assert_equal :inner, o.ret_def
   assert_equal :lambda, o.ret_lambda
 end
+
+assert('a string given to eval in a `define_method` block sees the closure') do
+  # `define_method` marks the block it installs a scope, the way `def` marks a
+  # method body, but the block keeps the closure it was made with: what a
+  # direct reference reaches from inside it, `eval` reaches too.
+  class TestEvalDefineMethod
+    x = 10
+    define_method(:direct) { x }
+    define_method(:read) { eval("x") }
+    define_method(:own) { |a| b = 1; eval("[a, b, x]") }
+    define_method(:nested) { [1].map { eval("x") } }
+    define_method(:by_lambda, lambda { eval("x") })
+    define_method(:write) { eval("x = 20") }
+
+    class << self
+      y = 30
+      define_method(:sclass_read) { eval("y") }
+    end
+  end
+
+  # A scope with no locals of its own is still a scope the block closes over,
+  # and the walk that builds the parser's scope list has to end at it all the
+  # same: it is the shape a binding's local-variable space takes too.
+  class TestEvalEmptyScope
+    1.times do
+      z = 40
+      define_method(:from_block) { eval("z") }
+    end
+  end
+
+  k = TestEvalDefineMethod
+  o = k.new
+
+  assert_equal 10, o.direct
+  assert_equal 10, o.read
+  assert_equal [5, 1, 10], o.own(5)
+  assert_equal [10], o.nested
+  assert_equal 10, o.by_lambda
+  assert_equal 30, k.sclass_read
+  assert_equal 40, TestEvalEmptyScope.new.from_block
+
+  # The store reaches the captured local itself, so the direct reference and
+  # the next instance both see it.
+  assert_equal 20, o.write
+  assert_equal 20, o.direct
+  assert_equal 20, k.new.read
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -184,14 +184,17 @@ assert('Calling the same method as the variable name') do
   assert_equal("Hit!") { fuga = "Miss!"; eval("-> { hoge.fuga }").call }
 end
 
-assert('Access numbered parameter from eval') do
+assert('a numbered parameter is not a name an eval string can use') do
+  # A numbered parameter belongs to the block that spells it, and a string is
+  # compiled with no block of its own, so the name is a method call there.
   hoge = Object.new
   def hoge.fuga(a, &b)
     b.call(a)
   end
-  assert_equal(6) {
-    hoge.fuga(3) { _1 + eval("_1") }
-  }
+  assert_equal(3) { hoge.fuga(3) { _1 } }
+  assert_raise(NameError) { hoge.fuga(3) { _1 + eval("_1") } }
+  assert_raise(NameError) { hoge.fuga(3) { eval("_1") } }
+  assert_raise(NameError) { hoge.fuga(3) { |a| eval("_1") } }
 end
 
 assert('Module#class_eval with string') do

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -121,6 +121,17 @@ assert('Kernel#local_variables', '15.3.1.3.28') do
   end
 
   assert_equal [:a], local_var_list
+
+  # A `define_method` block keeps the closure it was made with, so the locals
+  # it closes over are among its own; the `def` above it ends the walk.
+  def local_var_dm_maker(kl)
+    b = 2
+    kl.send(:define_method, :dm_list) { local_variables.sort }
+  end
+
+  k = Class.new
+  local_var_dm_maker(k)
+  assert_equal [:b, :kl], k.new.dm_list
 end
 
 # Kernel.local_variables is not provided by mruby. '15.3.1.2.7'

--- a/src/proc.c
+++ b/src/proc.c
@@ -498,7 +498,7 @@ mrb_proc_local_variables(mrb_state *mrb, const struct RProc *proc)
         }
       }
     }
-    if (MRB_PROC_SCOPE_P(proc)) break;
+    if (MRB_PROC_LVAR_BOUNDARY_P(proc)) break;
     proc = proc->upper;
   }
 


### PR DESCRIPTION
## Summary

A block that `define_method` turns into a method keeps its closure, and a direct reference to a local of the enclosing scope works. `eval` inside that block could not compile the same reference and `binding` inside it listed no locals at all: `mrb_define_method_raw()` marks the proc it installs `MRB_PROC_SCOPE`, and every walk that looks for local variables took the flag for the end of the chain, while the runtime walk `uvenv()` follows `upper` by the level the bytecode names and never reads it. Stop at the flag only where the proc carries no env, which is where `def` sets it, and end the scope list the parser is given at the same place. What an `eval` string reaches for a local variable then answers what CRuby answers, in every shape a scope comes in.

## Changes

| File | What |
| --- | --- |
| `include/mruby/proc.h` | `MRB_PROC_LVAR_BOUNDARY_P()`, beside the flag whose meaning it narrows |
| `src/proc.c` | `mrb_proc_local_variables()` walks past a `define_method` scope |
| `mrbgems/mruby-binding/src/binding.c` | `binding_local_variable_search()` and the depth count do the same |
| `mrbgems/mruby-compiler/src/codegen.c` | `search_upvar()` does the same; the numbered-parameter walk is gone |
| `mrbgems/mruby-compiler/src/compile.c` | the scope list handed to Prism ends where those walks do |
| `mrbgems/mruby-compiler/include/mrc_proc.h` | the proc flags the compiler reads, mirrored beside the struct |
| `mrbgems/mruby-binding/mrbgem.rake` | test dependency on `mruby-metaprog`, for `define_method` |
| `mrbgems/mruby-eval/test/eval.rb` | the shapes a scope comes in, and what a numbered parameter is not |
| `mrbgems/mruby-binding/test/binding.rb` | a binding taken in a `define_method` block |
| `mrbgems/mruby-metaprog/test/metaprog.rb` | `Kernel#local_variables` in one |

### Which scopes end a chain of locals

`MRB_PROC_SCOPE` says a proc is a scope, and two things set it. `OP_METHOD` sets it on a proc built by `mrb_proc_new()`, which captures nothing, and `OP_EXEC` does the same for a class body; there the flag and "the locals stop here" say the same thing, because the proc has no env and its `upper` only leads to the scope it was written in. `mrb_define_method_raw()` sets it on whatever proc it is handed, and a block comes with an env and with the closure chain it was made in. That chain is the one `uvenv()` walks, so the flag on it says nothing about locals.

The env is what tells the two apart, and `MRB_PROC_ENV_P()` already reads it, so the walks ask for a scope without an env.

### The scope list the parser is given

`mrc_pm_options_init()` built that list from a walk that stopped at neither, so for an `eval` inside a `def` the parser resolved a name of the class body that codegen would then refuse to place, and the refusal is a `codegen_error()`: a `SyntaxError` where CRuby answers `NameError`. The list now ends where the walks that read it end, and the name is compiled as the method call it is.

The walk leaves out a scope with no locals of its own, which is the shape a binding's local-variable space also takes, so its two loops ask where to stop of every proc rather than only of the ones they keep; otherwise the count and the fill end on different procs and the index the second counts down runs past the array it was sized for.

### The numbered parameter

`_1` in an `eval` string was answered by a walk of its own, `mrc_mruby_numbered_parameter_upvar()`, which reached the numbered parameter of the block the string was written in and of every block around that one. A numbered parameter is a name the block that spells it owns, and a string is compiled with no block of its own, so CRuby has none to offer an `eval` string in any shape. The walk goes, and the name is compiled as the method call it is, the way every other unreachable name in this PR is.

## Behaviour

```ruby
class Foo
  x = 10
  define_method(:direct) { x }
  define_method(:through_eval) { eval("x") }
  define_method(:through_binding) { binding.local_variables }
  def hidden; eval("x"); end
end

Foo.new.direct              # CRuby: 10, mruby before: 10, after: 10
Foo.new.through_eval        # CRuby: 10, mruby before: SyntaxError, after: 10
Foo.new.through_binding     # CRuby: [:x], mruby before: [], after: [:x]
Foo.new.hidden              # CRuby: NameError, mruby before: SyntaxError, after: NoMethodError
[7].map { _1 + eval("_1") } # CRuby: NameError, mruby before: [14], after: NoMethodError
```

`Binding#local_variable_get`, `Binding#local_variable_set` and `Kernel#local_variables` reach the same locals as `eval` does, and a store through either reaches the captured local itself, so the direct reference and the next instance both see it. `NoMethodError` is a `NameError`, which is what a name with nothing to resolve to is worth; mruby answers a bare name that way wherever it has none, as it already did for `eval("def m; z; end")`.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,992,662 | 1,992,102 | -560 |
| bintest | 1,397,590 | 1,397,110 | -480 |
| cxx_abi | 1,429,257 | 1,428,809 | -448 |
| byte-string | 1,358,870 | 1,358,390 | -480 |
| ascii-ctype | 1,381,894 | 1,381,414 | -480 |
| no-float | 1,323,214 | 1,322,718 | -496 |
| no-bigint | 1,281,622 | 1,281,142 | -480 |

In the bintest build `codegen.o` loses 624 bytes, which is the numbered-parameter walk and the call that reached it; `compile.o` gains 112, the second stop and the reshaped loop body; `proc.o` and `binding.o` gain 16 each, the added flag test.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2718 | 2644 | 74 | 0 | 0 | 0 |
| full-debug | 2966 | 2955 | 11 | 0 | 0 | 0 |
| bintest | 2966 | 2946 | 20 | 0 | 0 | 0 |
| cxx_abi | 2966 | 2946 | 20 | 0 | 0 | 0 |
| byte-string | 2878 | 2804 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2950 | 2928 | 22 | 0 | 0 | 0 |
| no-float | 2699 | 2602 | 97 | 0 | 0 | 0 |
| no-bigint | 2915 | 2882 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO. What `mruby-bin-debugger` evaluates for its `print` command is a string compiled against a stopped frame, and its block-scope test is what caught the walk over the two loops in `mrc_pm_options_init()`.

The `eval` tests take the shapes a scope comes in and give the answer CRuby gives for each: a class body, a `class << self` body, a block inside the block, a lambda handed to `define_method`, and a class body with no locals of its own on the reaching side; a `def` body, `def self.name`, and a `def` in a `class << self` body on the side that reaches nothing. The binding test builds its class inside a method, so the walk has a boundary to stop at and the list of names is exact, and it ends on the same guard for a `def` body. The numbered-parameter test that pinned the old answer now pins the refusal, in the block's own parameter, in an empty block, and under a named parameter.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/proc.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/proc.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/proc.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local-variable and closure handling for bindings and methods created with `define_method`.
  - `eval` now more consistently accesses captured locals in closures, while ordinary `def` methods remain isolated from surrounding locals.
  - Local-variable lookup now correctly respects method boundaries.
  - Numbered parameters such as `_1` are no longer resolved from enclosing scopes inside `eval`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->