### PR TITLE
mruby-eval: run a string under the class the calling frame runs under

### DIFF
--- a/mrbgems/mruby-binding/src/binding.c
+++ b/mrbgems/mruby-binding/src/binding.c
@@ -95,8 +95,11 @@ binding_env_new_lvspace(mrb_state *mrb, const struct REnv *e)
      (MRB_ENV_SET_SVAR below; see internal.h). */
   mrb_value *stacks = (mrb_value*)mrb_malloc(mrb, MRB_ENV_SVAR_STACK_SIZE(1));
   /* The space stands in for the frame the binding was taken from, so it
-     answers for the method that frame was called by: that is the name a
-     string evaluated in the binding is named for. */
+     answers for the class that frame ran under and for the method it was
+     called by: a string evaluated in the binding takes the first as the
+     class its constants, `class` bodies and class variables belong to, and
+     is named for the second. */
+  env->c = e ? e->c : NULL;
   env->mid = e ? e->mid : 0;
   env->stack = stacks;
   if (e && e->stack && MRB_ENV_LEN(e) > 0) {

--- a/mrbgems/mruby-eval/src/eval.c
+++ b/mrbgems/mruby-eval/src/eval.c
@@ -110,7 +110,16 @@ create_proc_from_string(mrb_state *mrb, const char *s, mrb_int len, mrb_value bi
     ci = c->cibase;
   }
   if (scope) {
-    target_class = MRB_PROC_TARGET_CLASS(scope);
+    /* The class the string's frame runs under is the one the caller's frame
+       runs under: the class the method was found in, or the one a block was
+       given to run under. A `super` in the string, and the caller's own
+       `super` once its frame has been given an env here, read it for the
+       class to look above. The proc's own class is its cref, which for a
+       method written in a `Class.new` or `class_eval` block is the scope
+       around that block, not the class the method was installed in. A
+       binding stands in for the frame it was taken from and carries that
+       frame's class on its scope. */
+    target_class = mrb_nil_p(binding) ? mrb_vm_ci_target_class(ci) : MRB_PROC_TARGET_CLASS(scope);
     if (!MRB_PROC_CFUNC_P(scope)) {
       if (e == NULL) {
         /* when `binding` is nil */

--- a/mrbgems/mruby-eval/test/binding.rb
+++ b/mrbgems/mruby-eval/test/binding.rb
@@ -111,3 +111,46 @@ assert 'Binding#eval on a binding taken under a given class' do
   assert_equal :m, obj.m
   assert_false Object.new.respond_to?(:m)
 end
+
+assert "a binding gives a string the scope its constants belong to" do
+  # The space a binding keeps its own locals in stands in for the frame the
+  # binding was taken from, so a string evaluated in it defines constants,
+  # classes and modules where that frame's code would have, and a block made
+  # in the string reads a superclass's constant before the top level's, the
+  # way one made in that frame does.
+  BindingScopeProbeTop = :top
+  class BindingScopeProbeBase
+    PROBE = :base
+    BindingScopeProbeTop = :base
+  end
+  class BindingScopeProbe < BindingScopeProbeBase
+    PROBE = :here
+    def self.scope; binding; end
+    def scope; binding; end
+  end
+  b = BindingScopeProbe.scope
+  assert_equal :here, b.eval("PROBE")
+  b.eval("FROM_STRING = 1")
+  assert_equal 1, BindingScopeProbe::FROM_STRING
+  assert_false Object.const_defined?(:FROM_STRING, false)
+  assert_false BindingScopeProbe.singleton_class.const_defined?(:FROM_STRING, false)
+  b.eval("class Inner; end; module InnerMod; end")
+  assert_true BindingScopeProbe.const_defined?(:Inner, false)
+  assert_true BindingScopeProbe.const_defined?(:InnerMod, false)
+  assert_false Object.const_defined?(:Inner, false)
+  assert_equal :base, b.eval("proc { BindingScopeProbeTop }").call
+  assert_equal :base, b.eval("[1].map { BindingScopeProbeTop }[0]")
+
+  # A block made in the string, and a binding taken in it, keep the scope.
+  b.eval("proc { FROM_BLOCK = 3 }").call
+  assert_equal 3, BindingScopeProbe::FROM_BLOCK
+  b.eval("binding").eval("FROM_INNER_BINDING = 4")
+  assert_equal 4, BindingScopeProbe::FROM_INNER_BINDING
+
+  # An instance method's binding and a string `class_eval`'s binding as well.
+  BindingScopeProbe.new.scope.eval("FROM_INSTANCE = 5")
+  assert_equal 5, BindingScopeProbe::FROM_INSTANCE
+  BindingScopeProbe.class_eval("binding").eval("FROM_CLASS_EVAL = 6")
+  assert_equal 6, BindingScopeProbe::FROM_CLASS_EVAL
+  assert_false Object.const_defined?(:FROM_CLASS_EVAL, false)
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -667,3 +667,65 @@ assert('eval string in a method starts at the visibility of the scope the method
   o.make
   assert_true o.respond_to?(:written)
 end
+
+module EvalFrameClassMaker
+  # A `Class.new` block written in a method: the methods it defines have
+  # this module for their cref, the way a script's have `Object`.
+  def self.subclass(base)
+    Class.new(base) do
+      def m(x); eval("super"); end
+      def m_args(x); eval("super(x + 1)"); end
+      def nested(x); [1].map { eval("super") }[0]; end
+      def has_super; eval("defined?(super)"); end
+      def own_super_after(x); eval("1"); super; end
+      def bound(x); binding.eval("super"); end
+    end
+  end
+end
+
+assert('a string given to eval runs under the class the calling frame runs under') do
+  # The string's frame, and the env the string leaves on the caller's frame,
+  # took their class from the caller's proc, which holds the cref: for a
+  # method written in a `Class.new` block that is the scope around the
+  # block, and for a block given a class to run under it is the scope the
+  # block was written in. A `super` in the string looked above that class,
+  # and once the env was there the caller's own `super`, and a `def` written
+  # after the call in a block given a class, went to it as well. The class a
+  # frame runs under is the one the method was found in, or the one the
+  # block was given.
+  base = Class.new do
+    def m(x); [:base, x]; end
+    def m_args(x); [:base, x]; end
+    def nested(x); [:base, x]; end
+    def has_super; end
+    def own_super_after(x); [:base, x]; end
+    def bound(x); [:base, x]; end
+  end
+  o = EvalFrameClassMaker.subclass(base).new
+  assert_equal [:base, 1], o.m(1)
+  assert_equal [:base, 2], o.m_args(1)
+  assert_equal [:base, 3], o.nested(3)
+  assert_equal 'super', o.has_super
+  assert_equal [:base, 4], o.own_super_after(4)
+  assert_equal [:base, 5], o.bound(5)
+
+  # a block given a class: a `def` after the call, one in a string, and one
+  # in a block made after the call all go to the given class
+  c = Class.new
+  c.class_eval { eval("1"); def after_call; end }
+  c.class_eval { eval("def in_string; end") }
+  c.class_eval { eval("1"); [1].each { def in_block; end } }
+  assert_equal [:after_call, :in_block, :in_string], c.instance_methods(false).sort
+  assert_false Object.new.respond_to?(:after_call, true)
+  assert_false Object.new.respond_to?(:in_string, true)
+  assert_false Object.new.respond_to?(:in_block, true)
+  o = Object.new
+  o.instance_eval { eval("1"); def on_self; end }
+  assert_equal [:on_self], o.singleton_methods
+
+  # a constant the string defines still belongs to the scope the block was
+  # written in, not to the class the block was given
+  k = Class.new { eval("EvalFrameClassConst = 1") }
+  assert_true Object.const_defined?(:EvalFrameClassConst, false)
+  assert_false k.const_defined?(:EvalFrameClassConst, false)
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -557,6 +557,40 @@ assert('a string given to eval in a `define_method` block sees the closure') do
   assert_equal 20, k.new.read
 end
 
+assert('a constant defined in a string given to eval belongs to the class the method was written in') do
+  # The frame of a method written `def self.name` carries the singleton
+  # class the method was found in, and a constant, class or module the
+  # string defines used to go there, or to `Object` through a binding.
+  # CRuby adds it to the cref, the class the code was written in.
+  class TestEvalConstDef
+    def self.direct; eval("FROM_DIRECT = 1"); end
+    def self.nested; proc { eval("FROM_NESTED = 2") }.call; end
+    def self.bound; binding.eval("FROM_BOUND = 3"); end
+    def self.opened; eval("class Opened; end; module OpenedMod; end"); end
+    class << self
+      def sclass; eval("FROM_SCLASS = 4"); end
+    end
+    def plain; eval("FROM_PLAIN = 5"); end
+  end
+  TestEvalConstDef.direct
+  TestEvalConstDef.nested
+  TestEvalConstDef.bound
+  TestEvalConstDef.opened
+  TestEvalConstDef.sclass
+  TestEvalConstDef.new.plain
+  assert_equal [1, 2, 3, 5], [
+    TestEvalConstDef::FROM_DIRECT, TestEvalConstDef::FROM_NESTED,
+    TestEvalConstDef::FROM_BOUND, TestEvalConstDef::FROM_PLAIN]
+  assert_true TestEvalConstDef.const_defined?(:Opened, false)
+  assert_true TestEvalConstDef.const_defined?(:OpenedMod, false)
+  sclass = TestEvalConstDef.singleton_class
+  assert_false sclass.const_defined?(:FROM_NESTED, false)
+  assert_false Object.const_defined?(:FROM_BOUND, false)
+  # A method written in `class << self` is written in the singleton class.
+  assert_equal 4, sclass::FROM_SCLASS
+  assert_false TestEvalConstDef.const_defined?(:FROM_SCLASS, false)
+end
+
 assert('a string given to eval in a `def` body has no scope around it') do
   # A method body carries no closure, so a local of the scope it was written
   # in is not a name it can reach: it is a method call there.

--- a/src/vm.c
+++ b/src/vm.c
@@ -3415,7 +3415,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_SETCONST, BB) {
       ci = mrb->c->ci;
-      struct RClass *c = MRB_PROC_TARGET_CLASS(ci->proc);
+      struct RClass *c = mrb_vm_cref_class(mrb, ci);
       if (!c) c = mrb->object_class;
       mrb_const_set(mrb, mrb_obj_value(c), irep->syms[b], regs[a]);
       ci = mrb->c->ci;
@@ -4634,7 +4634,7 @@ RETRY_TRY_BLOCK:
       mrb_value super = regs[a+1];
 
       if (mrb_nil_p(base)) {
-        baseclass = MRB_PROC_TARGET_CLASS(ci->proc);
+        baseclass = mrb_vm_cref_class(mrb, ci);
         if (!baseclass) baseclass = mrb->object_class;
         base = mrb_obj_value(baseclass);
       }
@@ -4651,7 +4651,7 @@ RETRY_TRY_BLOCK:
       mrb_value base = regs[a];
 
       if (mrb_nil_p(base)) {
-        baseclass = MRB_PROC_TARGET_CLASS(ci->proc);
+        baseclass = mrb_vm_cref_class(mrb, ci);
         if (!baseclass) baseclass = mrb->object_class;
         base = mrb_obj_value(baseclass);
       }

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1303,3 +1303,22 @@ assert('constant lookup: a block given a class to run under keeps its own') do
   end
   assert_equal(:lex, host.new.probe)
 end
+
+assert('constant definition: a block given a class to run under keeps its own') do
+  # The same holds for a constant, class or module the block defines: it
+  # belongs to the scope the block was written in, from any depth. The
+  # frame of the block carries the given class for `def`, and a block made
+  # inside it used to define there.
+  recv = Module.new
+  recv.class_eval { [1].each { Test4ConstDefDirect = :a } }
+  recv.class_eval { [1].each { [1].each { Test4ConstDefNested = :b } } }
+  recv.class_eval { [1].each { class Test4ConstDefClass; end } }
+  recv.class_eval { [1].each { module Test4ConstDefModule; end } }
+  Class.new { [1].each { Test4ConstDefClassNew = :c } }
+  Object.new.instance_eval { [1].each { Test4ConstDefInstance = :d } }
+  [:Test4ConstDefDirect, :Test4ConstDefNested, :Test4ConstDefClass,
+   :Test4ConstDefModule, :Test4ConstDefClassNew, :Test4ConstDefInstance].each do |name|
+    assert_true Object.const_defined?(name, false), name.to_s
+    assert_false recv.const_defined?(name, false), name.to_s
+  end
+end


### PR DESCRIPTION
## Summary

A string given to `eval` without a binding ran under the class of the caller's proc, which is the proc's cref: for a method written in a `Class.new` block that is the scope around the block, and for a block given a class to run under it is the scope the block was written in. A `super` in the string looked above the wrong class and raised `NoMethodError`, and the env the string leaves on the caller's frame carried the same class, so the caller's own `super` after the call, and a `def` written after the call in a `class_eval` block, went wrong the same way. The string's frame now runs under the class the caller's frame runs under, the class the method was found in or the one the block was given, which is what `mrb_proc_get_caller()` already reads for the same frame.

This PR is stacked on #7546 and includes its diff. Without #7546 a constant defined in an eval string in a `Class.new` block would move from `Object` to the class the block was given, because `OP_SETCONST` there still reads the running proc's class rather than the cref.

## Changes

| File                              | What                                                                                                                                                           |
| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-eval/src/eval.c`   | `create_proc_from_string()` takes the class from `mrb_vm_ci_target_class()` of the caller's frame when there is no binding                                     |
| `mrbgems/mruby-eval/test/eval.rb` | one test: `super`, `defined?(super)` and a later `super` in a method made in a `Class.new` block, a `def` after `eval` in a block given a class, and constants |

### The frame's class is where the method was found, the proc's is where it was written

`create_proc_from_string()` sets two things from one value: the target class of the C frame `eval` runs on, which `mrb_exec_irep()` copies to the string's frame, and the `c` of the env it allocates for the caller's frame when that frame has none yet. `OP_SUPER` reads the frame's class through `CI_TARGET_CLASS(ci - 1)->super`, and `mrb_vm_definee_class()` reads a given class through the env, so both want the class the frame runs under.

The value came from `MRB_PROC_TARGET_CLASS(scope)`. Since #7538 a method body proc keeps the class it was written in, its cref, and for a method in a `Class.new` block that is the scope around the block. For a `class_eval` block the proc's class is the scope the block was written in as well; the receiver is on the frame, not on the proc. So the string's frame, and the caller's env, got the cref instead of the frame's class. `mrb_proc_get_caller()` in `src/proc.c` fills the same env for a string `class_eval` from `mrb_vm_ci_target_class(ci)`, and `create_proc_from_string()` does the same now. The binding path is unchanged: the binding's scope proc carries the class of the frame the binding was taken from.

The frame's class is not where a `def` in the string goes. `OP_TDEF` asks `mrb_vm_definee_class()`, which walks the proc chain to the cref unless a class was given to the frame, and the string's proc has the caller's proc for its `upper`, so a `def` in the string lands where one in the caller would.

## Behaviour

```ruby
base = Class.new { def m(x); [:base, x]; end }
sub = Class.new(base) { def m(x); eval("super"); end }
sub.new.m(1)                  # master: NoMethodError   this PR: [:base, 1]

sub = Class.new(base) { def m(x); eval("1"); super; end }
sub.new.m(1)                  # master: NoMethodError   this PR: [:base, 1]

c = Class.new
c.class_eval { eval("1"); def after; end }
c.instance_methods(false)     # master: []              this PR: [:after]
Object.new.respond_to?(:after, true)     # master: true   this PR: false
```

CRuby answers as this PR does. A method written in a named class body, and a string given a binding, behaved the same before and after. Out of scope but still apart from CRuby: a `def` written in the body of a method that a `Class.new` block defines lands on `Object` in mruby and on the new class in CRuby, and a `def` directly in a `class_exec`, `module_exec` or `instance_exec` block lands on `Object`, where `class_eval` and `instance_eval` blocks answer the receiver; the second is `mrb_object_exec()` not marking the frame as given a class, and a separate change.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `2e26be049` (the base of #7546), #7546 at `2efaf0d4d`:

| Build            |    master |     #7546 |   this PR | delta |
| ---------------- | --------: | --------: | --------: | ----: |
| bintest          | 1,400,406 | 1,400,406 | 1,400,454 |   +48 |
| ascii-ctype      | 1,384,934 | 1,384,806 | 1,384,854 |   +48 |
| byte-string      | 1,361,910 | 1,361,782 | 1,361,830 |   +48 |
| cxx_abi          | 1,432,265 | 1,432,057 | 1,432,105 |   +48 |
| no-float         | 1,325,998 | 1,325,918 | 1,325,966 |   +48 |
| no-bigint        | 1,284,486 | 1,284,598 | 1,284,646 |   +48 |
| full-debug (-O0) | 1,996,214 | 1,996,134 | 1,996,166 |   +32 |

The delta column is against #7546. All of it is `eval.o`: `mrb_vm_ci_target_class()` is a call where the old expression read a flag and a field inline (+48 at `-O3`, +23 at `-O0`, the rest alignment). No other object changes.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,757 | 2,683 |   74 |   0 |     0 |       0 |
| bintest                          | 3,005 | 2,985 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 2,989 | 2,967 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,917 | 2,843 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,005 | 2,985 |   20 |   0 |     0 |       0 |
| no-float                         | 2,738 | 2,641 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,954 | 2,921 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,005 | 2,994 |   11 |   0 |     0 |       0 |

bintest passes on every build. The new test builds the subclass in a method of a module, so that the methods' cref is that module and not the class they are installed in, the way it is for a script; a `Class.new` written directly in a test block gets the given class back through the fallback of `mrb_proc_new()` and passes on master. It checks a bare `super`, `super` with arguments, `super` from a block in the string, `defined?(super)`, the caller's own `super` after an `eval`, and `binding.eval("super")`; a `def` after an `eval` in a `class_eval` block, in a string there, and in a block made after the `eval`, and the same under `instance_eval`; and that a constant an eval string defines in a `Class.new` block still belongs to `Object`. On master the test fails at the first assertion with `TypeError: self has wrong type to call super in this context`.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-eval/src/eval.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "mrbgems/mruby-eval/src/eval.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr=build" -DMRBGEM_MRUBY_EVAL_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "mrbgems/mruby-eval/src/eval.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected lexical scoping for code evaluated from methods and bindings.
  * Constants, classes, and modules created by evaluated code are now assigned to the expected class or module scope.
  * Improved `super` resolution in evaluated code, including code used with `class_eval` and `instance_eval`.
  * Bindings now preserve the scope of the frame where they were created.

* **Tests**
  * Added coverage for evaluated code, bindings, nested scopes, and constant resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->