### PR TITLE
kernel.c: leave a method out of reach to respond_to_missing?

### DIFF
--- a/doc/guides/capi.md
+++ b/doc/guides/capi.md
@@ -831,7 +831,7 @@ mrb_cmp(mrb, a, b)      /* Ruby <=> (returns mrb_int) */
 mrb_obj_classname(mrb, obj)          /* class name as C string */
 mrb_obj_class(mrb, obj)              /* class as RClass* */
 mrb_obj_is_kind_of(mrb, obj, klass)  /* is_a? / kind_of? */
-mrb_obj_respond_to(mrb, klass, mid)  /* respond_to? */
+mrb_obj_respond_to(mrb, klass, mid)  /* implemented? any visibility */
 mrb_obj_id(obj)                      /* object_id */
 mrb_obj_freeze(mrb, obj)             /* freeze */
 mrb_obj_dup(mrb, obj)                /* dup */

--- a/include/mruby.h
+++ b/include/mruby.h
@@ -1005,7 +1005,12 @@ MRB_API mrb_value mrb_obj_dup(mrb_state *mrb, mrb_value obj);
 
 /**
  * Returns true if obj responds to the given method. If the method was defined for that
- * class it returns true, it returns false otherwise.
+ * class, and this build implements it, it returns true; it returns false otherwise.
+ *
+ * Visibility is not weighed: a private or protected method answers true here,
+ * where `Kernel#respond_to?` asked without `include_private` answers false. A
+ * method that stands for a feature this build does not have answers false, as
+ * it does there.
  *
  *      Example:
  *      # Ruby style

--- a/src/class.c
+++ b/src/class.c
@@ -4264,7 +4264,12 @@ mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
   mrb_sym id;
 
   mrb_get_args(mrb, "n", &id);
-  return mrb_bool_value(mrb_obj_respond_to(mrb, mrb_class_ptr(mod), id));
+  /* `mrb_obj_respond_to` answers for any method it finds, so the search is
+     made here to weigh the visibility the listing reports on. */
+  struct RClass *c = mrb_class_ptr(mod);
+  mrb_method_t m = mrb_method_search_vm(mrb, &c, id);
+  if (MRB_METHOD_UNDEF_P(m) || MRB_METHOD_NOTIMPL_P(m)) return mrb_false_value();
+  return mrb_bool_value(!(m.flags & MRB_METHOD_PRIVATE_FL));
 }
 
 void

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -618,32 +618,38 @@ mrb_obj_remove_instance_variable(mrb_state *mrb, mrb_value self)
  *     obj.respond_to?(symbol, include_private=false) -> true or false
  *
  *  Returns `true` if _obj_ responds to the given
- *  method. Private methods are included in the search only if the
- *  optional second parameter evaluates to `true`.
+ *  method. Private and protected methods are included in the search
+ *  only if the optional second parameter evaluates to `true`.
  *
  *  If the method is defined but unimplemented on this machine,
  *  as IO#pread in a build without pread(2), false is returned
  *  and `respond_to_missing?` is not consulted.
  *
- *  If the method is not defined, `respond_to_missing?`
- *  method is called and the result is returned.
+ *  If the method is not defined, or is defined where the second
+ *  parameter does not reach it, `respond_to_missing?` method is
+ *  called and the result is returned.
  */
 static mrb_bool
 obj_respond_to_p(mrb_state *mrb, mrb_value self, mrb_sym id, mrb_bool priv)
 {
   struct RClass *c = mrb_class(mrb, self);
   mrb_method_t m = mrb_method_search_vm(mrb, &c, id);
-  if (MRB_METHOD_UNDEF_P(m)) {
-    mrb_sym rtm_id = MRB_SYM_Q(respond_to_missing);
-    if (!mrb_func_basic_p(mrb, self, rtm_id, mrb_false)) {
-      mrb_value v = mrb_funcall_argv2(mrb, self, rtm_id, mrb_symbol_value(id), mrb_bool_value(priv));
-      return mrb_bool(v);
+  if (!MRB_METHOD_UNDEF_P(m)) {
+    /* A method that is unimplemented on this machine answers a plain false,
+       and leaves `respond_to_missing?` nothing to add. */
+    if (MRB_METHOD_NOTIMPL_P(m)) return FALSE;
+    /* A method the caller may not reach is answered as if it were not there,
+       so `respond_to_missing?` gets its say, as in CRuby. */
+    if (priv || !(m.flags & (MRB_METHOD_PRIVATE_FL|MRB_METHOD_PROTECTED_FL))) {
+      return TRUE;
     }
-    return FALSE;
   }
-  /* The method is there, so `respond_to_missing?` has nothing to add, and one
-     that is unimplemented on this machine answers a plain false. */
-  return !MRB_METHOD_NOTIMPL_P(m);
+  mrb_sym rtm_id = MRB_SYM_Q(respond_to_missing);
+  if (!mrb_func_basic_p(mrb, self, rtm_id, mrb_false)) {
+    mrb_value v = mrb_funcall_argv2(mrb, self, rtm_id, mrb_symbol_value(id), mrb_bool_value(priv));
+    return mrb_bool(v);
+  }
+  return FALSE;
 }
 
 static mrb_value

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -443,6 +443,139 @@ assert('Kernel#respond_to? skips respond_to_missing? for an unimplemented method
   # A method that exists leaves respond_to_missing? nothing to answer.
   assert_false cls.new.respond_to?(:gone)
   assert_true cls.new.respond_to?(:no_such_method)
+
+  # Hiding it changes nothing: what the build does not implement is answered
+  # before visibility is weighed, at either visibility asked for.
+  hidden = Class.new(TestNotImplement) do
+    private :gone
+    def respond_to_missing?(name, priv = false)
+      true
+    end
+  end
+  assert_false hidden.new.respond_to?(:gone)
+  assert_false hidden.new.respond_to?(:gone, true)
+end
+
+class RespondToVisibility
+  def pub; end
+  private def priv; end
+  protected def prot; end
+
+  def later; end
+  def again; end
+  private :later, :again
+  public :again
+
+  alias_method :priv_alias, :priv
+
+  def self.smeth; end
+  class << self
+    private def shidden; end
+  end
+end
+
+class RespondToVisibilityChild < RespondToVisibility; end
+
+module RespondToVisibilityModule
+  def mpub; end
+  private def mpriv; end
+  protected def mprot; end
+end
+
+class RespondToVisibilityIncluder
+  include RespondToVisibilityModule
+end
+
+module RespondToVisibilityPrepended
+  private def ppriv; end
+end
+
+class RespondToVisibilityPrepender
+  prepend RespondToVisibilityPrepended
+end
+
+assert('Kernel#respond_to? weighs how the method may be called') do
+  obj = RespondToVisibility.new
+
+  assert_true  obj.respond_to?(:pub)
+  assert_true  obj.respond_to?(:pub, true)
+
+  # A method a call with a receiver cannot reach is not one the object
+  # responds to, unless the second parameter asks for it.
+  assert_false obj.respond_to?(:priv)
+  assert_true  obj.respond_to?(:priv, true)
+  assert_false obj.respond_to?(:prot)
+  assert_true  obj.respond_to?(:prot, true)
+
+  # the visibility a name carries is what counts, however it got there,
+  # and it is the one it carries now
+  assert_false obj.respond_to?(:later)
+  assert_true  obj.respond_to?(:later, true)
+  assert_true  obj.respond_to?(:again)
+  assert_false obj.respond_to?(:priv_alias)
+  assert_true  obj.respond_to?(:priv_alias, true)
+
+  # a singleton method is public where the surrounding scope said nothing,
+  # and private where its own class body said so
+  assert_true  RespondToVisibility.respond_to?(:smeth)
+  assert_false RespondToVisibility.respond_to?(:shidden)
+  assert_true  RespondToVisibility.respond_to?(:shidden, true)
+
+  # the answer comes from wherever the method is found
+  child = RespondToVisibilityChild.new
+  assert_false child.respond_to?(:priv)
+  assert_true  child.respond_to?(:priv, true)
+
+  includer = RespondToVisibilityIncluder.new
+  assert_true  includer.respond_to?(:mpub)
+  assert_false includer.respond_to?(:mpriv)
+  assert_true  includer.respond_to?(:mpriv, true)
+  assert_false includer.respond_to?(:mprot)
+  assert_true  includer.respond_to?(:mprot, true)
+
+  prepender = RespondToVisibilityPrepender.new
+  assert_false prepender.respond_to?(:ppriv)
+  assert_true  prepender.respond_to?(:ppriv, true)
+
+  # the private methods mruby itself defines answer the same way
+  assert_false obj.respond_to?(:initialize)
+  assert_true  obj.respond_to?(:initialize, true)
+  assert_false obj.respond_to?(:method_missing)
+  assert_false obj.respond_to?(:respond_to_missing?)
+end
+
+class RespondToHidden
+  private def hidden; end
+
+  def asked; @asked; end
+
+  def respond_to_missing?(name, include_private = false)
+    @asked = [name, include_private]
+    name == :hidden
+  end
+end
+
+class RespondToRefused < RespondToHidden
+  def respond_to_missing?(name, include_private = false)
+    @asked = [name, include_private]
+    false
+  end
+end
+
+assert('Kernel#respond_to? leaves a method out of reach to respond_to_missing?') do
+  obj = RespondToHidden.new
+  assert_true obj.respond_to?(:hidden)
+  assert_equal [:hidden, false], obj.asked
+
+  # the second parameter is handed over as it was given
+  refused = RespondToRefused.new
+  assert_false refused.respond_to?(:hidden)
+  assert_equal [:hidden, false], refused.asked
+
+  # a method the second parameter reaches is answered without asking
+  reached = RespondToRefused.new
+  assert_true reached.respond_to?(:hidden, true)
+  assert_nil reached.asked
 end
 
 assert('an unimplemented method can be overridden, aliased and undefined') do

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -376,6 +376,63 @@ assert('Module#method_defined?', '15.2.2.4.34') do
   assert_false Test4MethodDefined::C.method_defined? "method4"
 end
 
+assert('Module#method_defined? reports the methods a listing reports') do
+  mod = Module.new do
+    def mpub; end
+    private def mpriv; end
+    protected def mprot; end
+  end
+  ahead = Module.new do
+    private def ppriv; end
+  end
+  cls = Class.new do
+    include mod
+    prepend ahead
+    def pub; end
+    private def priv; end
+    protected def prot; end
+    class << self
+      def spub; end
+      private def spriv; end
+      protected def sprot; end
+    end
+  end
+  sub = Class.new(cls)
+
+  # public and protected methods are matched, private ones are not
+  assert_true  cls.method_defined?(:pub)
+  assert_false cls.method_defined?(:priv)
+  assert_true  cls.method_defined?(:prot)
+
+  # wherever the method is found
+  assert_false sub.method_defined?(:priv)
+  assert_true  sub.method_defined?(:prot)
+  assert_true  cls.method_defined?(:mpub)
+  assert_false cls.method_defined?(:mpriv)
+  assert_true  cls.method_defined?(:mprot)
+  assert_false cls.method_defined?(:ppriv)
+
+  # a singleton class reports its own methods the same way
+  sclass = class << cls; self; end
+  assert_true  sclass.method_defined?(:spub)
+  assert_false sclass.method_defined?(:spriv)
+  assert_true  sclass.method_defined?(:sprot)
+
+  # the private methods mruby itself defines are not reported either
+  assert_false cls.method_defined?(:initialize)
+  assert_false cls.method_defined?(:method_missing)
+
+  # a name with no method behind it is not put to respond_to_missing?, which
+  # answers for a receiver rather than for what a module defines
+  answering = Class.new do
+    def respond_to_missing?(name, include_private = false)
+      true
+    end
+  end
+  assert_false answering.method_defined?(:no_such_method)
+  assert_true  answering.new.respond_to?(:no_such_method)
+end
+
 assert('Module#module_eval', '15.2.2.4.35') do
   module Test4ModuleEval
     @a = 11


### PR DESCRIPTION
## Summary

`Kernel#respond_to?` and `Module#method_defined?` answered from whether a name was found in the method table, without weighing the visibility of what they found, so every private and protected method was reported as one the object responds to and one the module defines.

## Changes

| File                 | What                                                                                         |
| -------------------- | -------------------------------------------------------------------------------------------- |
| `src/kernel.c`       | `obj_respond_to_p` hands a method it may not reach to `respond_to_missing?`                  |
| `src/class.c`        | `mrb_mod_method_defined` searches the table itself and leaves out the private methods        |
| `include/mruby.h`    | say that `mrb_obj_respond_to` does not weigh visibility                                      |
| `doc/guides/capi.md` | gloss `mrb_obj_respond_to` by what it answers rather than by `respond_to?`                   |
| `test/t/kernel.rb`   | what `respond_to?` answers for a method out of reach, and what it asks `respond_to_missing?` |
| `test/t/module.rb`   | what `method_defined?` reports across visibility, inheritance and an included module         |

### `respond_to?` did not read the second parameter once the name was there

`obj_respond_to_p` returned as soon as `mrb_method_search_vm` found a method, so `include_private` decided nothing except which value to hand `respond_to_missing?` for a name that was missing. The same object answered `nil` to `defined?(recv.meth)`, which weighs visibility, so the two disagreed about the same call.

CRuby's `basic_obj_respond_to` refuses outright only a method defined with `rb_f_notimplement`; a name it finds but cannot reach at the visibility asked for goes to `respond_to_missing?`, with the parameter as it was given. This does the same, in that order, so an object that defines `respond_to_missing?` can still speak for a name its class hides.

### `method_defined?` borrowed a C API that answers a different question

`mrb_mod_method_defined` called `mrb_obj_respond_to`, which reports any method the search reaches. The call-seq above the function has always said that public and protected methods are matched, and `instance_methods` already weighs visibility, so a module disagreed with itself about the same name.

The search is made in the function now and only the private methods are left out. `mrb_obj_respond_to` keeps its meaning: the conversions that go through it (`convert_type` behind `mrb_check_convert_type`, `mrb_ary_splat`, the `__case_eqq` a `case` builds) ask whether a method is there at all, not whether a call could reach it.

## Behaviour

```ruby
class Foo
  def pub; end
  private def priv; end
  protected def prot; end
end

Foo.new.respond_to?(:priv)         # CRuby: false, mruby: true
Foo.new.respond_to?(:prot)         # CRuby: false, mruby: true
Foo.new.respond_to?(:priv, true)   # CRuby: true,  mruby: true
Foo.new.respond_to?(:puts)         # CRuby: false, mruby: true
Foo.method_defined?(:priv)         # CRuby: false, mruby: true
```

A name a class hides is put to `respond_to_missing?`, and what comes back is the answer.

```ruby
class Refuses
  private def hidden; end
  def respond_to_missing?(name, include_private = false) = false
end

class Answers
  private def hidden; end
  def respond_to_missing?(name, include_private = false) = true
end

Refuses.new.respond_to?(:hidden)   # CRuby: false, mruby: true
Answers.new.respond_to?(:hidden)   # CRuby: true,  mruby: true
```

`Answers` reads the same as before, by a different route: the name used to be answered by the method table alone.

`defined?`, `methods` and `instance_methods` already answered as CRuby does and are unchanged.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, gcc 13.3.0.

| Build       | master    | this PR   | delta |
| ----------- | --------- | --------- | ----- |
| full-debug  | 1,992,662 | 1,992,758 | +96   |
| bintest     | 1,397,590 | 1,397,670 | +80   |
| cxx_abi     | 1,429,257 | 1,429,305 | +48   |
| byte-string | 1,358,870 | 1,358,950 | +80   |
| ascii-ctype | 1,381,894 | 1,381,974 | +80   |
| no-float    | 1,323,214 | 1,323,278 | +64   |
| no-bigint   | 1,281,622 | 1,281,702 | +80   |

`full-debug` is `-O0`. The whole delta is `src/kernel.o`: `src/class.o` is byte-identical in every build, because the search that replaced the call to `mrb_obj_respond_to` is what the call was inlined to.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2718  | 2644 | 74   | 0   | 0     | 0       |
| full-debug  | 2966  | 2955 | 11   | 0   | 0     | 0       |
| bintest     | 2966  | 2946 | 20   | 0   | 0     | 0       |
| cxx_abi     | 2966  | 2946 | 20   | 0   | 0     | 0       |
| byte-string | 2878  | 2804 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2950  | 2928 | 22   | 0   | 0     | 0       |
| no-float    | 2699  | 2602 | 97   | 0   | 0     | 0       |
| no-bigint   | 2915  | 2882 | 33   | 0   | 0     | 0       |

`bintest` runs the command binary tests as well: 147 total, 146 OK, 1 skip, 0 KO.

The new assertions cover a private and a protected method at either visibility asked for, and reach the flag by every route that sets it: `private` applied after the definition, `public` applied after that, an alias of a private method, a private method found through a subclass, through an included module and through a prepended one, a singleton method left public by the scope around it and one its own singleton class body made private, and the private methods mruby itself defines (`initialize`, `method_missing`, `respond_to_missing?`). A second block records what `respond_to_missing?` is asked and when: it receives the second parameter as given, and is not asked at all when that parameter reaches the method. A method the build does not implement is still refused before visibility is weighed, at either visibility. The `method_defined?` block covers the same ground and pins the two places it differs from `respond_to?`: protected methods are reported, and a name with no method behind it is not put to `respond_to_missing?`.

86 expressions over these two methods were run against CRuby 4.0.6 as well, including the ones the tests leave out because they are settled elsewhere: the truthiness of the second argument, a `respond_to_missing?` that raises or answers with a value that is neither `true` nor `false`, `method_missing` without `respond_to_missing?`, `undef_method`, `extend`, `module_function`, `define_method`, `attr_accessor` and a frozen receiver. One answer differs, and it is the missing argument below rather than a visibility question.

Out of scope, and still unlike CRuby: `Module#method_defined?` takes no `inherit` argument (`Sub.method_defined?(:pub, false)` raises `ArgumentError` where CRuby answers `false`), and there is no `public_method_defined?`, `private_method_defined?`, `protected_method_defined?` or `private_class_method`.

## Environment

<details>

| Item     | Value                                              |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                 |
| Kernel   | Linux 7.0.0-31-generic x86_64                      |
| CPU      | AMD Ryzen 9 5950X 16-Core                          |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)        |
| binutils | GNU ld 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, taken with `touch src/kernel.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped.

```console
host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/kernel.c

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/kernel.c

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
```

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `respond_to?` to respect method visibility. Private and protected methods are reported only when private-method checks are explicitly enabled.
  * `respond_to?` now correctly handles `respond_to_missing?` for inaccessible or unimplemented methods.
  * Updated `Module#method_defined?` to accurately distinguish private, protected, inherited, included, and singleton methods.

* **Documentation**
  * Clarified method visibility behavior in API documentation and examples.

* **Tests**
  * Added coverage for visibility, aliases, singleton methods, inheritance, and missing-method handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->