### PR TITLE
vm.c: define a constant, class or module on the cref

### DIFF
--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -95,8 +95,11 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
      (MRB_ENV_SET_SVAR below; see internal.h). */
   mrb_value *stacks = (mrb_value*)mrb_malloc(mrb, MRB_ENV_SVAR_STACK_SIZE(1));
   /* The space stands in for the frame the binding was taken from, so it
-     answers for the method that frame was called by: that is the name a
-     string evaluated in the binding is named for. */
+     answers for the class that frame ran under and for the method it was
+     called by: a string evaluated in the binding takes the first as the
+     class its constants, `class` bodies and class variables belong to, and
+     is named for the second. */
+  env->c = e ? e->c : NULL;
   env->mid = e ? e->mid : 0;
   env->stack = stacks;
   if (e && e->stack && MRB_ENV_LEN(e) > 0) {

--- a/mrbgems/mruby-eval/test/binding.rb
+++ b/mrbgems/mruby-eval/test/binding.rb
@@ -111,3 +111,46 @@ assert 'Binding#eval on a binding taken under a given class' do
   assert_equal :m, obj.m
   assert_false Object.new.respond_to?(:m)
 end
+
+assert "a binding gives a string the scope its constants belong to" do
+  # The space a binding keeps its own locals in stands in for the frame the
+  # binding was taken from, so a string evaluated in it defines constants,
+  # classes and modules where that frame's code would have, and a block made
+  # in the string reads a superclass's constant before the top level's, the
+  # way one made in that frame does.
+  BindingScopeProbeTop = :top
+  class BindingScopeProbeBase
+    PROBE = :base
+    BindingScopeProbeTop = :base
+  end
+  class BindingScopeProbe < BindingScopeProbeBase
+    PROBE = :here
+    def self.scope; binding; end
+    def scope; binding; end
+  end
+  b = BindingScopeProbe.scope
+  assert_equal :here, b.eval("PROBE")
+  b.eval("FROM_STRING = 1")
+  assert_equal 1, BindingScopeProbe::FROM_STRING
+  assert_false Object.const_defined?(:FROM_STRING, false)
+  assert_false BindingScopeProbe.singleton_class.const_defined?(:FROM_STRING, false)
+  b.eval("class Inner; end; module InnerMod; end")
+  assert_true BindingScopeProbe.const_defined?(:Inner, false)
+  assert_true BindingScopeProbe.const_defined?(:InnerMod, false)
+  assert_false Object.const_defined?(:Inner, false)
+  assert_equal :base, b.eval("proc { BindingScopeProbeTop }").call
+  assert_equal :base, b.eval("[1].map { BindingScopeProbeTop }[0]")
+
+  # A block made in the string, and a binding taken in it, keep the scope.
+  b.eval("proc { FROM_BLOCK = 3 }").call
+  assert_equal 3, BindingScopeProbe::FROM_BLOCK
+  b.eval("binding").eval("FROM_INNER_BINDING = 4")
+  assert_equal 4, BindingScopeProbe::FROM_INNER_BINDING
+
+  # An instance method's binding and a string `class_eval`'s binding as well.
+  BindingScopeProbe.new.scope.eval("FROM_INSTANCE = 5")
+  assert_equal 5, BindingScopeProbe::FROM_INSTANCE
+  BindingScopeProbe.class_eval("binding").eval("FROM_CLASS_EVAL = 6")
+  assert_equal 6, BindingScopeProbe::FROM_CLASS_EVAL
+  assert_false Object.const_defined?(:FROM_CLASS_EVAL, false)
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -557,6 +557,40 @@ assert('a string given to eval in a `define_method` block sees the closure') do
   assert_equal 20, k.new.read
 end
 
+assert('a constant defined in a string given to eval belongs to the class the method was written in') do
+  # The frame of a method written `def self.name` carries the singleton
+  # class the method was found in, and a constant, class or module the
+  # string defines used to go there, or to `Object` through a binding.
+  # CRuby adds it to the cref, the class the code was written in.
+  class TestEvalConstDef
+    def self.direct; eval("FROM_DIRECT = 1"); end
+    def self.nested; proc { eval("FROM_NESTED = 2") }.call; end
+    def self.bound; binding.eval("FROM_BOUND = 3"); end
+    def self.opened; eval("class Opened; end; module OpenedMod; end"); end
+    class << self
+      def sclass; eval("FROM_SCLASS = 4"); end
+    end
+    def plain; eval("FROM_PLAIN = 5"); end
+  end
+  TestEvalConstDef.direct
+  TestEvalConstDef.nested
+  TestEvalConstDef.bound
+  TestEvalConstDef.opened
+  TestEvalConstDef.sclass
+  TestEvalConstDef.new.plain
+  assert_equal [1, 2, 3, 5], [
+    TestEvalConstDef::FROM_DIRECT, TestEvalConstDef::FROM_NESTED,
+    TestEvalConstDef::FROM_BOUND, TestEvalConstDef::FROM_PLAIN]
+  assert_true TestEvalConstDef.const_defined?(:Opened, false)
+  assert_true TestEvalConstDef.const_defined?(:OpenedMod, false)
+  sclass = TestEvalConstDef.singleton_class
+  assert_false sclass.const_defined?(:FROM_NESTED, false)
+  assert_false Object.const_defined?(:FROM_BOUND, false)
+  # A method written in `class << self` is written in the singleton class.
+  assert_equal 4, sclass::FROM_SCLASS
+  assert_false TestEvalConstDef.const_defined?(:FROM_SCLASS, false)
+end
+
 assert('a string given to eval in a `def` body has no scope around it') do
   # A method body carries no closure, so a local of the scope it was written
   # in is not a name it can reach: it is a method call there.

--- a/src/vm.c
+++ b/src/vm.c
@@ -3415,7 +3415,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_SETCONST, BB) {
       ci = mrb->c->ci;
-      struct RClass *c = MRB_PROC_TARGET_CLASS(ci->proc);
+      struct RClass *c = mrb_vm_cref_class(mrb, ci);
       if (!c) c = mrb->object_class;
       mrb_const_set(mrb, mrb_obj_value(c), irep->syms[b], regs[a]);
       ci = mrb->c->ci;
@@ -4634,7 +4634,7 @@ RETRY_TRY_BLOCK:
       mrb_value super = regs[a+1];
 
       if (mrb_nil_p(base)) {
-        baseclass = MRB_PROC_TARGET_CLASS(ci->proc);
+        baseclass = mrb_vm_cref_class(mrb, ci);
         if (!baseclass) baseclass = mrb->object_class;
         base = mrb_obj_value(baseclass);
       }
@@ -4651,7 +4651,7 @@ RETRY_TRY_BLOCK:
       mrb_value base = regs[a];
 
       if (mrb_nil_p(base)) {
-        baseclass = MRB_PROC_TARGET_CLASS(ci->proc);
+        baseclass = mrb_vm_cref_class(mrb, ci);
         if (!baseclass) baseclass = mrb->object_class;
         base = mrb_obj_value(baseclass);
       }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1303,3 +1303,22 @@ assert('constant lookup: a block given a class to run under keeps its own') do
   end
   assert_equal(:lex, host.new.probe)
 end
+
+assert('constant definition: a block given a class to run under keeps its own') do
+  # The same holds for a constant, class or module the block defines: it
+  # belongs to the scope the block was written in, from any depth. The
+  # frame of the block carries the given class for `def`, and a block made
+  # inside it used to define there.
+  recv = Module.new
+  recv.class_eval { [1].each { Test4ConstDefDirect = :a } }
+  recv.class_eval { [1].each { [1].each { Test4ConstDefNested = :b } } }
+  recv.class_eval { [1].each { class Test4ConstDefClass; end } }
+  recv.class_eval { [1].each { module Test4ConstDefModule; end } }
+  Class.new { [1].each { Test4ConstDefClassNew = :c } }
+  Object.new.instance_eval { [1].each { Test4ConstDefInstance = :d } }
+  [:Test4ConstDefDirect, :Test4ConstDefNested, :Test4ConstDefClass,
+   :Test4ConstDefModule, :Test4ConstDefClassNew, :Test4ConstDefInstance].each do |name|
+    assert_true Object.const_defined?(name, false), name.to_s
+    assert_false recv.const_defined?(name, false), name.to_s
+  end
+end


### PR DESCRIPTION
## Summary

A constant, class or module defined without a scope before its name was added to the class the frame carried: the class a method was found in, or the class `class_eval` and its kin gave the frame. A string evaluated in a block of a `def self.name` method, or through a binding taken in it, therefore defined on the singleton class or on `Object`, and a block made inside a `class_eval` block defined on the receiver. CRuby adds to the cref, the class the code was written in, and the VM now asks the scope for it the way a constant read already does. The env a `Binding` allocates for its own locals also carries the class of its scope now, next to the method name it already carried.

## Changes

| File                                  | What                                                                                                                    |
| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| `src/vm.c`                            | `OP_SETCONST`, `OP_CLASS` and `OP_MODULE` take the class from `mrb_vm_cref_class()` instead of the running proc         |
| `mrbgems/mruby-binding/src/binding.c` | `binding_env_new_lvspace()` copies `c` from the env it stands in for, as it copies `mid`                                |
| `test/t/module.rb`                    | one test: a constant, class or module defined in a block under `class_eval`, `instance_eval` or `Class.new`             |
| `mrbgems/mruby-eval/test/eval.rb`     | one test: a constant defined in an eval string in a `def self.name` method, from a block, a binding and `class << self` |
| `mrbgems/mruby-eval/test/binding.rb`  | one test: what a string evaluated in a binding defines and reads, and a superclass constant from a block made in it     |

### The proc's class is where the method was found, not where it was written

`OP_SETCONST`, `OP_CLASS` and `OP_MODULE` read `MRB_PROC_TARGET_CLASS(ci->proc)`. For a proc that closes over an env that is `env->c`, the class of the frame the proc was made in, and `mrb_env_new()` fills it from the callinfo's target class: for a method frame the class the method was found in, so the singleton class for a method written `def self.name`; for a `class_eval` frame the receiver. A method body proc keeps the class it was written in since #7538, so `Z = 1` directly in an eval string in the method lands right; a block made in that frame, and the eval string it runs, took the frame's class instead.

CRuby resolves all three from the cref, the class the code was lexically written in, with the crefs `class_eval` and its kin push skipped. mruby has had that walk since #7538 as `mrb_vm_cref_class()`, which `OP_GETCONST` and `defined?` already use. The three writers use it now, and fall back to `Object` where the chain reaches a C function's proc as before.

### The binding's env had no class

`binding_env_new_lvspace()` allocates the env a binding keeps its own top-level locals in. It copies the receiver and, since 31ec4b9b6, the method name from the env it stands in for, but never set `c`, so a string compiled against the binding ran as a proc whose `MRB_PROC_TARGET_CLASS()` is `NULL`. `lexical_scope_p()` in `src/variable.c` reads that as `Object`, and since the proc one level up carries the scope's class, the string counted as a lexical scope of `Object`'s own: a block made in the string found a top-level constant there before the ancestors of the class the binding was taken in. The env copies `c` now, as it copies `mid`. It is a freshly allocated object being filled in, so no write barrier is involved.

## Behaviour

```ruby
class C
  def self.go; proc { eval("Z = 1") }.call; end
end
C.go
C::Z                          # master: NameError   this PR: 1
C.singleton_class::Z          # master: 1           this PR: NameError

M = Module.new
M.class_eval { [1].each { W = 2 } }
M::W                          # master: 2           this PR: NameError
Object::W                     # master: NameError   this PR: 2

class Base; X = :base; end
X = :top
class D < Base
  def self.scope; binding; end
end
D.scope.eval("proc { X }").call   # master: :top    this PR: :base
```

CRuby answers as this PR does. A constant written directly in a class body, a method body's eval string, a `class << self` body, a string `class_eval` or `instance_eval`, and a top-level block is defined where it was before. Out of scope but still apart from CRuby: a class variable in a block under `class_eval` is read from the receiver, where CRuby reads it from the scope the block was written in and raises when that is the top level.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `2e26be049`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,400,406 | 1,400,406 |     0 |
| ascii-ctype      | 1,384,934 | 1,384,806 |  -128 |
| byte-string      | 1,361,910 | 1,361,782 |  -128 |
| cxx_abi          | 1,432,265 | 1,432,057 |  -208 |
| no-float         | 1,325,998 | 1,325,918 |   -80 |
| no-bigint        | 1,284,486 | 1,284,598 |  +112 |
| full-debug (-O0) | 1,996,214 | 1,996,134 |   -80 |

Every delta is in `vm.o` plus 16 bytes in `binding.o` (28 on `full-debug`) for the copied field. `vm.o` moves with how gcc lays out the three cases once they call `mrb_vm_cref_class()` instead of reading a field through two branches: -16 on `bintest`, -144 on `ascii-ctype` and `byte-string`, -224 on `cxx_abi`, -96 on `no-float`, -108 on `full-debug`, and +96 on `no-bigint`. No other object changes.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,756 | 2,682 |   74 |   0 |     0 |       0 |
| bintest                          | 3,004 | 2,984 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 2,988 | 2,966 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,916 | 2,842 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,004 | 2,984 |   20 |   0 |     0 |       0 |
| no-float                         | 2,737 | 2,640 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,953 | 2,920 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,004 | 2,993 |   11 |   0 |     0 |       0 |

bintest passes on every build. The new tests check that a constant, class or module defined from a block nested one and two deep under `class_eval`, under `instance_eval` and under `Class.new` lands on `Object` and not on the receiver; that an eval string in a `def self.name` method defines on the class whether run directly, from a block or through a binding, opens a class and a module there, and defines on the singleton class from a method written in `class << self`; and that a string evaluated in a binding taken in a singleton method, an instance method or a string `class_eval` defines constants, classes and modules on that class, including from a block and a binding made in the string, and that a block made in the string reads a superclass constant before the top level's. Each commit was built and tested on its own.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/host=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/host=build" -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-binding/src/binding.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-binding/src/binding.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/async-waddling-seal=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_BINDING_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-binding/src/binding.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected constant, class, and module resolution when evaluating strings or blocks through bindings and evaluation contexts.
  - Definitions now consistently appear in the intended lexical scope, including nested, singleton, `class_eval`, and `instance_eval` contexts.
  - Improved handling of class variables and class bodies evaluated from bindings.

- **Tests**
  - Added regression coverage for binding scope behavior and constant placement across instance, class, nested, and bound evaluation contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->