### PR TITLE
mruby-eval: give an eval string the visibility in effect around the call

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -763,6 +763,7 @@ mrb_shape_lookup(mrb_state *mrb, mrb_iv_shape *shape, mrb_sym sym)
 #define MRB_CI_MODFUNC_P(ci) MRB_FLAG_CHECK((ci)->vis, 3)
 #define MRB_CI_SET_MODFUNC(ci) MRB_FLAG_ON((ci)->vis, 3)
 #define MRB_CI_CLEAR_MODFUNC(ci) MRB_FLAG_OFF((ci)->vis, 3)
+void mrb_vm_ci_inherit_visibility(mrb_state *mrb, const struct RProc *p);
 mrb_int mrb_ci_bidx(mrb_callinfo *ci);
 mrb_int mrb_ci_nregs(mrb_callinfo *ci);
 mrb_value mrb_exec_irep(mrb_state *mrb, mrb_value self, const struct RProc *p);

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -143,8 +143,6 @@ eval_irep(mrb_state *mrb, mrb_value self, struct RProc *proc)
   /* no argument passed from eval() */
   ci->n = 0;
   ci->kw = FALSE;
-  /* clear visibility */
-  MRB_CI_SET_VISIBILITY_BREAK(ci);
   /* clear block */
   ci->stack[1] = mrb_nil_value();
   return mrb_exec_irep(mrb, self, proc);
@@ -300,6 +298,17 @@ f_eval(mrb_state *mrb, mrb_value self)
      with no env is a C function, which has no such name to lend. */
   struct REnv *e = MRB_PROC_ENV(proc);
   if (e) mrb->c->ci->mid = e->mid;
+  if (mrb_nil_p(binding)) {
+    /* The string runs in a copy of the caller's scope: a `def` in it answers
+       to the `private` written around the `eval` call, and a `private`
+       written inside the string reaches no further than its end. */
+    mrb_vm_ci_inherit_visibility(mrb, proc);
+    MRB_CI_SET_VISIBILITY_BREAK(mrb->c->ci);
+  }
+  /* A binding names a scope rather than copying one, so the frame is left
+     joined to it: the visibility written there reaches the string, and one
+     written in the string reaches back out to the scope and to every other
+     binding on it. */
   return eval_irep(mrb, self, proc);
 }
 
@@ -361,6 +370,9 @@ object_eval(mrb_state *mrb, mrb_value self, mrb_bool class_eval)
      in the string lands on the receiver. A `super` reads that same field for
      the class the method was found in, so there is no answer for it to give
      from this frame; the name the frame carries is left alone. */
+  /* The string gets the receiver for a scope rather than the caller's, so it
+     starts at the default and a visibility written in it ends with it. */
+  MRB_CI_SET_VISIBILITY_BREAK(mrb->c->ci);
   return eval_irep(mrb, self, proc);
 }
 

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -254,6 +254,97 @@ assert 'method visibility with eval' do
   end
 end
 
+assert 'a `def` in an eval string takes the visibility around the call' do
+  class Test4EvalVisibility
+    private
+    eval("def from_string; end")
+    protected
+    eval("def protected_from_string; end")
+    public
+    eval("def public_from_string; :ok; end")
+  end
+
+  o = Test4EvalVisibility.new
+  assert_raise(NoMethodError) { o.from_string }
+  assert_raise(NoMethodError) { o.protected_from_string }
+  assert_include Test4EvalVisibility.protected_instance_methods(false), :protected_from_string
+  assert_equal :ok, o.public_from_string
+end
+
+assert 'the visibility an eval string starts at is the one its whole scope is at' do
+  # The scope reaches the string through the env it shares with the caller, so
+  # a block between the two, and a second eval inside the first, are steps on
+  # the way to the `private` rather than scopes of their own.
+  class Test4EvalVisibilityNested
+    private
+    [1].each { eval("def from_block; end") }
+    eval("eval('def from_nested_string; end')")
+  end
+
+  o = Test4EvalVisibilityNested.new
+  assert_raise(NoMethodError) { o.from_block }
+  assert_raise(NoMethodError) { o.from_nested_string }
+end
+
+assert 'a `def` in an eval string follows a `module_function` around the call' do
+  module Test4EvalVisibilityModuleFunction
+    module_function
+    eval("def from_string; :ok; end")
+  end
+
+  assert_equal :ok, Test4EvalVisibilityModuleFunction.from_string
+  assert_include Test4EvalVisibilityModuleFunction.private_instance_methods(false), :from_string
+end
+
+assert 'eval with a binding takes the visibility where the binding was made' do
+  class Test4EvalVisibilityPublicScope
+    SCOPE = binding
+  end
+  class Test4EvalVisibilityPrivateScope
+    private
+    SCOPE = binding
+  end
+
+  # the binding names the scope the string runs in, so the visibility comes
+  # from there and not from the private scope the `eval` is called in
+  class Test4EvalVisibilityBindingCaller
+    private
+    eval("def from_public_scope; :ok; end", Test4EvalVisibilityPublicScope::SCOPE)
+    eval("def from_private_scope; end", Test4EvalVisibilityPrivateScope::SCOPE)
+  end
+
+  assert_equal :ok, Test4EvalVisibilityPublicScope.new.from_public_scope
+  assert_raise(NoMethodError) { Test4EvalVisibilityPrivateScope.new.from_private_scope }
+end
+
+assert 'a visibility written in a string given a binding stays with the scope' do
+  # A binding names a scope where a plain eval string copies one, so what the
+  # string writes reaches the scope itself and every other binding on it.
+  class Test4EvalVisibilityBindingWrite
+    FIRST = binding
+    SECOND = binding
+    eval("private", FIRST)
+    def written_after; end
+  end
+  eval("def from_the_other_binding; end", Test4EvalVisibilityBindingWrite::SECOND)
+
+  o = Test4EvalVisibilityBindingWrite.new
+  assert_raise(NoMethodError) { o.written_after }
+  assert_raise(NoMethodError) { o.from_the_other_binding }
+end
+
+assert 'a string given to class_eval starts public wherever it is called' do
+  # `class_eval` gives the string the receiver for a scope rather than the
+  # caller's, and a scope of one's own starts at the default.
+  class Test4EvalVisibilityClassEvalCaller
+    private
+    TARGET = Class.new
+    TARGET.class_eval("def from_string; :ok; end")
+  end
+
+  assert_equal :ok, Test4EvalVisibilityClassEvalCaller::TARGET.new.from_string
+end
+
 assert('alias and undef reject a dynamic symbol') do
   # OP_ALIAS and OP_UNDEF carry a symbol index, so an interpolated name cannot
   # be expressed. The codegen used to read the InterpolatedSymbolNode as if it

--- a/src/class.c
+++ b/src/class.c
@@ -953,6 +953,21 @@ check_visibility_break(const struct RProc *p, const struct RClass *c, mrb_callin
   return mrb_vm_ci_target_class(ci) != c || MRB_CI_VISIBILITY_BREAK_P(ci);
 }
 
+/* The env a scope wrote its visibility to, following p->upper from a proc
+   that has already passed check_visibility_break(): the first step that
+   breaks leaves the env of the level below it, which is the scope's own. */
+static struct REnv*
+find_visibility_env(const struct RProc *p, const struct RClass *c)
+{
+  for (;;) {
+    struct REnv *env = p->e.env;
+    p = p->upper;
+    if (check_visibility_break(p, c, NULL, env)) {
+      return env;
+    }
+  }
+}
+
 static void
 find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinfo **cp, struct REnv **ep)
 {
@@ -968,15 +983,8 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
     return;
   }
 
-  for (;;) {
-    struct REnv *env = p->e.env;
-    p = p->upper;
-    if (check_visibility_break(p, c, ci, env)) {
-      *ep = env;
-      *cp = NULL;
-      return;
-    }
-  }
+  *ep = find_visibility_env(p, c);
+  *cp = NULL;
 }
 
 /*

--- a/src/class.c
+++ b/src/class.c
@@ -987,6 +987,28 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
   *cp = NULL;
 }
 
+/* Gives the current frame the visibility of the scope `p` was compiled
+   against. `eval` on a string wants this: the string runs in that scope, so a
+   `def` in it takes the visibility written there, while the frame goes on
+   breaking the scope so that a `private` written inside the string stops at
+   the end of it, the way CRuby's copy of the caller's cref does. A proc that
+   captured no env was compiled against no Ruby scope and has none to lend. */
+void
+mrb_vm_ci_inherit_visibility(mrb_state *mrb, const struct RProc *p)
+{
+  mrb_callinfo *ci = mrb->c->ci;
+
+  if (MRB_PROC_ENV(p) == NULL) return;
+  struct REnv *e = find_visibility_env(p, mrb_vm_ci_target_class(ci));
+  MRB_CI_SET_VISIBILITY(ci, MRB_ENV_VISIBILITY(e));
+  if (MRB_ENV_MODFUNC_P(e)) {
+    MRB_CI_SET_MODFUNC(ci);
+  }
+  else {
+    MRB_CI_CLEAR_MODFUNC(ci);
+  }
+}
+
 /*
  * Defines a method with raw mrb_method_t structure.
  * This is a low-level function for method definition.


### PR DESCRIPTION
## Summary

A `def` inside a string handed to `eval` is always public: `eval_irep()` marks the string's frame as the start of a visibility scope, and a scope of one's own starts at the default. CRuby evaluates the string against a copy of the caller's cref, so such a `def` takes the visibility in effect where `eval` was called; where `eval` is given a binding CRuby does not copy, and a visibility written in the string reaches the scope the binding names.

## Changes

| File | What |
| --- | --- |
| `src/class.c` | `find_visibility_env()` names the `p->upper` walk that ends `find_visibility_scope()`; `mrb_vm_ci_inherit_visibility()` gives the current frame the visibility of the scope a proc was compiled against |
| `include/mruby/internal.h` | declares `mrb_vm_ci_inherit_visibility()` |
| `mrbgems/mruby-eval/src/eval.c` | the visibility break moves out of `eval_irep()` to the three callers that differ over it |
| `mrbgems/mruby-eval/test/eval.rb` | six asserts for the visibility an eval string starts at and writes to |

### Copy, join, or break

`MRB_CI_SET_VISIBILITY_BREAK()` on the string's frame is what keeps a `private` written inside the string from reaching the code that called `eval`, which the existing `method visibility with eval` pins. It was set for every string, and the three ways a string is run want three different answers, so the call moves out of `eval_irep()` into them.

`Kernel#eval` with no binding copies: the string is compiled against the caller's scope, so it starts at the visibility written there, and the break keeps what the string writes from reaching back out. This is the case the change is about, and it is CRuby's copy of the caller's cref.

`Kernel#eval` with a binding joins: a binding names a scope where the copy stands in for one, so the frame is left as a step in it. The visibility written in the scope reaches the string as before, and one written in the string reaches the scope itself and every other binding on it, which is what a shared cref gives in CRuby.

`Module#module_eval` and `BasicObject#instance_eval` on a string break: the string they run gets the receiver for a scope rather than the caller's, so it starts at the default and what it writes ends with it. That is CRuby's answer for them too, and it is unchanged.

### Where the start is read from

`mrb_vm_ci_inherit_visibility()` walks `p->upper` from the proc the string was compiled into, for the env the scope wrote its visibility to. That walk is the tail of `find_visibility_scope()`, which is why the tail now has a name: reached from a proc rather than from a live frame, the walk is the whole of the answer.

The walk is what a step between the string and the visibility asks for. A block between the two carries an env of its own, and a binding wraps the scope in the local variable space `mruby-binding` builds for it; neither is a scope that breaks, so both are steps on the way rather than the answer. The class the walk compares against is the frame's target class, which is where the binding's space would otherwise stop it: that space is built for the binding and carries no class at all.

## Behaviour

```ruby
class Foo
  private
  eval("def from_string; end")
end
Foo.new.from_string    # CRuby: NoMethodError, mruby: nil

eval("def top_from_string; end")
Object.private_instance_methods(false).include?(:top_from_string)  # CRuby: true, mruby: false

class Bar
  SCOPE = binding
  eval("private", SCOPE)
  def written_after; end
end
Bar.new.written_after  # CRuby: NoMethodError, mruby: nil
```

`protected`, an explicit `public` and `module_function` reach the string as `private` does.

The scope an `eval` call can sit in, with a `private` written in it:

| Where the `eval` call sits | CRuby | this PR | a plain `def` written there, mruby |
| --- | --- | --- | --- |
| class body | private | private | private |
| block in a class body | private | private | private |
| inside another eval string | private | private | n/a |
| `class_eval` / `instance_eval` block | private | not defined | private |
| method body | private | public | public |
| `def self.name` body | private, on the class | public, on the singleton | public, on the singleton |
| `class << self` body | private | public | public |

The last three rows answer as a `def` written in the same place already answers in mruby, and CRuby's own answer for the last two differs between a plain `def` and one in a string: a method body and a `class << self` body are scopes that start public here, and a `def` inside `def self.name` lands on the singleton class, where a method is always public.

Out of the scope of this change, but the fourth row and next to it: an `eval` anywhere in a block run by `class_exec` moves every later `def` in that block off the receiver, because `create_proc_from_string()` builds the caller's frame an env carrying the eval's target class rather than the frame's own, where `mrb_proc_get_caller()` builds the same env with the frame's.

```ruby
c = Class.new
c.class_exec do
  eval("1")
  def b; end
end
c.instance_methods(false)  # CRuby: [:b], mruby: []
```

## Size

`.text` of `bin/mruby`, master `cde4a50af` against this PR.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 1,992,278 | 1,992,614 | +336 |
| bintest | 1,397,286 | 1,397,622 | +336 |
| cxx_abi | 1,428,857 | 1,429,225 | +368 |
| byte-string | 1,358,566 | 1,358,902 | +336 |
| ascii-ctype | 1,381,590 | 1,381,926 | +336 |
| no-float | 1,322,846 | 1,323,198 | +352 |
| no-bigint | 1,281,318 | 1,281,654 | +336 |

In the bintest build `class.o` gains 272 bytes, the new entry point plus the walk that no longer folds into its one caller, and `eval.o` gains 64, the branch on the binding and the two calls.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| host | 2724 | 2650 | 74 | 0 | 0 | 0 |
| full-debug | 2972 | 2961 | 11 | 0 | 0 | 0 |
| bintest | 2972 | 2952 | 20 | 0 | 0 | 0 |
| cxx_abi | 2972 | 2952 | 20 | 0 | 0 | 0 |
| byte-string | 2884 | 2810 | 74 | 0 | 0 | 0 |
| ascii-ctype | 2956 | 2934 | 22 | 0 | 0 | 0 |
| no-float | 2705 | 2608 | 97 | 0 | 0 | 0 |
| no-bigint | 2921 | 2888 | 33 | 0 | 0 | 0 |

bintest: 147 total, 146 OK, 1 skip, 0 KO. `mruby-bin-debugger` evaluates its `print` expressions as strings against a stopped frame, which is the binding path.

The new asserts take the visibility to the string by each route it arrives by: `private`, `protected` and `public` written straight above the call; a block and a second `eval` between the two; a `module_function`; and a binding, whose own scope is what the string starts at even where `eval` is called from a private one. Two pin the directions that are meant to stay put: a string given to `class_eval` starts public wherever it is called from, and what a string given a binding writes stays with the scope that binding names. Five of the six fail on master.

Beside them, 46 programs were run against CRuby 4.0.6 and compared: the visibility written above the call in each shape a scope comes in, what the string itself writes and where that reaches, the same through a block, a lambda and up to three nested eval strings, a binding taken in a class body, in a method and from a `Proc`, and `class_eval` and `instance_eval` on a string. One answer differs, the `def self.name` row of the table above, and it differs on master in the same way.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU | AMD Ryzen 9 5950X |
| gcc | 13.3.0 |
| clang | 23.1.0 (Homebrew) |
| binutils | 2.47 |
| CRuby | 4.0.6 |

Compile lines, `touch src/class.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected method visibility handling for methods defined inside `eval`, `instance_eval`, and `class_eval`.
  - Methods created through `eval` now consistently respect the surrounding scope’s public, protected, private, or module-function visibility.
  - Evaluated code with an explicit binding now preserves visibility changes in the bound scope.
  - Prevented visibility settings from unintentionally leaking beyond `instance_eval` and `class_eval` blocks.
- **Tests**
  - Added coverage for visibility across nested evaluations, blocks, bindings, and module functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->