### PR TITLE
mruby-compiler: forward the keyword locals from a bare `super`

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -130,6 +130,7 @@ typedef struct scope {
   uint32_t lastlabel;
   uint16_t ainfo:15;
   mrc_bool mscope:1;
+  uint32_t aspec;               /* the operand of this scope's `OP_ENTER` */
 
   struct loopinfo *loop;
   const char *filename;
@@ -1564,24 +1565,118 @@ loop_pop(mrc_codegen_scope *s, int val)
   if (val) push();
 }
 
+/* The method scope a `super`, a `zsuper` or a `yield` belongs to. */
+struct mscope {
+  int ainfo;                    /* the argument layout the forwarded arguments
+                                   and the block are read by; -1 when there
+                                   is no method scope */
+  int lv;                       /* scopes between the method and the asker */
+  uint32_t aspec;               /* the operand of the method's `OP_ENTER` */
+  const mrc_constant_id_list *names;  /* its locals by register, when the
+                                         method is in this compile unit */
+#if defined(MRC_TARGET_MRUBY)
+  const mrc_irep *irep;         /* its irep, when the method is on the proc
+                                   chain of the compile context instead */
+#endif
+};
+
+/* Read the method's local in register `reg` into `cursp()`. */
 static void
-gen_blkmove(mrc_codegen_scope *s, uint16_t ainfo, int lv)
+gen_mscope_lvar(mrc_codegen_scope *s, const struct mscope *m, int reg)
 {
-  int m1 = (ainfo>>7)&0x3f;
-  int r  = (ainfo>>6)&0x1;
-  int m2 = (ainfo>>1)&0x1f;
-  int kd = (ainfo)&0x1;
-  int off = m1+r+m2+kd+1;
-  if (lv == 0) {
-    gen_move(s, cursp(), off, 0);
+  if (m->lv == 0) {
+    gen_move(s, cursp(), reg, 0);
   }
   else {
     /* `lv` counts the scopes between here and the method, while `OP_GETUPVAR`
        counts the envs above this frame's own, and the method's env is the
        first of those: one level fewer. */
-    genop_3(s, OP_GETUPVAR, cursp(), off, lv-1);
+    genop_3(s, OP_GETUPVAR, cursp(), reg, m->lv-1);
   }
   push();
+}
+
+static void
+gen_blkmove(mrc_codegen_scope *s, const struct mscope *m)
+{
+  int m1 = (m->ainfo>>7)&0x3f;
+  int r  = (m->ainfo>>6)&0x1;
+  int m2 = (m->ainfo>>1)&0x1f;
+  int kd = (m->ainfo)&0x1;
+  gen_mscope_lvar(s, m, m1+r+m2+kd+1);
+}
+
+static mrc_sym nsym(mrc_parser_state *p, const uint8_t *start, size_t length);
+
+/* The name of the method's local in register `reg`, as a symbol of this
+   compile unit.  0 when the method carries no names. */
+static mrc_sym
+mscope_lvar_name(mrc_codegen_scope *s, const struct mscope *m, int reg)
+{
+  if (m->names) return m->names->ids[reg-1];
+#if defined(MRC_TARGET_MRUBY)
+  if (m->irep && m->irep->lv) {
+    const char *name = mrb_sym_name(s->c->mrb, m->irep->lv[reg-1]);
+    if (name) return nsym(s->c->p, (const uint8_t *)name, strlen(name));
+  }
+#endif
+  return 0;
+}
+
+/* Build the keyword hash a bare `super` forwards, at `cursp()`.
+
+   `OP_KARG` moves each keyword parameter into its local by deleting it from
+   the dictionary the frame received, so by the time `super` runs that
+   dictionary holds only what no parameter claimed, and it is the very object
+   that `**rest` names.  Forwarding it as read hands the parent a dictionary
+   with the declared keywords missing, and lets the parent's `OP_KARG` delete
+   from the caller's `rest`.  The keyword locals hold the current values, as
+   CRuby forwards them, so the hash is rebuilt from a copy of `rest` with
+   those written over it: the order CRuby's parent sees the keys in, and the
+   one that lets a declared keyword win over a key of its name in `rest`.
+
+   Answers whether the hash was built; the registers above `cursp()` are
+   used as scratch, the block's slot among them.  When the method carries no
+   local names there is nothing to build it from, and the dictionary stays
+   as read. */
+static mrc_bool
+gen_zsuper_kwargs(mrc_codegen_scope *s, const struct mscope *m)
+{
+  uint32_t a = m->aspec;
+  int ka = MRC_ASPEC_KEY(a);
+  int kd = MRC_ASPEC_KDICT(a);
+  int kw_pos = MRC_ASPEC_REQ(a) + MRC_ASPEC_OPT(a) + MRC_ASPEC_REST(a) + MRC_ASPEC_POST(a) + 1;
+  /* the keyword locals follow the dictionary, the block's slot and the
+     block's name */
+  int kw_reg = kw_pos + 2 + MRC_ASPEC_BLOCK(a);
+
+  if (ka > 0 && mscope_lvar_name(s, m, kw_reg) == 0) return FALSE;
+  if (kd) {
+    genop_2(s, OP_HASH, cursp(), 0);
+    push();
+    gen_mscope_lvar(s, m, kw_pos);
+    pop(); pop();
+    genop_1(s, OP_HASHCAT, cursp());
+    push();
+  }
+  for (int i = 0; i < ka; i++) {
+    genop_2(s, OP_LOADSYM, cursp(), new_sym(s, mscope_lvar_name(s, m, kw_reg+i)));
+    push();
+    gen_mscope_lvar(s, m, kw_reg+i);
+  }
+  if (ka > 0) {
+    pop_n(ka*2);
+    if (kd) {
+      pop();
+      genop_2(s, OP_HASHADD, cursp(), ka);
+    }
+    else {
+      genop_2(s, OP_HASH, cursp(), ka);
+    }
+    push();
+  }
+  pop();
+  return TRUE;
 }
 
 /* Whether a `return` here leaves a method that is not part of this compile
@@ -1604,22 +1699,30 @@ return_leaves_upper_p(mrc_codegen_scope *s)
 }
 
 /* Find the method scope that a `super`, a `zsuper` or a `yield` belongs to.
-   Answers its `ainfo`, the argument layout that the forwarded arguments and
-   the block are read by, and sets `lvp` to the number of levels between it
-   and `s`.  Answers -1 when there is no method scope to find. */
-static int
-search_mscope(mrc_codegen_scope *s, int *lvp)
+   Fills `m` with its `ainfo`, the argument layout that the forwarded
+   arguments and the block are read by, the number of levels between it and
+   `s`, and where its locals are to be found.  `ainfo` is -1 when there is
+   no method scope to find. */
+static void
+search_mscope(mrc_codegen_scope *s, struct mscope *m)
 {
   mrc_codegen_scope *s2 = s;
   int lv = 0;
 
+  memset(m, 0, sizeof(*m));
+  m->ainfo = -1;
   while (!s2->mscope) {
     lv++;
     s2 = s2->prev;
     if (!s2) break;
   }
-  *lvp = lv;
-  if (s2) return (int)s2->ainfo;
+  m->lv = lv;
+  if (s2) {
+    m->ainfo = (int)s2->ainfo;
+    m->aspec = s2->aspec;
+    m->names = s2->lv;
+    return;
+  }
 
 #if defined(MRC_TARGET_MRUBY)
   /* A string compiled for `eval` has a scope chain of its own, and the method
@@ -1631,7 +1734,7 @@ search_mscope(mrc_codegen_scope *s, int *lvp)
      for itself as the `ainfo` it would have answered. */
   const struct RProc *u = s->c->upper;
 
-  (*lvp)--;
+  m->lv--;
 
   while (u && !MRC_PROC_CFUNC_P(u)) {
     if (MRC_PROC_SCOPE_P(u)) {
@@ -1639,17 +1742,18 @@ search_mscope(mrc_codegen_scope *s, int *lvp)
       if (!ir || ir->ilen == 0 || ir->iseq[0] != OP_ENTER) break;
       uint32_t a = PEEK_W(ir->iseq + 1);
       uint32_t ma = MRC_ASPEC_REQ(a) + MRC_ASPEC_OPT(a);
-      return (int)(((ma & 0x3f) << 7)
-                   | (MRC_ASPEC_REST(a) << 6)
-                   | ((MRC_ASPEC_POST(a) & 0x1f) << 1)
-                   | ((MRC_ASPEC_KEY(a) || MRC_ASPEC_KDICT(a)) ? 1 : 0));
+      m->ainfo = (int)(((ma & 0x3f) << 7)
+                       | (MRC_ASPEC_REST(a) << 6)
+                       | ((MRC_ASPEC_POST(a) & 0x1f) << 1)
+                       | ((MRC_ASPEC_KEY(a) || MRC_ASPEC_KDICT(a)) ? 1 : 0));
+      m->aspec = a;
+      m->irep = ir;
+      return;
     }
     u = u->upper;
-    (*lvp)++;
+    m->lv++;
   }
 #endif
-
-  return -1;
 }
 
 static void
@@ -3657,6 +3761,7 @@ lambda_body(mrc_codegen_scope *s, mrc_node *tree, mrc_node *body, pm_constant_id
   if (parameters == NULL) { /* empty parameter OR numbered parameters */
     genop_W(s, OP_ENTER, MRC_ARGS_REQ(na));
     s->ainfo = (na & 0x3f) << 7;
+    s->aspec = MRC_ARGS_REQ(na);
   }
   else {
     mrc_aspec a;
@@ -3686,6 +3791,7 @@ lambda_body(mrc_codegen_scope *s, mrc_node *tree, mrc_node *body, pm_constant_id
       | ((ra & 0x1) << 6)
       | ((pa & 0x1f) << 1)
       | ((ka | kd) ? 1 : 0);
+    s->aspec = a;
     /* generate jump table for optional arguments initializer */
     pos = new_label(s);
     for (i=0; i<oa; i++) {
@@ -6270,10 +6376,10 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_SUPER_NODE:
     {
       CAST(super);
-      int lv;
-      int ainfo = search_mscope(s, &lv);
+      struct mscope m;
       int n = 0, nk = 0, st = 0;
 
+      search_mscope(s, &m);
       push();
       CAST3(arguments, cast->arguments, arguments);
       if (arguments) {
@@ -6296,7 +6402,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (ainfo >= 0) gen_blkmove(s, (uint16_t)ainfo, lv);
+        else if (m.ainfo >= 0) gen_blkmove(s, &m);
         else {
           genop_1(s, OP_LOADNIL, cursp());
           push();
@@ -6307,7 +6413,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (ainfo >= 0) gen_blkmove(s, (uint16_t)ainfo, lv);
+        else if (m.ainfo >= 0) gen_blkmove(s, &m);
         else {
           genop_1(s, OP_LOADNIL, cursp());
           push();
@@ -6322,25 +6428,32 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_FORWARDING_SUPER_NODE:
     {
       CAST(forwarding_super);
-      int lv;
-      int ainfo = search_mscope(s, &lv);
+      struct mscope m;
       int n = CALL_MAXARGS;
       int sp = cursp();
 
+      search_mscope(s, &m);
       push();        /* room for receiver */
-      if (ainfo > 0) {
-        genop_2S(s, OP_ARGARY, cursp(), (ainfo<<4)|(lv & 0xf));
+      if (m.ainfo > 0) {
+        mrc_bool blk_lost = FALSE;
+
+        genop_2S(s, OP_ARGARY, cursp(), (m.ainfo<<4)|(m.lv & 0xf));
         push(); push(); push();   /* ARGARY pushes 3 values at most */
         pop(); pop(); pop();
         /* keyword arguments */
-        if (ainfo & 0x1) {
+        if (m.ainfo & 0x1) {
           n |= CALL_MAXARGS<<4;
           push();
+          blk_lost = gen_zsuper_kwargs(s, &m);
         }
         /* block argument */
         if (cast->block) {
           push();
           codegen(s, (mrc_node *)cast->block, VAL);
+        }
+        else if (blk_lost) {
+          push();
+          gen_blkmove(s, &m);
         }
       }
       else {
@@ -6348,8 +6461,8 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         if (cast->block) {
           codegen(s, (mrc_node *)cast->block, VAL);
         }
-        else if (ainfo >= 0) {
-          gen_blkmove(s, 0, lv);
+        else if (m.ainfo >= 0) {
+          gen_blkmove(s, &m);
         }
         else {
           /* There is no method scope to belong to, so there is no block to
@@ -6386,11 +6499,11 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_YIELD_NODE:
     {
       CAST(yield);
-      int lv;
-      int ainfo = search_mscope(s, &lv);
+      struct mscope m;
       int n = 0, nk = 0, st = 0;
 
-      if (ainfo < 0) codegen_error(s, "invalid yield (SyntaxError)");
+      search_mscope(s, &m);
+      if (m.ainfo < 0) codegen_error(s, "invalid yield (SyntaxError)");
       push();
       CAST3(arguments, cast->arguments, arguments);
       if (arguments) {
@@ -6412,7 +6525,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       push(); pop(); /* space for a block */
       pop_n(st+1);
-      genop_2S(s, OP_BLKPUSH, cursp(), (ainfo<<4)|(lv & 0xf));
+      genop_2S(s, OP_BLKPUSH, cursp(), (m.ainfo<<4)|(m.lv & 0xf));
       if (nk == 0 && n < 15) {
         /* fast path: direct block call without method dispatch */
         genop_2(s, OP_BLKCALL, cursp(), n);

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -472,10 +472,14 @@ assert('`super` and `yield` in a string given to eval belong to the caller') do
   base = Class.new do
     def m(x); [:base, x]; end
     def blk; block_given? ? yield(:b) : :noblk; end
+    def kw(a:, b: 2); [a, b]; end
+    def rest(a:, **o); [a, o]; end
   end
   sub = Class.new(base) do
     def m(x); eval("super"); end
     def blk; eval("super"); end
+    def kw(a:, b: 2); eval("super"); end
+    def rest(a:, **o); eval("a = 7; [0].each { return super }"); end
     def y; eval("yield 21"); end
     def y_nested; eval("[1].map { yield 2 }"); end
     def y_args(a, b = 1, *r, c, d: 4, &e); eval("yield a"); end
@@ -484,6 +488,10 @@ assert('`super` and `yield` in a string given to eval belong to the caller') do
 
   assert_equal [:base, 1], o.m(1)
   assert_equal [:blk, :b], o.blk { |v| [:blk, v] }
+  # the keyword locals the string reads are the method's, by name, and the
+  # `rest` it copies is the one the method's frame holds
+  assert_equal [1, 3], o.kw(a: 1, b: 3)
+  assert_equal [7, {c: 2}], o.rest(a: 1, c: 2)
   assert_equal 42, o.y { |v| v * 2 }
   assert_equal [4], o.y_nested { |v| v * 2 }
   assert_equal 35, o.y_args(7, 8) { |v| v * 5 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -2688,6 +2688,9 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
     }
     /* initialize rest arguments with empty Array */
     if (r) {
+      /* the post arguments may have been moved over the register the block
+         arrived in, which was its only reference from the stack */
+      mrb_gc_protect(mrb, blk);
       rest = mrb_ary_new_capa(mrb, 0);
       regs[m1+o+1] = rest;
     }

--- a/test/t/gc.rb
+++ b/test/t/gc.rb
@@ -278,6 +278,32 @@ assert('OP_SETIDX does not retain a duplicated Hash key in the GC arena') do
   assert_operator GC.stat[:live] - base, :<, 100
 end
 
+assert('OP_ENTER keeps the block alive while it lays out a short argument list') do
+  # A call that passes fewer positional arguments than the `*rest` and post
+  # parameters span has its post arguments moved to the end of that span,
+  # and when nothing but the required arguments came, or they came packed in
+  # one array with a keyword hash after it, that is the register the block
+  # arrived in.  The empty `rest` is allocated right after, with the block
+  # held in a C local and nowhere the marker looks, so a collection landing
+  # on that allocation freed the `Proc`, and what the method then read as its
+  # block was whatever the cell was reused for.  Enough calls for the
+  # collector to land there.
+  def gc_test_short_args(x, *r, y, &blk); blk; end
+  def gc_test_short_args_kw(x, *r, y, **o, &blk); blk; end
+  args = [1, 2]
+  kw = {}
+  bad = 0
+  i = 0
+  while i < 5000
+    b = gc_test_short_args(1, 2) { :c }
+    bad += 1 unless b.call == :c
+    b = gc_test_short_args_kw(*args, **kw) { :c }
+    bad += 1 unless b.call == :c
+    i += 1
+  end
+  assert_equal 0, bad
+end
+
 assert('OP_ADD does not retain an overflowed Integer in the GC arena') do
   # The overflow branch promotes to a big integer, so it only exists with
   # mruby-bigint.  The shift count is a variable because a constant shift is

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -47,6 +47,76 @@ assert('super forwards the caller\'s block from inside a block') do
   assert_equal [:blk, :b], deep.new.m { |v| [:blk, v] }
 end
 
+assert('super forwards the keyword arguments at their current values') do
+  # Each keyword parameter is moved into its local by deleting it from the
+  # dictionary the frame received, so by the time `super` runs the dictionary
+  # holds only what no parameter claimed, and it is the object `**rest`
+  # names.  A bare `super` builds the parent's dictionary afresh from the
+  # keyword locals and a copy of `rest`, as CRuby does.
+  base = Class.new do
+    def kw(a:, b: 2); [a, b]; end
+    def rest(a:, **o); [a, o]; end
+    def restonly(**o); o; end
+    def all(x, *r, y, a:, b: 2, **o, &blk); [x, r, y, a, b, o, blk ? blk.call : nil]; end
+  end
+  sub = Class.new(base) do
+    def kw(a:, b: 2); super; end
+    def rest(a:, **o); super; end
+    def restonly(**o); [super, o]; end
+    def all(x, *r, y, a:, b: 2, **o, &blk); super; end
+  end
+  o = sub.new
+  assert_equal [1, 3], o.kw(a: 1, b: 3)
+  assert_equal [1, 2], o.kw(a: 1)
+  assert_equal [1, {c: 3}], o.rest(a: 1, c: 3)
+  assert_equal [1, [2], 3, 4, 2, {c: 5}, :blk], o.all(1, 2, 3, a: 4, c: 5) { :blk }
+
+  # the parent's dictionary is a copy, so what its keyword parameters delete
+  # from it stays in the child's `rest`
+  parent_dict, own = o.restonly(a: 1)
+  assert_equal({a: 1}, parent_dict)
+  assert_equal({a: 1}, own)
+  assert_false parent_dict.equal?(own)
+  twice = Class.new(base) do
+    def kw(a:, b: 2); [super, super]; end
+    def rest(a:, **o); [super, super, o]; end
+  end
+  assert_equal [[1, 2], [1, 2]], twice.new.kw(a: 1)
+  assert_equal [[1, {c: 2}], [1, {c: 2}], {c: 2}], twice.new.rest(a: 1, c: 2)
+
+  # the locals are read where `super` is, so a keyword reassigned before it
+  # reaches the parent reassigned, a declared keyword wins over a key of its
+  # name in `rest`, and the child's default is what the parent sees when the
+  # caller passed nothing
+  reassign = Class.new(base) do
+    def kw(a:, b: 2); a *= 10; b = :changed; super; end
+    def rest(a:, **o); o = {a: 5, z: 1}; super; end
+  end
+  assert_equal [10, :changed], reassign.new.kw(a: 1)
+  assert_equal [1, {z: 1}], reassign.new.rest(a: 1)
+  defaults = Class.new(Class.new { def m(a: :parent); a; end }) { def m(a: :child); super; end }
+  assert_equal :child, defaults.new.m
+
+  # from inside a block, a nested block or a lambda, up more than one level,
+  # with a block of its own, and through `...` and the anonymous `**`
+  blk = Class.new(base) do
+    def kw(a:, b: 2); r = nil; [0].each { r = super }; r; end
+    def rest(a:, **o); r = nil; [0].each { [1].each { r = super } }; r; end
+    def restonly(**o); -> { super }.call; end
+    def all(x, *r, y, a:, b: 2, **o, &blk); super { :from_child }; end
+  end
+  assert_equal [1, 2], blk.new.kw(a: 1)
+  assert_equal [1, {c: 2}], blk.new.rest(a: 1, c: 2)
+  assert_equal({a: 1}, blk.new.restonly(a: 1))
+  assert_equal [1, [], 2, 3, 2, {}, :from_child], blk.new.all(1, 2, a: 3)
+  deep = Class.new(sub) { def kw(a:, b: 2); super; end }
+  assert_equal [1, 3], deep.new.kw(a: 1, b: 3)
+  fwd = Class.new(base) { def rest(...); super; end }
+  assert_equal [1, {c: 2}], fwd.new.rest(a: 1, c: 2)
+  anon = Class.new(base) { def rest(*, **, &); super; end }
+  assert_equal [1, {c: 2}], anon.new.rest(a: 1, c: 2)
+end
+
 assert('yield', '11.3.5') do
 # it's syntax error now
 #  assert_raise LocalJumpError do


### PR DESCRIPTION
## Summary

This branch is on top of #7543 and includes its diff: the test below hands a block to a method with `*rest` and post parameters from a call that packs its arguments, which is the shape that PR keeps alive across `OP_ENTER`.

A bare `super` forwarded the keyword dictionary its frame had received, after `OP_KARG` had deleted every declared keyword from it, so a method with a required keyword raised `missing keyword` from its own `super`, and one with `**rest` handed the parent `rest` itself to be emptied in turn. The dictionary is now built at the `super` from the keyword locals and a copy of `rest`, which is what CRuby forwards.

## Changes

| File                                   | What                                                                                                                                         |
| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | `gen_zsuper_kwargs()` builds the dictionary; `search_mscope()` answers where the method's locals are; the scope keeps its `OP_ENTER` operand |
| `test/t/syntax.rb`                     | the shapes a bare `super` with keywords comes in                                                                                             |
| `mrbgems/mruby-eval/test/eval.rb`      | the same from a string given to `eval`                                                                                                       |

### What `OP_ARGARY` read

`OP_ENTER` puts the dictionary a frame received into the register after the positional arguments, and `OP_KARG` reads each keyword parameter out of it with `mrb_hash_delete_key()`, so once the prologue has run the register holds only what no parameter claimed. That object is also what `**rest` names. `OP_ARGARY` read that register for the parent, so a method that declared a keyword forwarded a dictionary without it, one that took `**rest` forwarded `rest` itself, and the parent's own `OP_KARG` then deleted from the caller's local. A keyword reassigned before `super` never reached the parent either, since the dictionary was never read again after the prologue.

Nothing on the path copied: an explicit `g(**o)` gets its fresh hash from `OP_HASH` and `OP_HASHCAT` at the call site, and `OP_ARGARY` was the one caller of `OP_SUPER` that skipped that step.

### Where the dictionary is built now

The keyword locals hold the values CRuby forwards, so the codegen for a bare `super` emits the hash after `OP_ARGARY`: an empty `OP_HASH` and an `OP_HASHCAT` of `rest` when the method takes one, then the declared keywords as `OP_LOADSYM` and local pairs under `OP_HASHADD`, or under `OP_HASH` when there is no `rest`. That is the order CRuby's parent sees the keys in, and it is the one that lets a declared keyword win over a key of its name that `rest` was reassigned to hold. The block's slot is used as scratch on the way and the block is read again afterwards, by the same move `super(...)` with no block already uses.

The register of each keyword local follows from the `OP_ENTER` operand, which the scope now keeps beside `ainfo`: the dictionary sits after the positional arguments, the block's slot and its name after that, and the keyword locals after those, in declaration order. The names are read off the scope's local table. From a block the locals are read through `OP_GETUPVAR` at the level `search_mscope()` already counted for the block that `super` forwards.

A string given to `eval` has no method scope of its own; `search_mscope()` already restated the method's `OP_ENTER` from the proc chain, and now hands over the irep as well, whose local table gives the names. A method compiled without a local table keeps forwarding the dictionary as read, since there is nothing to build from.

## Behaviour

```ruby
class A; def m(a:, b: 2); [a, b]; end; end
class B < A; def m(a:, b: 2); super; end; end
B.new.m(a: 1, b: 3)     # CRuby: [1, 3], mruby before: ArgumentError (missing keyword: a), after: [1, 3]

class C < A; def m(a:, b: 2); a *= 10; super; end; end
C.new.m(a: 1)           # CRuby: [10, 2], mruby before: ArgumentError, after: [10, 2]

class R; def m(a:, **o); [a, o]; end; end
class S < R; def m(**o); r = super; [r, o]; end; end
S.new.m(a: 1, z: 2)     # CRuby: [[1, {z: 2}], {a: 1, z: 2}], mruby before: [[1, {z: 2}], {z: 2}], after: [[1, {z: 2}], {a: 1, z: 2}]
```

Every method that declares a keyword and calls a bare `super` raised before, at any depth of inheritance, from a block or a lambda, from an included or a prepended module, and with any mix of positional, `*rest`, post and block parameters around the keyword. A method taking only `**rest` went through, with its `rest` losing whatever the parent declared.

A bare `super` from a method that declares a keyword into a parent that takes no parameters raises `ArgumentError` now, as in CRuby, where the empty dictionary used to pass.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | base PR   | this PR   | delta from base |
| ---------------- | --------- | --------- | --------- | --------------- |
| full-debug (-O0) | 1,996,214 | 1,996,246 | 1,997,350 | +1,104          |
| bintest          | 1,400,406 | 1,400,598 | 1,401,846 | +1,248          |
| cxx_abi          | 1,432,265 | 1,432,329 | 1,433,577 | +1,248          |
| byte-string      | 1,361,910 | 1,361,798 | 1,363,046 | +1,248          |
| ascii-ctype      | 1,384,934 | 1,384,822 | 1,386,070 | +1,248          |
| no-float         | 1,325,998 | 1,326,014 | 1,327,342 | +1,328          |
| no-bigint        | 1,284,486 | 1,284,502 | 1,285,750 | +1,248          |

In the bintest build `codegen.o` gains 1,248 bytes, which is the whole delta: `gen_zsuper_kwargs()`, the name lookup, and the struct that `search_mscope()` fills in place of the two values it answered. `vm.o` is unchanged.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2755  | 2681 | 74   | 0   | 0     | 0       |
| full-debug  | 3003  | 2992 | 11   | 0   | 0     | 0       |
| bintest     | 3003  | 2983 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3003  | 2983 | 20   | 0   | 0     | 0       |
| byte-string | 2915  | 2841 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2987  | 2965 | 22   | 0   | 0     | 0       |
| no-float    | 2736  | 2639 | 97   | 0   | 0     | 0       |
| no-bigint   | 2952  | 2919 | 33   | 0   | 0     | 0       |

bintest: 147 total, 147 OK, 0 KO.

The syntax test takes the shapes a bare `super` with keywords comes in and gives each the answer CRuby gives: a required keyword, an optional one, `**rest` alone and beside a declared keyword, the whole parameter list with positional, `*rest`, post and block parameters around them; two `super` in one method, and the parent's dictionary being a copy of the child's `rest`; a keyword reassigned before `super`, a key of a declared keyword's name put into `rest`, and a child default the caller did not override; `super` from a block, a nested block and a lambda, up two levels of inheritance, with a block of its own, and through `...` and the anonymous `**`. The eval test adds a required keyword and a `**rest` with a reassigned keyword from a string, the second from a block inside the string. Both were run against the tree before the change: every case that declares a keyword raised `ArgumentError`, and the `rest` cases answered with the child's `rest` emptied.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch src/vm.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/vm.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed bare `super` so keyword arguments are forwarded with their current values, including reassigned and default values.
  - Preserved remaining keyword arguments and block forwarding across nested scopes, lambdas, and repeated calls.
  - Prevented blocks from being collected during argument processing when short argument lists include rest or keyword arguments.

- **Tests**
  - Added coverage for keyword forwarding, evaluated `super` calls, nested scopes, inheritance, and block lifetime during garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->