### PR TITLE
class.c: take the `inherit` argument in `Module#method_defined?` and add its siblings

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -60,6 +60,7 @@ void mrb_method_added(mrb_state *mrb, struct RClass *c, mrb_sym mid);
 mrb_noreturn void mrb_method_missing(mrb_state *mrb, mrb_sym name, mrb_value self, mrb_value args);
 mrb_method_t mrb_vm_find_method(mrb_state *mrb, struct RClass *c, struct RClass **cp, mrb_sym mid);
 mrb_value mrb_mod_const_missing(mrb_state *mrb, mrb_value mod);
+int mrb_mod_method_visibility(mrb_state *mrb, mrb_value mod);
 mrb_value mrb_const_missing(mrb_state *mrb, mrb_value mod, mrb_sym sym);
 size_t mrb_class_mt_memsize(mrb_state*, struct RClass*);
 mrb_value mrb_obj_extend(mrb_state*, mrb_value obj);

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -573,6 +573,45 @@ mrb_mod_protected_instance_methods(mrb_state *mrb, mrb_value mod)
   return mod_instance_methods(mrb, mod, MT_PROTECTED);
 }
 
+/*
+ *  call-seq:
+ *     mod.public_method_defined?(symbol, inherit=true)    -> true or false
+ *
+ *  Returns `true` if the named public method is defined by _mod_.  If
+ *  _inherit_ is set, the lookup will also search _mod_'s ancestors.
+ */
+static mrb_value
+mrb_mod_public_method_defined(mrb_state *mrb, mrb_value mod)
+{
+  return mrb_bool_value(mrb_mod_method_visibility(mrb, mod) == MRB_METHOD_PUBLIC_FL);
+}
+
+/*
+ *  call-seq:
+ *     mod.private_method_defined?(symbol, inherit=true)    -> true or false
+ *
+ *  Returns `true` if the named private method is defined by _mod_.  If
+ *  _inherit_ is set, the lookup will also search _mod_'s ancestors.
+ */
+static mrb_value
+mrb_mod_private_method_defined(mrb_state *mrb, mrb_value mod)
+{
+  return mrb_bool_value(mrb_mod_method_visibility(mrb, mod) == MRB_METHOD_PRIVATE_FL);
+}
+
+/*
+ *  call-seq:
+ *     mod.protected_method_defined?(symbol, inherit=true)    -> true or false
+ *
+ *  Returns `true` if the named protected method is defined by _mod_.  If
+ *  _inherit_ is set, the lookup will also search _mod_'s ancestors.
+ */
+static mrb_value
+mrb_mod_protected_method_defined(mrb_state *mrb, mrb_value mod)
+{
+  return mrb_bool_value(mrb_mod_method_visibility(mrb, mod) == MT_PROTECTED);
+}
+
 static int
 undefined_method_i(mrb_state *mrb, mrb_sym mid, mrb_method_t m, void *p)
 {
@@ -721,6 +760,9 @@ static const mrb_mt_entry metaprog_mod_rom_entries[] = {
   MRB_MT_ENTRY(mrb_mod_public_instance_methods,  MRB_SYM(public_instance_methods), MRB_ARGS_OPT(1)),
   MRB_MT_ENTRY(mrb_mod_private_instance_methods, MRB_SYM(private_instance_methods), MRB_ARGS_OPT(1)),
   MRB_MT_ENTRY(mrb_mod_protected_instance_methods, MRB_SYM(protected_instance_methods), MRB_ARGS_OPT(1)),
+  MRB_MT_ENTRY(mrb_mod_public_method_defined,    MRB_SYM_Q(public_method_defined), MRB_ARGS_ARG(1,1)),
+  MRB_MT_ENTRY(mrb_mod_private_method_defined,   MRB_SYM_Q(private_method_defined), MRB_ARGS_ARG(1,1)),
+  MRB_MT_ENTRY(mrb_mod_protected_method_defined, MRB_SYM_Q(protected_method_defined), MRB_ARGS_ARG(1,1)),
   MRB_MT_ENTRY(mrb_mod_undefined_methods,        MRB_SYM(undefined_instance_methods), MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_mod_remove_method,            MRB_SYM(remove_method),  MRB_ARGS_ANY()),  /* 15.2.2.4.41 */
   MRB_MT_ENTRY(mrb_f_nil,                        MRB_SYM(method_removed), MRB_ARGS_REQ(1)),

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -358,6 +358,66 @@ assert 'Module#prepend #instance_methods(false)' do
   assert_equal([:m1], Class.new(Class.new{def m2;end}){ prepend Module.new; def m1; end }.instance_methods(false), bug6660)
 end
 
+assert('Module#public_method_defined?, #private_method_defined?, #protected_method_defined?') do
+  mod = Module.new do
+    def mpub; end
+    private def mpriv; end
+    protected def mprot; end
+  end
+  cls = Class.new do
+    include mod
+    def pub; end
+    private def priv; end
+    protected def prot; end
+  end
+  sub = Class.new(cls)
+
+  # each answers for exactly one visibility
+  assert_true  cls.public_method_defined?(:pub)
+  assert_false cls.public_method_defined?(:priv)
+  assert_false cls.public_method_defined?(:prot)
+  assert_false cls.private_method_defined?(:pub)
+  assert_true  cls.private_method_defined?(:priv)
+  assert_false cls.private_method_defined?(:prot)
+  assert_false cls.protected_method_defined?(:pub)
+  assert_false cls.protected_method_defined?(:priv)
+  assert_true  cls.protected_method_defined?(:prot)
+
+  # wherever the method is found
+  assert_true  sub.public_method_defined?(:mpub)
+  assert_true  sub.private_method_defined?(:mpriv)
+  assert_true  sub.protected_method_defined?(:mprot)
+  assert_true  cls.private_method_defined?("initialize")
+
+  # or only where the module defines it itself
+  assert_false sub.public_method_defined?(:pub, false)
+  assert_false sub.private_method_defined?(:priv, false)
+  assert_false sub.protected_method_defined?(:prot, false)
+  assert_true  cls.protected_method_defined?(:prot, false)
+
+  # a visibility changed in a subclass makes the method the subclass's own
+  hidden = Class.new(cls) { private :pub }
+  assert_true  hidden.private_method_defined?(:pub, false)
+  assert_false cls.private_method_defined?(:pub)
+
+  # a name with no method behind it, or with the method undefined
+  assert_false cls.public_method_defined?(:no_such_method)
+  assert_false cls.private_method_defined?(:no_such_method)
+  assert_false cls.protected_method_defined?(:no_such_method)
+  gone = Class.new(cls) { undef_method :pub }
+  assert_false gone.public_method_defined?(:pub)
+  assert_false gone.private_method_defined?(:pub)
+  assert_false gone.protected_method_defined?(:pub)
+  assert_false TestNotImplement.public_method_defined?(:gone)
+
+  # the name has to be a Symbol or a String, and inherit is the only other
+  # argument
+  assert_raise(TypeError) { cls.public_method_defined?(1) }
+  assert_raise(TypeError) { cls.private_method_defined?(nil) }
+  assert_raise(TypeError) { cls.protected_method_defined?([]) }
+  assert_raise(ArgumentError) { cls.public_method_defined?(:pub, false, false) }
+end
+
 assert('Module#remove_class_variable', '15.2.2.4.39') do
   class Test4RemoveClassVariable
     @@cv = 99

--- a/src/class.c
+++ b/src/class.c
@@ -4320,9 +4320,11 @@ mrb_mod_const_missing(mrb_state *mrb, mrb_value mod)
    so the search is made here to weigh the visibility the listing reports on.
    With `inherit` false the method has to be `mod`'s own: the walk starts at
    the origin, past the modules prepended in front of it, and a method found
-   further up is not counted. */
-static int
-mod_method_visibility(mrb_state *mrb, mrb_value mod)
+   further up is not counted.  The arguments are read here so that the four
+   methods built on this (`method_defined?` and the three in mruby-metaprog)
+   read them the same way. */
+int
+mrb_mod_method_visibility(mrb_state *mrb, mrb_value mod)
 {
   mrb_sym id;
   mrb_bool inherit = TRUE;
@@ -4369,7 +4371,7 @@ mod_method_visibility(mrb_state *mrb, mrb_value mod)
 static mrb_value
 mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
 {
-  int vis = mod_method_visibility(mrb, mod);
+  int vis = mrb_mod_method_visibility(mrb, mod);
   return mrb_bool_value(vis == MRB_METHOD_PUBLIC_FL || vis == MRB_METHOD_PROTECTED_FL);
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -4315,14 +4315,36 @@ mrb_mod_const_missing(mrb_state *mrb, mrb_value mod)
   return mrb_const_missing(mrb, mod, sym);
 }
 
+/* The visibility of the method `mod` answers `name` with, or -1 when there is
+   none to answer with.  `mrb_obj_respond_to` answers for any method it finds,
+   so the search is made here to weigh the visibility the listing reports on.
+   With `inherit` false the method has to be `mod`'s own: the walk starts at
+   the origin, past the modules prepended in front of it, and a method found
+   further up is not counted. */
+static int
+mod_method_visibility(mrb_state *mrb, mrb_value mod)
+{
+  mrb_sym id;
+  mrb_bool inherit = TRUE;
+
+  mrb_get_args(mrb, "n|b", &id, &inherit);
+  struct RClass *c = mrb_class_ptr(mod);
+  if (!inherit) MRB_CLASS_ORIGIN(c);
+  struct RClass *found = c;
+  mrb_method_t m = mrb_method_search_vm(mrb, &found, id);
+  if (MRB_METHOD_UNDEF_P(m) || MRB_METHOD_NOTIMPL_P(m)) return -1;
+  if (!inherit && found != c) return -1;
+  return MRB_METHOD_VISIBILITY(m);
+}
+
 /* 15.2.2.4.34 */
 /*
  *  call-seq:
- *     mod.method_defined?(symbol)    -> true or false
+ *     mod.method_defined?(symbol, inherit=true)    -> true or false
  *
  *  Returns `true` if the named method is defined by
- *  _mod_ (or its included modules and, if _mod_ is a class,
- *  its ancestors). Public and protected methods are matched.
+ *  _mod_.  If _inherit_ is set, the lookup will also search _mod_'s
+ *  ancestors. Public and protected methods are matched.
  *
  *     module A
  *       def method1()  end
@@ -4335,25 +4357,20 @@ mrb_mod_const_missing(mrb_state *mrb, mrb_value mod)
  *       def method3()  end
  *     end
  *
- *     A.method_defined? :method1    #=> true
- *     C.method_defined? "method1"   #=> true
- *     C.method_defined? "method2"   #=> true
- *     C.method_defined? "method3"   #=> true
- *     C.method_defined? "method4"   #=> false
+ *     A.method_defined? :method1           #=> true
+ *     C.method_defined? "method1"          #=> true
+ *     C.method_defined? "method2"          #=> true
+ *     C.method_defined? "method2", true    #=> true
+ *     C.method_defined? "method2", false   #=> false
+ *     C.method_defined? "method3"          #=> true
+ *     C.method_defined? "method4"          #=> false
  */
 
 static mrb_value
 mrb_mod_method_defined(mrb_state *mrb, mrb_value mod)
 {
-  mrb_sym id;
-
-  mrb_get_args(mrb, "n", &id);
-  /* `mrb_obj_respond_to` answers for any method it finds, so the search is
-     made here to weigh the visibility the listing reports on. */
-  struct RClass *c = mrb_class_ptr(mod);
-  mrb_method_t m = mrb_method_search_vm(mrb, &c, id);
-  if (MRB_METHOD_UNDEF_P(m) || MRB_METHOD_NOTIMPL_P(m)) return mrb_false_value();
-  return mrb_bool_value(!(m.flags & MRB_METHOD_PRIVATE_FL));
+  int vis = mod_method_visibility(mrb, mod);
+  return mrb_bool_value(vis == MRB_METHOD_PUBLIC_FL || vis == MRB_METHOD_PROTECTED_FL);
 }
 
 void
@@ -4914,7 +4931,7 @@ static const mrb_mt_entry mod_rom_entries[] = {
   MRB_MT_ENTRY(mrb_mod_to_s,            MRB_SYM(inspect),          MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_do_nothing,          MRB_SYM(method_added),     MRB_ARGS_REQ(1) | MRB_MT_PRIVATE),
   MRB_MT_ENTRY(mrb_do_nothing,          MRB_SYM(method_removed),   MRB_ARGS_REQ(1) | MRB_MT_PRIVATE),
-  MRB_MT_ENTRY(mrb_mod_method_defined,  MRB_SYM_Q(method_defined), MRB_ARGS_REQ(1)),                   /* 15.2.2.4.34 */
+  MRB_MT_ENTRY(mrb_mod_method_defined,  MRB_SYM_Q(method_defined), MRB_ARGS_ARG(1,1)),                 /* 15.2.2.4.34 */
   MRB_MT_ENTRY(mrb_do_nothing,          MRB_SYM(method_undefined), MRB_ARGS_REQ(1) | MRB_MT_PRIVATE),
   MRB_MT_ENTRY(mrb_mod_module_eval,     MRB_SYM(module_eval),      MRB_ARGS_ANY()),                    /* 15.2.2.4.35 */
   MRB_MT_ENTRY(mrb_mod_module_function, MRB_SYM(module_function),  MRB_ARGS_ANY() | MRB_MT_PRIVATE),

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -433,6 +433,62 @@ assert('Module#method_defined? reports the methods a listing reports') do
   assert_true  answering.new.respond_to?(:no_such_method)
 end
 
+assert('Module#method_defined? with inherit false reports only the module\'s own methods') do
+  mod = Module.new do
+    def mpub; end
+  end
+  ahead = Module.new do
+    def apub; end
+  end
+  cls = Class.new do
+    include mod
+    prepend ahead
+    def pub; end
+    private def priv; end
+  end
+  sub = Class.new(cls)
+
+  # a method the class itself defines, wherever the walk would have found it
+  assert_true  cls.method_defined?(:pub, false)
+  assert_true  cls.method_defined?(:pub, true)
+  assert_false cls.method_defined?(:priv, false)
+  assert_false cls.method_defined?(:no_such_method, false)
+
+  # methods that come from an ancestor, an included module, a prepended
+  # module or Object are not the class's own
+  assert_false sub.method_defined?(:pub, false)
+  assert_true  sub.method_defined?(:pub)
+  assert_false cls.method_defined?(:mpub, false)
+  assert_true  cls.method_defined?(:mpub)
+  assert_false cls.method_defined?(:apub, false)
+  assert_true  cls.method_defined?(:apub)
+  assert_false cls.method_defined?(:inspect, false)
+  assert_true  cls.method_defined?(:inspect)
+
+  # a module is asked the same way, about the modules it includes
+  mod2 = Module.new { include mod }
+  assert_true  mod.method_defined?(:mpub, false)
+  assert_false mod2.method_defined?(:mpub, false)
+  assert_true  mod2.method_defined?(:mpub)
+
+  # a visibility changed in a subclass makes the method the subclass's own
+  shown = Class.new(cls) { public :priv }
+  assert_true  shown.method_defined?(:priv, false)
+  assert_false cls.method_defined?(:priv)
+
+  # a method undefined or left unimplemented is not there to be found, own or
+  # inherited; see "Kernel#respond_to? with an unimplemented method"
+  gone = Class.new(cls) { undef_method :pub }
+  assert_false gone.method_defined?(:pub, false)
+  assert_false gone.method_defined?(:pub)
+  assert_false TestNotImplement.method_defined?(:gone, false)
+
+  # inherit is read for truth, as in CRuby
+  assert_true  sub.method_defined?(:pub, 1)
+  assert_false sub.method_defined?(:pub, nil)
+  assert_raise(ArgumentError) { cls.method_defined?(:pub, false, false) }
+end
+
 assert('Module#module_eval', '15.2.2.4.35') do
   module Test4ModuleEval
     @a = 11


### PR DESCRIPTION
## Summary

`Module#method_defined?` took one argument, so the `inherit` flag CRuby has read since 2.6 raised `ArgumentError`, and there was no `public_method_defined?`, `private_method_defined?` or `protected_method_defined?` to ask for one visibility at a time. This adds the argument to core and the three methods to `mruby-metaprog`.

## Changes

| File                                      | What                                                                                     |
| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
| `src/class.c`                             | `method_defined?` takes `inherit`; the lookup moves to `mrb_mod_method_visibility`       |
| `include/mruby/internal.h`                | declare `mrb_mod_method_visibility` for the gem                                          |
| `mrbgems/mruby-metaprog/src/metaprog.c`   | `public_method_defined?`, `private_method_defined?`, `protected_method_defined?`         |
| `test/t/module.rb`                        | what `method_defined?` answers with `inherit` false, and how the flag is read            |
| `mrbgems/mruby-metaprog/test/metaprog.rb` | the three methods across visibility, inheritance, `undef_method` and a copied visibility |

### `inherit` false asks for the module's own method

With `inherit` false the search starts at the origin class, so a module prepended in front of the receiver is not counted as the receiver's own, and a method found above the origin is dropped. That is what CRuby does with `RCLASS_ORIGIN` and its owner check. A visibility changed in a subclass (`private :pub`) writes a copy into the subclass's table, and the copy is the subclass's own method, so `hidden.private_method_defined?(:pub, false)` is `true` in both.

The flag is read for truth, as CRuby's `RTEST` does, so `nil` turns the search off and any other object leaves it on.

### The three methods sit beside `public_instance_methods`

The ISO standard asks for `method_defined?` alone (15.2.2.4.34), so the three are gem methods, next to `public_instance_methods` and its siblings. The lookup they share with `method_defined?` stays in `class.c` and is declared in `internal.h`, the way `mrb_mod_to_s` and `mrb_mod_const_missing` are, so the four read their arguments and walk the ancestors in one place; each of the three is one comparison against the visibility that comes back.

## Behaviour

```ruby
class Base
  def pub; end
  private def priv; end
  protected def prot; end
end
class Sub < Base; end

Sub.method_defined?(:pub, false)          # CRuby: false, mruby: ArgumentError
Base.method_defined?(:pub, false)         # CRuby: true,  mruby: ArgumentError
Base.public_method_defined?(:pub)         # CRuby: true,  mruby: NoMethodError
Base.private_method_defined?(:priv)       # CRuby: true,  mruby: NoMethodError
Base.protected_method_defined?(:prot)     # CRuby: true,  mruby: NoMethodError
Sub.private_method_defined?(:priv, false) # CRuby: false, mruby: NoMethodError
```

`method_defined?` with one argument answers as before.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, gcc 13.3.0.

| Build       | master    | this PR   | delta |
| ----------- | --------- | --------- | ----- |
| full-debug  | 1,996,214 | 1,996,582 | +368  |
| bintest     | 1,400,406 | 1,400,838 | +432  |
| cxx_abi     | 1,432,265 | 1,432,697 | +432  |
| byte-string | 1,361,910 | 1,362,342 | +432  |
| ascii-ctype | 1,384,934 | 1,385,366 | +432  |
| no-float    | 1,325,998 | 1,326,430 | +432  |
| no-bigint   | 1,284,486 | 1,284,918 | +432  |

`full-debug` is `-O0`. `src/class.o` grows by 304 bytes: the lookup is a function of its own now that the gem calls it, where before it was inlined into `method_defined?`, and it reads a second argument and walks to the origin. `metaprog.o` grows by 128 bytes for the three wrappers. No other object changes.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2755  | 2681 | 74   | 0   | 0     | 0       |
| full-debug  | 3003  | 2992 | 11   | 0   | 0     | 0       |
| bintest     | 3003  | 2983 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3003  | 2983 | 20   | 0   | 0     | 0       |
| byte-string | 2915  | 2841 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2987  | 2965 | 22   | 0   | 0     | 0       |
| no-float    | 2736  | 2639 | 97   | 0   | 0     | 0       |
| no-bigint   | 2952  | 2919 | 33   | 0   | 0     | 0       |

`bintest` runs the command binary tests as well: 147 total, 146 OK, 1 skip, 0 KO.

The `method_defined?` block asks with `inherit` false for a method the class defines, one it inherits, one from an included module, one from a prepended module and one from `Object`, then for a module about the module it includes, for a visibility copied into a subclass with `public`, for an undefined method and an unimplemented one, and reads the flag as `1`, `nil` and a third argument. The `mruby-metaprog` block puts a public, a private and a protected method to each of the three, through a subclass and an included module, with `inherit` false on either side of the line, for a copy made by `private`, for a name with nothing behind it, an undefined method and an unimplemented one, and for a name that is not a Symbol or a String.

200 expressions over the four methods were run against CRuby 4.0.6 as well, including `extend`, `module_function`, `alias_method`, `remove_method` after `private`, `define_method`, `attr_accessor`, `Struct` and `Data` accessors, the singleton class of a class and of an object, `BasicObject` and `Kernel` ownership, a frozen receiver, and the error messages. Every answer these methods give is the same. What differs is elsewhere and out of scope: `define_method` and `attr_reader` written after a bare `private` stay public in mruby, so `private_method_defined?` says `false` for them where CRuby says `true`; there is no `private_class_method`; `private` does not take an Array; `Array#map` is Enumerable's here; and `Method#arity` reports `-2` for `MRB_ARGS_ARG(1,1)`, as it does for `const_defined?`.

## Environment

<details>

| Item     | Value                                              |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                 |
| Kernel   | Linux 7.0.0-31-generic x86_64                      |
| CPU      | AMD Ryzen 9 5950X 16-Core                          |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)        |
| binutils | GNU ld 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, taken with `touch src/class.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped.

```console
host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/class.c

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visibility-specific checks for public, private, and protected methods through `Module`.
  - Updated `Module#method_defined?` to accept an optional inheritance flag, allowing checks to include or exclude inherited methods.
  - Method visibility checks now account for inherited, included, prepended, undefined, and redefined methods.

- **Tests**
  - Added coverage for visibility results, inheritance filtering, accepted argument types, and invalid arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->