### PR TITLE
vm.c: keep the block alive while `OP_ENTER` lays out a short argument list

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2688,6 +2688,9 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
     }
     /* initialize rest arguments with empty Array */
     if (r) {
+      /* the post arguments may have been moved over the register the block
+         arrived in, which was its only reference from the stack */
+      mrb_gc_protect(mrb, blk);
       rest = mrb_ary_new_capa(mrb, 0);
       regs[m1+o+1] = rest;
     }

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -278,6 +278,32 @@ assert('OP_SETIDX does not retain a duplicated Hash key in the GC arena') do
   assert_operator GC.stat[:live] - base, :<, 100
 end
 
+assert('OP_ENTER keeps the block alive while it lays out a short argument list') do
+  # A call that passes fewer positional arguments than the `*rest` and post
+  # parameters span has its post arguments moved to the end of that span,
+  # and when nothing but the required arguments came, or they came packed in
+  # one array with a keyword hash after it, that is the register the block
+  # arrived in.  The empty `rest` is allocated right after, with the block
+  # held in a C local and nowhere the marker looks, so a collection landing
+  # on that allocation freed the `Proc`, and what the method then read as its
+  # block was whatever the cell was reused for.  Enough calls for the
+  # collector to land there.
+  def gc_test_short_args(x, *r, y, &blk); blk; end
+  def gc_test_short_args_kw(x, *r, y, **o, &blk); blk; end
+  args = [1, 2]
+  kw = {}
+  bad = 0
+  i = 0
+  while i < 5000
+    b = gc_test_short_args(1, 2) { :c }
+    bad += 1 unless b.call == :c
+    b = gc_test_short_args_kw(*args, **kw) { :c }
+    bad += 1 unless b.call == :c
+    i += 1
+  end
+  assert_equal 0, bad
+end
+
 assert('OP_ADD does not retain an overflowed Integer in the GC arena') do
   # The overflow branch promotes to a big integer, so it only exists with
   # mruby-bigint.  The shift count is a variable because a constant shift is


### PR DESCRIPTION
## Summary

`OP_ENTER` lost the block of a call that passed fewer positional arguments than the method's `*rest` and post parameters span: it moved the post arguments over the register the block had arrived in and then allocated the empty `rest`, with the block held only in a C local, so the collector could free the `Proc` between the two. Root the block before that allocation, as the other branch of the same function already does.

## Changes

| File           | What                                                                  |
| -------------- | --------------------------------------------------------------------- |
| `src/vm.c`     | `vm_op_enter()` protects the block before allocating the empty `rest` |
| `test/t/gc.rb` | the call shape, repeated until a collection lands on the allocation   |

### The window

`vm_op_enter()` reads the block out of its register first, and stores it at its final position last, after every argument has been laid out; the comment above that store says it is placed there to keep the block from the collector, and the branch for a call with at least as many arguments as parameters protects the block before it moves anything over its register. The branch for a call with fewer does not. There the post arguments are moved to the end of the positional span, which is where the block's register sits when the call packed its arguments into one array, or when nothing but the required arguments came; the empty array for `rest` is allocated right after, and under `MRB_GC_STRESS` every allocation collects.

The `Proc` is white at that point: the frame's register was overwritten, the caller's register is the same memory, and `mrb_callinfo` does not hold the block for the marker. What the parent then reads as its block is whatever the freed cell is next used for, an `Array` in the test.

## Behaviour

```ruby
def m(x, *r, y, **o, &blk); blk; end
args = [1, 2]
m(*args, **{}) { :c }   # CRuby: a Proc, mruby before: a Proc, or an Array, or an assertion in the marker, depending on where the collector was; after: a Proc
```

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,996,214 | 1,996,246 | +32   |
| bintest          | 1,400,406 | 1,400,598 | +192  |
| cxx_abi          | 1,432,265 | 1,432,329 | +64   |
| byte-string      | 1,361,910 | 1,361,798 | -112  |
| ascii-ctype      | 1,384,934 | 1,384,822 | -112  |
| no-float         | 1,325,998 | 1,326,014 | +16   |
| no-bigint        | 1,284,486 | 1,284,502 | +16   |

The change is one call in `vm_op_enter()`, which is inlined into `mrb_vm_exec()`; the spread across builds is the inliner laying that function out again.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2754  | 2680 | 74   | 0   | 0     | 0       |
| full-debug  | 3002  | 2991 | 11   | 0   | 0     | 0       |
| bintest     | 3002  | 2982 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3002  | 2982 | 20   | 0   | 0     | 0       |
| byte-string | 2914  | 2840 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2986  | 2964 | 22   | 0   | 0     | 0       |
| no-float    | 2735  | 2638 | 97   | 0   | 0     | 0       |
| no-bigint   | 2951  | 2918 | 33   | 0   | 0     | 0       |

bintest: 147 total, 147 OK, 0 KO.

The new test calls both shapes five thousand times and calls the block it gets back each time. On master the host build fails with a segmentation fault by the thousandth call, and the full-debug build, which collects at every allocation, gets an `Array` back on the first.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch src/vm.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/vm.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when calling methods with rest parameters, post arguments, keyword arguments, and blocks.
  * Prevented blocks from becoming unavailable during garbage collection in these scenarios.

* **Tests**
  * Added regression coverage for block handling and garbage collection during complex argument calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->