### PR TITLE
vm.c: mark a frame given a class by class_exec and instance_exec

### DIFF
--- a/mrbgems/mruby-class-ext/test/module.rb
+++ b/mrbgems/mruby-class-ext/test/module.rb
@@ -134,3 +134,38 @@ assert 'Module#module_eval' do
   assert_equal("hi", obj.hi)
   assert_equal("hello", obj.hello)
 end
+
+module ExecGivenClassMaker
+  # Run in a method, so that the blocks' cref is this module rather than the
+  # class `mrb_proc_new()` falls back to when a block at the top level of a
+  # compiled test file has no cref to answer with.
+  def self.on_class(c); c.class_exec { def from_block; end; [1].each { def from_nested_block; end } }; end
+  def self.on_module(m); m.module_exec { def from_block; end }; end
+  def self.private_on(c); c.class_exec { private; def hidden; end }; c.class_exec { def shown; end }; end
+end
+
+assert('a `def` in a block given to class_exec or module_exec adds to the receiver') do
+  # `mrb_object_exec()` set the class the frame runs under without marking
+  # the frame as given one, so a `def` in the block, or in a block made in
+  # it, went to the cref of the block, `Object` for a script, where a
+  # `class_eval` block was marked and answered the receiver. The visibility
+  # of the block starts at the default and ends with the block, as it does
+  # there.
+  c = Class.new
+  ExecGivenClassMaker.on_class(c)
+  assert_true c.new.respond_to?(:from_block)
+  assert_true c.new.respond_to?(:from_nested_block)
+  assert_false Object.new.respond_to?(:from_block, true)
+  assert_false Object.new.respond_to?(:from_nested_block, true)
+
+  m = Module.new
+  ExecGivenClassMaker.on_module(m)
+  assert_true Class.new { include m }.new.respond_to?(:from_block)
+  assert_false Object.new.respond_to?(:from_block, true)
+
+  c = Class.new
+  ExecGivenClassMaker.private_on(c)
+  assert_false c.new.respond_to?(:hidden)
+  assert_true c.new.respond_to?(:hidden, true)
+  assert_true c.new.respond_to?(:shown)
+end

--- a/mrbgems/mruby-object-ext/test/object.rb
+++ b/mrbgems/mruby-object-ext/test/object.rb
@@ -65,3 +65,23 @@ assert('argument forwarding via instance_exec from c') do
   # currently there is no easy way to call a method from C passing keyword arguments
   #assert_equal [[], { a: 1 }, nil], instance_exec_from_c(a: 1) { |*args, **kw, &blk| [args, kw, blk] }
 end
+
+module InstanceExecGivenClassMaker
+  # Run in a method, so that the block's cref is this module rather than the
+  # class `mrb_proc_new()` falls back to when a block at the top level of a
+  # compiled test file has no cref to answer with.
+  def self.on(o); o.instance_exec { def from_block; end; [1].each { def from_nested_block; end } }; end
+end
+
+assert('a `def` in a block given to instance_exec adds to the receiver') do
+  # `mrb_object_exec()` set the class the frame runs under without marking
+  # the frame as given one, so a `def` in the block, or in a block made in
+  # it, went to the cref of the block, `Object` for a script, where an
+  # `instance_eval` block was marked and answered the singleton class.
+  o = Object.new
+  InstanceExecGivenClassMaker.on(o)
+  assert_true o.respond_to?(:from_block)
+  assert_true o.respond_to?(:from_nested_block)
+  assert_false Object.new.respond_to?(:from_block, true)
+  assert_false Object.new.respond_to?(:from_nested_block, true)
+end

--- a/src/vm.c
+++ b/src/vm.c
@@ -1675,6 +1675,12 @@ mrb_object_exec(mrb_state *mrb, mrb_value self, struct RClass *target_class)
   mrb_gc_protect(mrb, blk);
   ci->stack[bidx] = mrb_nil_value();
   mrb_vm_ci_target_class_set(ci, target_class);
+  /* The block was given the class to run under, as one given to
+     `eval_under()` is: a `def` in it, or in a block made in it, adds to that
+     class rather than to the block's cref, and a visibility written in it
+     starts at the default and ends with the block. */
+  MRB_CI_SET_VISIBILITY_BREAK(ci);
+  MRB_CI_SET_GIVEN_CLASS(ci);
   return mrb_exec_irep(mrb, self, mrb_proc_ptr(blk));
 }
 


### PR DESCRIPTION
## Summary

A `def` written in a block given to `class_exec`, `module_exec` or `instance_exec`, or in a block made inside it, was added to the block's cref, `Object` for a script, where a `class_eval` or `instance_eval` block adds to the receiver. `mrb_object_exec()` set the class the frame runs under but did not mark the frame as given one, and since #7538 the mark is what `mrb_vm_definee_class()` reads. The frame is marked now, with the visibility break the `eval_under()` frame gets, so that a `private` written in a `class_exec` block ends with the block.

## Changes

| File                                      | What                                                                                                                     |
| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `src/vm.c`                                | `mrb_object_exec()` sets `MRB_CI_SET_GIVEN_CLASS` and `MRB_CI_SET_VISIBILITY_BREAK` on the frame, as `eval_under()` does |
| `mrbgems/mruby-class-ext/test/module.rb`  | one test: a `def` in a `class_exec` and a `module_exec` block, in a nested block, and the visibility written in one      |
| `mrbgems/mruby-object-ext/test/object.rb` | one test: a `def` in an `instance_exec` block and in a nested block                                                      |

### One mark for the two ways a block is given a class

#7538 split the class a frame carries from the class a `def` goes to: `mrb_vm_definee_class()` answers the frame's class only when the frame is marked as given one, and otherwise walks the proc chain to the cref. `eval_under()` in `src/class.c` marks the frame it sets up for a `class_eval` or `instance_eval` block. `mrb_object_exec()`, which `class_exec`, `module_exec` and `instance_exec` call, sets the frame's class through `mrb_vm_ci_target_class_set()` and was left without the mark, so the walk went past the frame to the cref. The two marks `eval_under()` sets are set here too.

The `Class#class_exec` test in the tree passes on master. A block written at the top level of a compiled test file has no cref to answer with, and `mrb_proc_new()` then falls back to the class of the frame the block was made in, which for the test block is the class it was given. The new tests make the block in a method of a module, which gives the block a cref of its own to fall to, the way a block in a script falls to `Object`.

## Behaviour

```ruby
c = Class.new
c.class_exec { def from_block; end }
c.instance_methods(false)                   # master: []      this PR: [:from_block]
Object.new.respond_to?(:from_block, true)   # master: true    this PR: false

o = Object.new
o.instance_exec { [1].each { def nested; end } }
o.singleton_methods                         # master: []      this PR: [:nested]
```

CRuby answers as this PR does. A `class_eval` or `instance_eval` block, and a string given to any of the five, behaved the same before and after.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `c0ea489c8`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,401,846 | 1,401,846 |     0 |
| ascii-ctype      | 1,386,070 | 1,386,070 |     0 |
| byte-string      | 1,363,046 | 1,363,046 |     0 |
| cxx_abi          | 1,433,577 | 1,433,577 |     0 |
| no-float         | 1,327,342 | 1,327,342 |     0 |
| no-bigint        | 1,285,750 | 1,285,750 |     0 |
| full-debug (-O0) | 1,997,350 | 1,997,398 |   +48 |

At `-O3` gcc lays `mrb_object_exec()` out differently but in the same number of bytes, so `vm.o` and the binary are the same size on every optimized build. On `full-debug` the two `MRB_FLAG_ON` are +40 in `vm.o`, the rest alignment. No other object changes.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,757 | 2,683 |   74 |   0 |     0 |       0 |
| bintest                          | 3,005 | 2,985 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 2,989 | 2,967 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,917 | 2,843 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,005 | 2,985 |   20 |   0 |     0 |       0 |
| no-float                         | 2,738 | 2,641 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,954 | 2,921 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,005 | 2,994 |   11 |   0 |     0 |       0 |

bintest passes on every build. The new tests check that a `def` in a `class_exec`, `module_exec` or `instance_exec` block, and one in a block made inside it, is a method of the receiver and not of `Object`, and that a `private` written in a `class_exec` block hides the `def` after it and reaches no further than the block. On master both fail with `Expected false to be true` where they check that `Object` did not receive the method; the check on the receiver passes there too, since a method of `Object` answers for every object.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/vm.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/vm.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/swift-whistling-river=." -ffile-prefix-map="build/pr2=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `class_exec` and `module_exec` so methods defined within execution blocks are added to the intended class or module, including nested blocks.
  - Fixed `instance_exec` so methods defined in its block are added to the receiver’s singleton class rather than to `Object`.
  - Ensured visibility changes made during an execution block remain scoped to that block and reset afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->