### PR TITLE
class.c: give `define_method` and `attr_*` the visibility of the scope they are called in

### DIFF
--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -586,6 +586,40 @@ assert('Module#define_method - the visibility it takes from the scope') do
   assert_equal [:mf], mod.singleton_methods(false)
 end
 
+assert('Module#attr_* - the visibility they take from the scope') do
+  c = Class.new do
+    private
+    attr_reader :r
+    attr_accessor :a
+    protected
+    attr_writer :w
+    public
+    attr_reader :p
+    def self.make; attr_reader :from_cm; end
+  end
+  c.make
+  assert_equal [:a, :a=, :r], c.private_instance_methods(false).sort
+  assert_equal [:w=], c.protected_instance_methods(false)
+  assert_equal [:from_cm, :p], c.public_instance_methods(false).sort
+
+  # a singleton class takes no visibility from its body
+  s = Class.new do
+    class << self
+      private
+      attr_reader :sr
+    end
+  end
+  assert_equal [:sr], s.singleton_methods(false)
+
+  # module_function scope: private, with no module method copy
+  mod = Module.new do
+    module_function
+    attr_reader :mf
+  end
+  assert_equal [:mf], mod.private_instance_methods(false)
+  assert_equal [], mod.singleton_methods(false)
+end
+
 assert('Module#define_method - where a def in the block lands') do
   # A `define_method` block keeps the scope it was written in, its cref
   # along with its locals, so a `def` in it adds to that scope's class and

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -551,6 +551,41 @@ assert('Module.nesting from a method with a receiver', '15.2.2.2.2') do
                Test4NestingInSdef.in_sclass)
 end
 
+assert('Module#define_method - the visibility it takes from the scope') do
+  c = Class.new do
+    private
+    define_method(:priv) {}
+    protected
+    define_method(:prot) {}
+    public
+    define_method(:pub) {}
+    def self.make; define_method(:from_cm) {}; end
+  end
+  c.make
+  assert_equal [:priv], c.private_instance_methods(false)
+  assert_equal [:prot], c.protected_instance_methods(false)
+  assert_equal [:from_cm, :pub], c.public_instance_methods(false).sort
+
+  # a singleton class takes no visibility from its body, as a `def` there does not
+  s = Class.new do
+    class << self
+      private
+      define_method(:sm) {}
+      def sd; end
+    end
+  end
+  assert_equal [:sd, :sm], s.singleton_methods(false).sort
+  assert_equal [], s.singleton_class.private_instance_methods(false)
+
+  # module_function scope: the instance method is private, the module one public
+  mod = Module.new do
+    module_function
+    define_method(:mf) {}
+  end
+  assert_equal [:mf], mod.private_instance_methods(false)
+  assert_equal [:mf], mod.singleton_methods(false)
+end
+
 assert('Module#define_method - where a def in the block lands') do
   # A `define_method` block keeps the scope it was written in, its cref
   # along with its locals, so a `def` in it adds to that scope's class and

--- a/src/class.c
+++ b/src/class.c
@@ -2686,6 +2686,11 @@ mrb_mod_visibility(mrb_state *mrb, mrb_value mod, int vis)
     struct RClass *t = c;
     MRB_CLASS_ORIGIN(t);
     mrb_mt_tbl *h = mt_writable(mrb, c, t);
+    if (argc == 1 && mrb_array_p(argv[0])) {
+      /* the names `attr_accessor` and its kin answer with */
+      argc = RARRAY_LEN(argv[0]);
+      argv = RARRAY_PTR(argv[0]);
+    }
     for (int i=0; i<argc; i++) {
       mrb_check_type(mrb, argv[i], MRB_TT_SYMBOL);
       mrb_sym mid = mrb_symbol(argv[i]);
@@ -3355,8 +3360,11 @@ prepare_writer_name(mrb_state *mrb, mrb_sym sym)
   return prepare_name_common(mrb, sym, NULL, "=");
 }
 
+/* Defines the accessors named and answers their names, reader before
+   writer for each name, so that `private attr_accessor :a` can pass them on
+   the way CRuby's answer can. */
 static mrb_value
-mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_int aargc, mrb_value (*accessor)(mrb_state*, mrb_value), mrb_sym (*access_name)(mrb_state*, mrb_sym))
+mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_bool reader, mrb_bool writer)
 {
   struct RClass *c = mrb_class_ptr(mod);
   const mrb_value *argv;
@@ -3369,23 +3377,25 @@ mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_int aargc, mrb_value (*access
   mrb_bool modfunc;
   int vis = caller_scope_visibility(mrb, c, &modfunc);
 
+  mrb_value names = mrb_ary_new_capa(mrb, argc * (reader + writer));
   int ai = mrb_gc_arena_save(mrb);
   for (int i=0; i<argc; i++) {
-    mrb_sym method = to_sym(mrb, argv[i]);
-    mrb_value name = prepare_ivar_name(mrb, method);
-    if (access_name) {
-      method = access_name(mrb, method);
+    mrb_sym sym = to_sym(mrb, argv[i]);
+    mrb_value ivar = prepare_ivar_name(mrb, sym);
+    for (int w = 0; w < 2; w++) {
+      if (!(w ? writer : reader)) continue;
+      mrb_sym mid = w ? prepare_writer_name(mrb, sym) : sym;
+      struct RProc *p = mrb_proc_new_cfunc_with_env(mrb, w ? mrb_attr_writer : mrb_attr_reader, 1, &ivar);
+      if (!w) p->flags |= MRB_PROC_NOARG;
+      mrb_method_t m;
+      MRB_METHOD_FROM_PROC(m, p);
+      MRB_METHOD_SET_VISIBILITY(m, vis);
+      mrb_define_method_raw(mrb, c, mid, m);
+      mrb_ary_push(mrb, names, mrb_symbol_value(mid));
     }
-
-    struct RProc *p = mrb_proc_new_cfunc_with_env(mrb, accessor, 1, &name);
-    p->flags |= aargc == 0 ? MRB_PROC_NOARG : 0;
-    mrb_method_t m;
-    MRB_METHOD_FROM_PROC(m, p);
-    MRB_METHOD_SET_VISIBILITY(m, vis);
-    mrb_define_method_raw(mrb, c, method, m);
     mrb_gc_arena_restore(mrb, ai);
   }
-  return mrb_nil_value();
+  return names;
 }
 
 mrb_value
@@ -3398,7 +3408,7 @@ mrb_attr_reader(mrb_state *mrb, mrb_value obj)
 static mrb_value
 mrb_mod_attr_reader(mrb_state *mrb, mrb_value mod)
 {
-  return mod_attr_define(mrb, mod, 0, mrb_attr_reader, NULL);
+  return mod_attr_define(mrb, mod, TRUE, FALSE);
 }
 
 mrb_value
@@ -3414,14 +3424,13 @@ mrb_attr_writer(mrb_state *mrb, mrb_value obj)
 static mrb_value
 mrb_mod_attr_writer(mrb_state *mrb, mrb_value mod)
 {
-  return mod_attr_define(mrb, mod, 1, mrb_attr_writer, prepare_writer_name);
+  return mod_attr_define(mrb, mod, FALSE, TRUE);
 }
 
 static mrb_value
 mrb_mod_attr_accessor(mrb_state *mrb, mrb_value mod)
 {
-  mrb_mod_attr_reader(mrb, mod);
-  return mrb_mod_attr_writer(mrb, mod);
+  return mod_attr_define(mrb, mod, TRUE, TRUE);
 }
 
 static mrb_value

--- a/src/class.c
+++ b/src/class.c
@@ -1130,6 +1130,16 @@ eq_defined_mark(mrb_state *mrb, struct RClass *c)
   }
 }
 
+/* module_function scope: also define a public method on the singleton
+   class, so the module method (M.foo) mirrors the private instance one */
+static void
+define_modfunc_copy(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_t m)
+{
+  MRB_SET_VISIBILITY_FLAGS(m.flags, MRB_METHOD_PUBLIC_FL);
+  prepare_singleton_class(mrb, (struct RBasic*)c);
+  mrb_define_method_raw(mrb, c->c, mid, m);
+}
+
 MRB_API void
 mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_t m)
 {
@@ -1196,12 +1206,7 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
     if (mid == MRB_OPSYM(eq)) eq_defined_mark(mrb, named);
   }
   if (modfunc) {
-    /* module_function scope: also define a public method on the singleton
-       class, so the module method (M.foo) mirrors the private instance one */
-    mrb_method_t sm = m;
-    MRB_SET_VISIBILITY_FLAGS(sm.flags, MRB_METHOD_PUBLIC_FL);
-    prepare_singleton_class(mrb, (struct RBasic*)c);
-    mrb_define_method_raw(mrb, c->c, mid, sm);
+    define_modfunc_copy(mrb, c, mid, m);
   }
 }
 

--- a/src/class.c
+++ b/src/class.c
@@ -3364,6 +3364,11 @@ mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_int aargc, mrb_value (*access
 
   mrb_get_args(mrb, "*", &argv, &argc);
 
+  /* An accessor made in a module_function scope is private and gets no
+     module method copy, as CRuby's `rb_attr()` makes it. */
+  mrb_bool modfunc;
+  int vis = caller_scope_visibility(mrb, c, &modfunc);
+
   int ai = mrb_gc_arena_save(mrb);
   for (int i=0; i<argc; i++) {
     mrb_sym method = to_sym(mrb, argv[i]);
@@ -3376,6 +3381,7 @@ mod_attr_define(mrb_state *mrb, mrb_value mod, mrb_int aargc, mrb_value (*access
     p->flags |= aargc == 0 ? MRB_PROC_NOARG : 0;
     mrb_method_t m;
     MRB_METHOD_FROM_PROC(m, p);
+    MRB_METHOD_SET_VISIBILITY(m, vis);
     mrb_define_method_raw(mrb, c, method, m);
     mrb_gc_arena_restore(mrb, ai);
   }

--- a/src/class.c
+++ b/src/class.c
@@ -987,6 +987,35 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
   *cp = NULL;
 }
 
+/* The visibility a method made by a call from Ruby takes, read from the
+   frame the C function was called from.  A call written in the body of the
+   class it defines on takes the visibility written there, as a `def` in
+   that body would; a call on another class, or from inside a method, makes
+   a public method.  The receiver has to be both the self and the class of
+   that frame, the way CRuby's `rb_vm_cref_in_context()` answers for
+   `define_method` and `rb_attr()`.  A singleton class takes no visibility
+   from its body here either. */
+static int
+caller_scope_visibility(mrb_state *mrb, struct RClass *c, mrb_bool *modfunc)
+{
+  const struct mrb_context *ec = mrb->c;
+  mrb_callinfo *ci = ec->ci - 1;
+
+  *modfunc = FALSE;
+  if (ci < ec->cibase || c->tt == MRB_TT_SCLASS) return MRB_METHOD_PUBLIC_FL;
+  if (mrb_vm_ci_target_class(ci) != c) return MRB_METHOD_PUBLIC_FL;
+  mrb_value self = ci->stack[0];
+  if (!(mrb_class_p(self) || mrb_module_p(self)) || mrb_class_ptr(self) != c) {
+    return MRB_METHOD_PUBLIC_FL;
+  }
+
+  struct REnv *e;
+  find_visibility_scope(mrb, c, 1, &ci, &e);
+  mrb_assert(ci || e);
+  *modfunc = e ? MRB_ENV_MODFUNC_P(e) : MRB_CI_MODFUNC_P(ci);
+  return (int)((e ? MRB_ENV_VISIBILITY(e) : MRB_CI_VISIBILITY(ci)) << 25);
+}
+
 /* Gives the current frame the visibility of the scope `p` was compiled
    against. `eval` on a string wants this: the string runs in that scope, so a
    `def` in it takes the visibility written there, while the frame goes on
@@ -4417,7 +4446,16 @@ define_method_m(mrb_state *mrb, struct RClass *c, int vis)
 mrb_value
 mrb_mod_define_method_m(mrb_state *mrb, struct RClass *c)
 {
-  return define_method_m(mrb, c, MRB_METHOD_PUBLIC_FL);
+  mrb_bool modfunc;
+  int vis = caller_scope_visibility(mrb, c, &modfunc);
+  mrb_value name = define_method_m(mrb, c, vis);
+  if (modfunc) {
+    /* the copy is made of what the name now resolves to, as the copy
+       `module_function :name` makes is */
+    mrb_sym mid = mrb_symbol(name);
+    define_modfunc_copy(mrb, c, mid, mrb_method_search(mrb, c, mid));
+  }
+  return name;
 }
 
 static mrb_value

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -198,6 +198,58 @@ assert('Module#attr_writer', '15.2.2.4.14') do
   assert_equal 'test', AttrTestWriter.cattr_val
 end
 
+assert('Module#attr_* take the visibility of the scope they are called in') do
+  c = Class.new {
+    def set; self.w = 1; self.a = 2; @r = 3; end
+    def get; [r, a]; end
+    def set_prot(other); other.r = 4; end
+    private
+    attr_reader :r
+    attr_writer :w
+    attr_accessor :a
+    protected
+    attr_writer :r
+  }
+  obj = c.new
+  obj.set
+  assert_equal [3, 2], obj.get
+  assert_raise(NoMethodError) { obj.r }
+  assert_raise(NoMethodError) { obj.a }
+  assert_raise(NoMethodError) { obj.r = 5 }
+  other = c.new
+  obj.set_prot(other)
+  assert_equal [4, nil], other.get
+  assert_false c.method_defined?(:r)
+  assert_false c.method_defined?(:a=)
+  assert_true c.method_defined?(:r=)
+
+  # a `class_eval` block is the body too
+  c = Class.new
+  c.class_eval { private; attr_reader :r }
+  assert_raise(NoMethodError) { c.new.r }
+
+  # a call on another class, or from inside a method, defines a public accessor
+  other = Class.new
+  c = Class.new {
+    private
+    other.attr_accessor :pub
+    def self.make; attr_reader :from_cm; end
+  }
+  c.make
+  assert_nil other.new.pub
+  assert_nil c.new.from_cm
+
+  # module_function scope: private, and no module method is made of it
+  mod = Module.new {
+    module_function
+    attr_reader :mf
+  }
+  assert_false mod.respond_to?(:mf)
+  klass = Class.new { include mod; def call_mf; mf; end }
+  assert_nil klass.new.call_mf
+  assert_raise(NoMethodError) { klass.new.mf }
+end
+
 assert('Module#class_eval', '15.2.2.4.15') do
   class Test4ClassEval
     @a = 11

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -198,6 +198,28 @@ assert('Module#attr_writer', '15.2.2.4.14') do
   assert_equal 'test', AttrTestWriter.cattr_val
 end
 
+assert('Module#attr_* answer the names they define') do
+  r = w = a = nil
+  Class.new {
+    r = attr_reader :x, 'y'
+    w = attr_writer :x
+    a = attr_accessor :x, :y
+  }
+  assert_equal [:x, :y], r
+  assert_equal [:x=], w
+  assert_equal [:x, :x=, :y, :y=], a
+
+  # which is what a visibility written in front of them takes
+  c = Class.new {
+    def get; [r, a]; end
+    private attr_reader :r
+    private attr_accessor :a
+  }
+  assert_equal [nil, nil], c.new.get
+  assert_raise(NoMethodError) { c.new.r }
+  assert_raise(NoMethodError) { c.new.a = 2 }
+end
+
 assert('Module#attr_* take the visibility of the scope they are called in') do
   c = Class.new {
     def set; self.w = 1; self.a = 2; @r = 3; end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -502,6 +502,70 @@ assert('Module#define_method') do
   end
 end
 
+assert('Module#define_method takes the visibility of the scope it is called in') do
+  c = Class.new {
+    private
+    define_method(:priv) { :priv }
+    protected
+    define_method(:prot) { :prot }
+    public
+    define_method(:pub) { :pub }
+    def call_priv; priv; end
+    def call_prot; self.prot; end
+  }
+  obj = c.new
+  assert_equal :priv, obj.call_priv
+  assert_equal :prot, obj.call_prot
+  assert_equal :pub, obj.pub
+  assert_raise(NoMethodError) { obj.priv }
+  assert_raise(NoMethodError) { obj.prot }
+  assert_false c.method_defined?(:priv)
+  assert_true c.method_defined?(:prot)
+
+  # a block written in the body is still that body
+  c = Class.new {
+    def call_priv; priv; end
+    private
+    [1].each { define_method(:priv) { :priv } }
+  }
+  assert_equal :priv, c.new.call_priv
+  assert_raise(NoMethodError) { c.new.priv }
+
+  # and so is a `class_eval` block
+  c = Class.new
+  c.class_eval { private; define_method(:priv) { :priv } }
+  assert_raise(NoMethodError) { c.new.priv }
+
+  # a call on another class defines a public method
+  other = Class.new
+  Class.new {
+    private
+    other.define_method(:pub) { :pub }
+  }
+  assert_equal :pub, other.new.pub
+
+  # a call from inside a method is not in the body
+  c = Class.new {
+    private
+    def self.make; define_method(:from_cm) { :from_cm }; end
+    def make; self.class.define_method(:from_im) { :from_im }; end
+  }
+  c.make
+  c.new.__send__(:make)
+  assert_equal :from_cm, c.new.from_cm
+  assert_equal :from_im, c.new.from_im
+
+  # module_function scope: a private instance method and a public module one
+  mod = Module.new {
+    module_function
+    define_method(:mf) { :mf }
+  }
+  assert_equal :mf, mod.mf
+  klass = Class.new { include mod; def call_mf; mf; end }
+  assert_equal :mf, klass.new.call_mf
+  assert_raise(NoMethodError) { klass.new.mf }
+end
+
 # @!group prepend
   assert('Module#prepend') do
     module M0


### PR DESCRIPTION
## Summary

`define_method`, `attr_reader`, `attr_writer` and `attr_accessor` defined a public method whatever visibility was written before them in a class body, so a bare `private` reached the `def`s after it and nothing else. They now read the visibility of the scope they are called in, the way a `def` there does, and `attr_*` answer the names they define so that `private attr_reader :r` is a way to write one.

## Changes

| File                                      | What                                                                                                         |
| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| `src/class.c`                             | `caller_scope_visibility` reads the caller's scope; `define_method` and `attr_*` take what it answers        |
| `src/class.c`                             | `attr_*` answer the names they define; `private` and its siblings take a single array of names               |
| `test/t/module.rb`                        | the visibility each takes in a body, a block, `class_eval`, on another class, in a method, `module_function` |
| `mrbgems/mruby-metaprog/test/metaprog.rb` | the same, read back through `private_instance_methods` and `singleton_methods`                               |

### The scope is the caller's frame, and only when it is the receiver's body

`mrb_define_method_raw` resolves a default visibility on the current frame, which for a `def` is the body the `def` is written in. For a C method the current frame is the C method's own, which nothing has written a visibility to, so `attr_reader` always came out public, and `define_method` did not even ask.

`caller_scope_visibility` looks one frame up instead, at the Ruby frame the call was made from, and takes its visibility only when that frame's self and class are both the receiver. That is the condition CRuby's `rb_vm_cref_in_context()` puts on `define_method` and `rb_attr()`: a call on another class from a private body, or on the class from inside one of its methods, defines a public method. Where the condition holds the walk is `find_visibility_scope` with `n` = 1, the one `private` itself uses to find the scope to write to, so a block written in the body, a `class_eval` block and an eval string all read the body's visibility.

A singleton class takes no visibility from its body, as a `def` in `class << self` does not in mruby; that is unchanged and out of scope here.

### `module_function` reaches `define_method` and not `attr_*`

In a `module_function` scope CRuby's `define_method` makes the private instance method and the public module method, and `rb_attr()` makes only a private instance method. The singleton copy `mrb_define_method_raw` makes for a `def` in that scope is given a function of its own, and `define_method` makes the same copy of what the name resolves to once it is defined, as `module_function :name` does; `attr_*` read the visibility and make no copy.

### `attr_*` answer their names

`attr_reader :a, :b` answers `[:a, :b]`, `attr_writer :a` answers `[:a=]` and `attr_accessor :a, :b` answers `[:a, :a=, :b, :b=]`, reader before writer for each name, as CRuby's do. `private`, `protected` and `public` take a single array of names, so `private attr_accessor :a` reads as it does in CRuby. With two or more arguments they still take symbols only, as CRuby's do.

## Behaviour

```ruby
class C
  private
  define_method(:dm) { :dm }
  attr_reader :ar
  protected
  attr_writer :aw
end
C.new.dm           # CRuby: NoMethodError, mruby: :dm
C.new.ar           # CRuby: NoMethodError, mruby: nil
C.new.aw = 1       # CRuby: NoMethodError, mruby: 1

module M
  module_function
  define_method(:mf) { :mf }
  attr_reader :ma
end
M.mf               # CRuby: :mf, mruby: NoMethodError
M.respond_to?(:ma) # CRuby: false, mruby: false

class D
  private attr_reader :r   # CRuby: [:r], mruby: TypeError
end
```

A call on another class, or from inside a method, still defines a public method, in both: `Class.new { private; Other.attr_reader :x }` leaves `Other#x` public.

Out of scope and still different: `self.a = 1` inside a method raises `NoMethodError` for a private `a=` in mruby, where CRuby has let a private method be called on an explicit `self` since 2.7.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, gcc 13.3.0.

| Build       | master    | this PR   | delta  |
| ----------- | --------- | --------- | ------ |
| full-debug  | 1,996,214 | 1,997,286 | +1,072 |
| bintest     | 1,400,406 | 1,400,774 | +368   |
| cxx_abi     | 1,432,265 | 1,432,665 | +400   |
| byte-string | 1,361,910 | 1,362,278 | +368   |
| ascii-ctype | 1,384,934 | 1,385,302 | +368   |
| no-float    | 1,325,998 | 1,326,382 | +384   |
| no-bigint   | 1,284,486 | 1,284,854 | +368   |

`full-debug` is `-O0`. The growth is in `src/class.o` alone: the scope walk is inlined into the `define_method` and `attr_*` entry points, `attr_*` build the array of names, and `private` takes one apart. Against that, `mrb_define_method_raw` loses the constant-propagated clone the old `attr_*` had, and `prepare_writer_name` is folded into `mod_attr_define`.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2758  | 2684 | 74   | 0   | 0     | 0       |
| full-debug  | 3006  | 2995 | 11   | 0   | 0     | 0       |
| bintest     | 3006  | 2986 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3006  | 2986 | 20   | 0   | 0     | 0       |
| byte-string | 2918  | 2844 | 74   | 0   | 0     | 0       |
| ascii-ctype | 2990  | 2968 | 22   | 0   | 0     | 0       |
| no-float    | 2739  | 2642 | 97   | 0   | 0     | 0       |
| no-bigint   | 2955  | 2922 | 33   | 0   | 0     | 0       |

`bintest` runs the command binary tests as well: 147 total, 146 OK, 1 skip, 0 KO.

The `test/t/module.rb` blocks put `define_method` and each `attr_*` after `private`, `protected` and `public` in a class body, in a block written in the body and in a `class_eval` block, call them on another class from a private body and on the class from a class method and an instance method, and run them in a `module_function` scope; visibility is read by calling the method with and without a receiver and through `method_defined?`. A separate block reads the names `attr_*` answer and writes `private attr_reader` and `private attr_accessor`. The `mruby-metaprog` blocks read the same definitions back through `private_instance_methods`, `protected_instance_methods`, `public_instance_methods` and `singleton_methods`, including the singleton class body and the presence or absence of the `module_function` copy.

The cases in the Behaviour section and their variants, 13 in all, were run against CRuby 4.0.6 as well; every answer is the same, apart from the `self.a = 1` difference named above.

## Environment

<details>

| Item     | Value                                              |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                 |
| Kernel   | Linux 7.0.0-31-generic x86_64                      |
| CPU      | AMD Ryzen 9 5950X 16-Core                          |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)        |
| binutils | GNU ld 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, taken with `touch src/class.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped.

```console
host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/class.c

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `define_method` now inherits the visibility of its surrounding scope: public, protected, or private.
  - `attr_reader`, `attr_writer`, and `attr_accessor` now apply the surrounding scope’s visibility when creating methods.
  - Methods defined within `module_function` scopes correctly remain private as instance methods while exposing the appropriate module-level behavior.
  - Accessor declarations return the names of the methods they define.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->