### PR TITLE
class.c: let a `private` in a `class << self` body reach the defs below it

### DIFF
--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -626,16 +626,19 @@ assert('Module#define_method - the visibility it takes from the scope') do
   assert_equal [:prot], c.protected_instance_methods(false)
   assert_equal [:from_cm, :pub], c.public_instance_methods(false).sort
 
-  # a singleton class takes no visibility from its body, as a `def` there does not
+  # the body of a `class << self` is a body too, and a `def self.x` there
+  # is public whatever it says
   s = Class.new do
     class << self
       private
       define_method(:sm) {}
       def sd; end
+      def self.sx; end
     end
   end
-  assert_equal [:sd, :sm], s.singleton_methods(false).sort
-  assert_equal [], s.singleton_class.private_instance_methods(false)
+  assert_equal [], s.singleton_methods(false)
+  assert_equal [:sd, :sm], s.singleton_class.private_instance_methods(false).sort
+  assert_equal [:sx], s.singleton_class.singleton_methods(false)
 
   # module_function scope: the instance method is private, the module one public
   mod = Module.new do
@@ -662,14 +665,15 @@ assert('Module#attr_* - the visibility they take from the scope') do
   assert_equal [:w=], c.protected_instance_methods(false)
   assert_equal [:from_cm, :p], c.public_instance_methods(false).sort
 
-  # a singleton class takes no visibility from its body
+  # the body of a `class << self` is a body too
   s = Class.new do
     class << self
       private
       attr_reader :sr
     end
   end
-  assert_equal [:sr], s.singleton_methods(false)
+  assert_equal [], s.singleton_methods(false)
+  assert_equal [:sr], s.singleton_class.private_instance_methods(false)
 
   # module_function scope: private, with no module method copy
   mod = Module.new do

--- a/src/class.c
+++ b/src/class.c
@@ -993,8 +993,8 @@ find_visibility_scope(mrb_state *mrb, const struct RClass *c, int n, mrb_callinf
    that body would; a call on another class, or from inside a method, makes
    a public method.  The receiver has to be both the self and the class of
    that frame, the way CRuby's `rb_vm_cref_in_context()` answers for
-   `define_method` and `rb_attr()`.  A singleton class takes no visibility
-   from its body here either. */
+   `define_method` and `rb_attr()`.  The body of a `class << self` is such
+   a body for its singleton class. */
 static int
 caller_scope_visibility(mrb_state *mrb, struct RClass *c, mrb_bool *modfunc)
 {
@@ -1002,10 +1002,10 @@ caller_scope_visibility(mrb_state *mrb, struct RClass *c, mrb_bool *modfunc)
   mrb_callinfo *ci = ec->ci - 1;
 
   *modfunc = FALSE;
-  if (ci < ec->cibase || c->tt == MRB_TT_SCLASS) return MRB_METHOD_PUBLIC_FL;
+  if (ci < ec->cibase) return MRB_METHOD_PUBLIC_FL;
   if (mrb_vm_ci_target_class(ci) != c) return MRB_METHOD_PUBLIC_FL;
   mrb_value self = ci->stack[0];
-  if (!(mrb_class_p(self) || mrb_module_p(self)) || mrb_class_ptr(self) != c) {
+  if (!(mrb_class_p(self) || mrb_module_p(self) || mrb_sclass_p(self)) || mrb_class_ptr(self) != c) {
     return MRB_METHOD_PUBLIC_FL;
   }
 
@@ -1215,18 +1215,17 @@ mrb_define_method_raw(mrb_state *mrb, struct RClass *c, mrb_sym mid, mrb_method_
     MRB_SET_VISIBILITY_FLAGS(flags, MRB_METHOD_PRIVATE_FL);
   }
   else if ((flags & MT_VMASK) == MT_VDEFAULT) {
-    /* singleton methods are always public */
-    if (c->tt == MRB_TT_SCLASS) {
-      MRB_SET_VISIBILITY_FLAGS(flags, MRB_METHOD_PUBLIC_FL);
-    }
-    else {
-      mrb_callinfo *ci;
-      struct REnv *e;
-      find_visibility_scope(mrb, c, 0, &ci, &e);
-      mrb_assert(ci || e);
-      MRB_SET_VISIBILITY_FLAGS(flags, (uint32_t)(e ? MRB_ENV_VISIBILITY(e) : MRB_CI_VISIBILITY(ci)) << 25);
-      modfunc = e ? MRB_ENV_MODFUNC_P(e) : MRB_CI_MODFUNC_P(ci);
-    }
+    /* The visibility written in the scope the `def` stands in.  The body of
+       a `class << self` is such a scope too: a `private` written there
+       reaches the `def`s below it, the way CRuby's cref for that body does.
+       Only a `def self.x` is public whatever the scope says, and the VM
+       passes that as an explicit visibility instead of the default. */
+    mrb_callinfo *ci;
+    struct REnv *e;
+    find_visibility_scope(mrb, c, 0, &ci, &e);
+    mrb_assert(ci || e);
+    MRB_SET_VISIBILITY_FLAGS(flags, (uint32_t)(e ? MRB_ENV_VISIBILITY(e) : MRB_CI_VISIBILITY(ci)) << 25);
+    modfunc = e ? MRB_ENV_MODFUNC_P(e) : MRB_CI_MODFUNC_P(ci);
   }
   mt_put(mrb, h, mid, flags, ptr);
   if (!mrb->bootstrapping) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -2999,8 +2999,13 @@ vm_op_div(mrb_state *mrb, uint32_t a, mrb_sym *midp)
   return VM_NEXT;
 }
 
+/* `vis` is the visibility the method takes: the default, which is what the
+   scope it is written in says, or public for a singleton definition.  A
+   `def self.x` in a `private` section, or in the body of a `class << self`,
+   is public as CRuby makes it, while a plain `def` in a `class << self`
+   body takes the visibility written there like any other body's `def`. */
 static mrb_sym
-vm_define_method(mrb_state *mrb, struct RClass *tc, const mrb_irep *irep, uint16_t b, uint16_t c)
+vm_define_method(mrb_state *mrb, struct RClass *tc, const mrb_irep *irep, uint16_t b, uint16_t c, uint32_t vis)
 {
   struct RProc *p = mrb_proc_new(mrb, irep->reps[c]);
   mrb_sym mid = irep->syms[b];
@@ -3008,7 +3013,7 @@ vm_define_method(mrb_state *mrb, struct RClass *tc, const mrb_irep *irep, uint16
 
   p->flags |= MRB_PROC_SCOPE | MRB_PROC_STRICT | MRB_PROC_CREF;
   MRB_METHOD_FROM_PROC(m, p);
-  MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_VDEFAULT_FL);
+  MRB_METHOD_SET_VISIBILITY(m, vis);
   mrb_define_method_raw(mrb, tc, mid, m);
   mrb_method_added(mrb, tc, mid);
   return mid;
@@ -4713,7 +4718,7 @@ RETRY_TRY_BLOCK:
     CASE(OP_TDEF, BBB) {
       struct RClass *tc = check_target_class(mrb);
       if (mrb_unlikely(!tc)) goto L_RAISE;
-      mid = vm_define_method(mrb, tc, irep, b, c);
+      mid = vm_define_method(mrb, tc, irep, b, c, MRB_METHOD_VDEFAULT_FL);
       ci = mrb->c->ci;
       mrb_gc_arena_restore(mrb, ai);
       regs[a] = mrb_symbol_value(mid);
@@ -4722,7 +4727,7 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_SDEF, BBB) {
       struct RClass *tc = mrb_class_ptr(mrb_singleton_class(mrb, regs[a]));
-      mid = vm_define_method(mrb, tc, irep, b, c);
+      mid = vm_define_method(mrb, tc, irep, b, c, MRB_METHOD_PUBLIC_FL);
       ci = mrb->c->ci;
       mrb_gc_arena_restore(mrb, ai);
       regs[a] = mrb_symbol_value(mid);

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -696,6 +696,114 @@ assert('Module#define_method takes the visibility of the scope it is called in')
   assert_raise(NoMethodError) { klass.new.mf }
 end
 
+assert('a `private` in the body of a `class << self` reaches the defs below it') do
+  c = Class.new {
+    class << self
+      def call_priv; priv; end
+      def call_prot; self.prot; end
+      def call_dm; dm; end
+      def call_attr; self.a = 1; a; end
+      private
+      def priv; :priv; end
+      define_method(:dm) { :dm }
+      attr_accessor :a
+      def self.on_sclass; :on_sclass; end
+      protected
+      def prot; :prot; end
+    end
+  }
+  assert_equal :priv, c.call_priv
+  assert_equal :prot, c.call_prot
+  assert_equal :dm, c.call_dm
+  assert_equal 1, c.call_attr
+  assert_raise(NoMethodError) { c.priv }
+  assert_raise(NoMethodError) { c.prot }
+  assert_raise(NoMethodError) { c.dm }
+  assert_raise(NoMethodError) { c.a }
+  assert_raise(NoMethodError) { c.a = 2 }
+  assert_false c.respond_to?(:priv)
+  assert_false c.respond_to?(:prot)
+  assert_true c.respond_to?(:priv, true)
+  assert_true c.respond_to?(:call_priv)
+  # a `def self.x` is public wherever it is written
+  assert_equal :on_sclass, (class << c; self; end).on_sclass
+
+  # so is a `def obj.x`, in a `private` section of a class body or of the
+  # object's own singleton class body
+  o = Object.new
+  c2 = Class.new {
+    private
+    def self.cm; :cm; end
+    def o.om; :om; end
+  }
+  class << o
+    private
+    def sing; :sing; end
+    def self.om2; :om2; end
+  end
+  assert_equal :cm, c2.cm
+  assert_equal :om, o.om
+  assert_equal :om2, (class << o; self; end).om2
+  assert_raise(NoMethodError) { o.sing }
+  assert_equal :sing, o.__send__(:sing)
+
+  # the singleton class body of a module, and the same body reached through
+  # `class_eval`
+  m = Module.new
+  class << m
+    private
+    def mp; :mp; end
+  end
+  assert_raise(NoMethodError) { m.mp }
+  c3 = Class.new
+  (class << c3; self; end).class_eval { private; def ce; :ce; end }
+  assert_raise(NoMethodError) { c3.ce }
+  assert_equal :ce, c3.__send__(:ce)
+
+  # a block written in the body is still that body
+  c4 = Class.new {
+    class << self
+      def call_blk; blk; end
+      private
+      [1].each { def blk; :blk; end }
+    end
+  }
+  assert_equal :blk, c4.call_blk
+  assert_raise(NoMethodError) { c4.blk }
+
+  # the body is a scope of its own: it starts public under a `private`
+  # written in the class body, and its `private` stops at its end
+  c5 = Class.new {
+    private
+    class << self
+      def inside; :inside; end
+      private
+      def inner; end
+    end
+    def self.after; :after; end
+    def outer; :outer; end
+  }
+  assert_equal :inside, c5.inside
+  assert_equal :after, c5.after
+  assert_raise(NoMethodError) { c5.new.outer }
+  assert_raise(NoMethodError) { c5.inner }
+
+  # a protected singleton method is reachable from a subclass's singleton
+  # method and from nowhere else
+  c6 = Class.new {
+    class << self
+      def cmp(other); other.prot; end
+      protected
+      def prot; :prot; end
+    end
+  }
+  sub = Class.new(c6)
+  assert_equal :prot, sub.cmp(c6)
+  assert_equal :prot, c6.cmp(sub)
+  assert_raise(NoMethodError) { c6.prot }
+  assert_raise(NoMethodError) { Class.new { def self.cmp(o); o.prot; end }.cmp(c6) }
+end
+
 # @!group prepend
   assert('Module#prepend') do
     module M0


### PR DESCRIPTION
## Summary

A method defined on a singleton class with the default visibility was always public, so a `private` or `protected` written in the body of a `class << self` reached none of the `def`, `define_method` and `attr_*` below it. The body now gives its `def`s the visibility written there, the way any other body does, and only a `def self.x` is public whatever the scope says.

## Changes

| File                                      | What                                                                                                                        |
| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `src/class.c`                             | `mrb_define_method_raw` reads the scope for a singleton class too; `caller_scope_visibility` accepts one as the body's self |
| `src/vm.c`                                | `vm_define_method` takes the visibility: `OP_TDEF` passes the default, `OP_SDEF` passes public                              |
| `test/t/module.rb`                        | `def`, `define_method`, `attr_*`, `protected`, `def self.x`, `def obj.x`, a block, `class_eval`, where the body ends        |
| `mrbgems/mruby-metaprog/test/metaprog.rb` | the two blocks that recorded the old answer now record the new one                                                          |

### Public is a property of the definition form, not of the class

`mrb_define_method_raw` resolved the default visibility by asking the class: a singleton class answered public before the scope was looked at. That rule was there for `def self.x`, which CRuby makes public even under a `private`, but CRuby's `vm_define_method()` decides that on the singleton definition form and leaves the class out of it: a plain `def` in a `class << self` body goes through the cref of that body and takes what is written there, as `def`s in a class body do.

So `OP_SDEF` now hands `mrb_define_method_raw` an explicit public, and the default visibility is read from the scope whatever the class is. The scope walk is the one `private` itself writes to, so a block written in the body, a `class_eval` block on the singleton class and an eval string there all see the body's visibility, and the body's `private` stops at its end as it does for a class body.

`caller_scope_visibility`, which answers for `define_method` and `attr_*`, had the same exclusion and the same reason. It now takes a singleton class as the self of the body it looks at; the condition that the frame's self and class are both the receiver is unchanged, so a call from inside a singleton method still makes a public method.

## Behaviour

```ruby
class C
  class << self
    private
    def m; end
    define_method(:dm) {}
    attr_reader :ar
    def self.on_sclass; end
  end
  private
  def self.cm; end
end
C.m                          # CRuby: NoMethodError, mruby: nil
C.respond_to?(:m)            # CRuby: false, mruby: true
C.dm                         # CRuby: NoMethodError, mruby: nil
C.ar                         # CRuby: NoMethodError, mruby: nil
C.singleton_class.on_sclass  # CRuby: nil, mruby: nil
C.cm                         # CRuby: nil, mruby: nil
```

Out of scope and still different: a `def initialize` in a `class << self` body is forced private in mruby, where CRuby forces `initialize`, `initialize_copy` and `respond_to_missing?` private only on a class that is not a singleton class.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`, gcc 13.3.0.

| Build       | master    | this PR   | delta |
| ----------- | --------- | --------- | ----- |
| full-debug  | 1,998,774 | 1,998,790 | +16   |
| bintest     | 1,402,518 | 1,402,486 | -32   |
| cxx_abi     | 1,434,393 | 1,434,441 | +48   |
| byte-string | 1,363,894 | 1,363,862 | -32   |
| ascii-ctype | 1,386,918 | 1,386,886 | -32   |
| no-float    | 1,328,094 | 1,328,062 | -32   |
| no-bigint   | 1,286,710 | 1,286,678 | -32   |

`full-debug` is `-O0`. The 32 bytes come off `src/class.o`, where the singleton-class branch is gone; `src/vm.o` is unchanged in the C builds, as `vm_define_method` is inlined into both opcodes with the visibility folded, and grows by 64 bytes in `cxx_abi`.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2769  | 2695 | 74   | 0   | 0     | 0       |
| full-debug  | 3017  | 3006 | 11   | 0   | 0     | 0       |
| bintest     | 3017  | 2997 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3017  | 2997 | 20   | 0   | 0     | 0       |
| byte-string | 2929  | 2855 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3001  | 2979 | 22   | 0   | 0     | 0       |
| no-float    | 2750  | 2653 | 97   | 0   | 0     | 0       |
| no-bigint   | 2966  | 2933 | 33   | 0   | 0     | 0       |

`bintest` runs the command binary tests as well: 147 total, 146 OK, 1 skip, 0 KO.

The new `test/t/module.rb` block writes `private` and `protected` in a `class << self` body in front of `def`, `define_method` and `attr_accessor`, calls each with and without a receiver and reads it through `respond_to?`, checks that `def self.x` in that body and `def self.x` and `def obj.x` under a class-level `private` stay public, that a `def` in a block written in the body is private, that the body of a module's singleton class and the same body reached through `class_eval` behave alike, that a body opened under a class-level `private` starts public and its own `private` stops at its end, and that a protected singleton method is reachable from a subclass's singleton method and from nowhere else. The two `mruby-metaprog` blocks read the definitions back through `private_instance_methods`, `singleton_methods` and the singleton class's own `singleton_methods`.

The cases in the Behaviour section and their variants, 45 in all, were run against CRuby 4.0.6 as well; every answer is the same, apart from the `initialize` difference named above.

## Environment

<details>

| Item     | Value                                              |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                 |
| Kernel   | Linux 7.0.0-31-generic x86_64                      |
| CPU      | AMD Ryzen 9 5950X 16-Core                          |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)        |
| binutils | GNU ld 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, taken with `touch src/class.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped.

```console
host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/class.c

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/class.c

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/class.c
```

`cxx_abi` compiles with `gcc -x c++ -std=gnu++03`; `g++` only links.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected method visibility handling within singleton-class bodies.
  * `private` and `protected` declarations now correctly apply to methods, dynamically defined methods, and attribute accessors in these scopes.
  * Explicit singleton methods defined with `def self.method` or on an object remain public as expected.
  * Improved consistency across class evaluation, module singleton classes, blocks, and inherited protected methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->