### PR TITLE
kernel.c: leave an undefined respond_to_missing? unasked

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -644,8 +644,10 @@ obj_respond_to_p(mrb_state *mrb, mrb_value self, mrb_sym id, mrb_bool priv)
       return TRUE;
     }
   }
+  /* An entry `undef_method` left behind is not a redefinition: it stops the
+     lookup without standing for one, so it is not asked, as in CRuby. */
   mrb_sym rtm_id = MRB_SYM_Q(respond_to_missing);
-  if (!mrb_func_basic_p(mrb, self, rtm_id, mrb_false)) {
+  if (!mrb_func_basic_p(mrb, self, rtm_id, mrb_false) && mrb_respond_to(mrb, self, rtm_id)) {
     mrb_value v = mrb_funcall_argv2(mrb, self, rtm_id, mrb_symbol_value(id), mrb_bool_value(priv));
     return mrb_bool(v);
   }
@@ -743,7 +745,7 @@ mrb_f_defined_method(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "n", &sym);
   mrb_sym rt_id = MRB_SYM_Q(respond_to);
   mrb_bool found;
-  if (mrb_func_basic_p(mrb, self, rt_id, obj_respond_to)) {
+  if (mrb_func_basic_p(mrb, self, rt_id, obj_respond_to) || !mrb_respond_to(mrb, self, rt_id)) {
     found = obj_respond_to_p(mrb, self, sym, TRUE);
   }
   else {
@@ -878,7 +880,7 @@ mrb_f_defined_method_on(mrb_state *mrb, mrb_value self)
   mrb_method_t m = mrb_method_search_vm(mrb, &c, sym);
   if (MRB_METHOD_UNDEF_P(m)) {
     mrb_sym rtm_id = MRB_SYM_Q(respond_to_missing);
-    if (!mrb_func_basic_p(mrb, recv, rtm_id, mrb_false)) {
+    if (!mrb_func_basic_p(mrb, recv, rtm_id, mrb_false) && mrb_respond_to(mrb, recv, rtm_id)) {
       mrb_value v = mrb_funcall_argv2(mrb, recv, rtm_id,
                                       mrb_symbol_value(sym), mrb_false_value());
       if (mrb_test(v)) return mrb_str_new_lit_frozen(mrb, "method");

--- a/test/t/kernel.rb
+++ b/test/t/kernel.rb
@@ -578,6 +578,40 @@ assert('Kernel#respond_to? leaves a method out of reach to respond_to_missing?')
   assert_nil reached.asked
 end
 
+class RespondToMissingUndefined
+  def pub; end
+  private def priv; end
+  undef_method :respond_to_missing?
+end
+
+class RespondToMissingClaims
+  def respond_to_missing?(name, include_private = false)
+    true
+  end
+end
+
+class RespondToMissingStopped < RespondToMissingClaims
+  undef_method :respond_to_missing?
+end
+
+assert('Kernel#respond_to? answers false where respond_to_missing? is undefined') do
+  obj = RespondToMissingUndefined.new
+  # a name with no method behind it is false at either visibility asked for,
+  # rather than an error about `respond_to_missing?` itself
+  assert_false obj.respond_to?(:no_such_method)
+  assert_false obj.respond_to?(:no_such_method, true)
+
+  # the methods that are there answer as before
+  assert_true obj.respond_to?(:pub)
+  assert_false obj.respond_to?(:priv)
+  assert_true obj.respond_to?(:priv, true)
+
+  # the undefinition stops the lookup, so a superclass that would have
+  # claimed the name is not asked either
+  assert_true RespondToMissingClaims.new.respond_to?(:no_such_method)
+  assert_false RespondToMissingStopped.new.respond_to?(:no_such_method)
+end
+
 assert('an unimplemented method can be overridden, aliased and undefined') do
   overridden = Class.new(TestNotImplement) do
     def gone

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -2030,6 +2030,43 @@ assert('defined? asks respond_to? about a call on self') do
   assert_nil defined?(TestNotImplement.gone)
 end
 
+class DefinedBareCallNoMissing
+  undef_method :respond_to_missing?
+  def bare_none; defined?(no_such_method_at_all); end
+end
+
+class DefinedBareCallNoRespondTo
+  undef_method :respond_to?
+  def bare_none; defined?(no_such_method_at_all); end
+  def bare_self; defined?(bare_self); end
+end
+
+class DefinedBareCallRaises
+  def respond_to_missing?(name, include_private = false)
+    raise 'defined? let respond_to_missing? raise'
+  end
+  def bare_none; defined?(no_such_method_at_all); end
+end
+
+assert('defined? on self answers nil where respond_to_missing? or respond_to? is undefined') do
+  # a name with no method behind it is nil, not an error about the hook
+  # that has been undefined; the same asked with a receiver is nil as well
+  o = DefinedBareCallNoMissing.new
+  assert_nil o.bare_none
+  assert_nil defined?(o.no_such_method_at_all)
+
+  # an undefined `respond_to?` is not a redefinition either, so the answer
+  # is the one `respond_to?` would give
+  o = DefinedBareCallNoRespondTo.new
+  assert_nil o.bare_none
+  assert_equal 'method', o.bare_self
+  assert_nil defined?(o.no_such_method_at_all)
+
+  # what a `respond_to_missing?` the object defines raises is not caught
+  # for a call on self, which is why an undefined one has to be told apart
+  assert_raise(RuntimeError) { DefinedBareCallRaises.new.bare_none }
+end
+
 assert('defined? answers nil where evaluating a receiver raises') do
   assert_nil defined?(DefinedRecvRaises.boom.anything)
   assert_equal :caught, (defined?(DefinedRecvRaises.boom.x) ? :answered : :caught)


### PR DESCRIPTION
## Summary

`respond_to?` raises `NoMethodError` about `respond_to_missing?` itself once that hook has been undefined with `undef_method`, and `defined?` on a call written without a receiver does the same for an undefined `respond_to?` or `respond_to_missing?`. CRuby answers `false` and `nil` there. This PR answers the same way.

## Changes

| File               | What                                                                                                                                      |
| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `src/kernel.c`     | An entry `undef_method` left behind for `respond_to_missing?` or `respond_to?` is no longer taken for a redefinition, so it is not called |
| `test/t/kernel.rb` | `Kernel#respond_to?` with `respond_to_missing?` undefined, in the class and in a subclass of one that defines it                          |
| `test/t/syntax.rb` | `defined?` on self with `respond_to_missing?` or `respond_to?` undefined, and the receiver form beside it                                 |

### Why the test was wrong

`obj_respond_to_p()` decides whether to call `respond_to_missing?` with `mrb_func_basic_p()`, which answers `false` both for a redefined method and for an undefined one, since an entry `undef_method` leaves behind is not the C function asked about. The call then goes to a method that is not there. `mrb_f_defined_method()` uses the same test on `respond_to?`, and `mrb_f_defined_method_on()` on `respond_to_missing?`.

CRuby's `vm_respond_to()` and `basic_obj_respond_to_missing()` look the method entry up and treat a missing entry the same as the basic one: nothing to ask. The three places now also ask `mrb_respond_to()` whether the hook is there, and only where `mrb_func_basic_p()` said it is not mruby's own, so the usual path costs nothing more.

### What is left alone

`mrb_func_basic_p()` itself keeps its meaning. The other hooks it guards, `inherited`, `included`, `prepended`, `extended`, `method_added`, `initialize_copy`, `Hash#default` and `method_missing`, raise `NoMethodError` in CRuby too when undefined, so those callers are right as they are.

## Behaviour

```ruby
class A; undef_method :respond_to_missing?; end
A.new.respond_to?(:x)                  # CRuby: false, mruby: NoMethodError
A.new.respond_to?(:x, true)            # CRuby: false, mruby: NoMethodError
A.new.instance_eval { defined?(x) }    # CRuby: nil,   mruby: NoMethodError

class B; undef_method :respond_to?; end
B.new.instance_eval { defined?(x) }    # CRuby: nil,   mruby: NoMethodError
```

`defined?(A.new.x)` with a receiver written was already `nil`, because that form folds what the receiver's evaluation raises into `nil`. The self form does not, which is what made the difference visible. A `respond_to_missing?` that raises still propagates from `respond_to?` and from the self form, as in CRuby.

## Size

`bin/mruby` `.text`, `size -A`, `MRUBY_CONFIG=ci/gcc-clang` with gcc. master is edd066a5a.

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 1,998,774 | 1,998,854 |   +80 |
| bintest          | 1,402,518 | 1,402,566 |   +48 |
| cxx_abi          | 1,434,393 | 1,434,457 |   +64 |
| byte-string      | 1,363,894 | 1,363,942 |   +48 |
| ascii-ctype      | 1,386,918 | 1,386,966 |   +48 |
| no-float         | 1,328,094 | 1,328,206 |  +112 |
| no-bigint        | 1,286,710 | 1,286,758 |   +48 |

The whole delta is `src/kernel.o`, the extra call and branch at each of the three places.

## Testing

| Build       | Total |    OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ----: | ---: | --: | ----: | ------: |
| host        | 2,770 | 2,696 |   74 |   0 |     0 |       0 |
| full-debug  | 3,018 | 3,007 |   11 |   0 |     0 |       0 |
| bintest     | 3,018 | 2,998 |   20 |   0 |     0 |       0 |
| cxx_abi     | 3,018 | 2,998 |   20 |   0 |     0 |       0 |
| byte-string | 2,930 | 2,856 |   74 |   0 |     0 |       0 |
| ascii-ctype | 3,002 | 2,980 |   22 |   0 |     0 |       0 |
| no-float    | 2,751 | 2,654 |   97 |   0 |     0 |       0 |
| no-bigint   | 2,967 | 2,934 |   33 |   0 |     0 |       0 |

bintest on the bintest build: 147 total, 146 OK, 1 Skip, 0 KO.

The new tests pin the four answers above, that the methods an object does have keep answering as before at both visibilities, that an undefinition in a subclass also stops a superclass's `respond_to_missing?` from being asked, and that a `respond_to_missing?` which raises is still not caught for the self form of `defined?`. Every expected value was checked against CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                 |
| Kernel   | Linux 7.0.0-31-generic x86_64                      |
| CPU      | AMD Ryzen 9 5950X                                  |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| binutils | GNU ld 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines for `src/kernel.c`, taken from `rake --verbose` with `-MMD -c`, `-I` and `-o` dropped.

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/kernel.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/kernel.c
```

The `-ffile-prefix-map` options are dropped as well. cxx_abi links with g++.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `respond_to?` so methods undefined with `undef_method` are no longer incorrectly treated as available through `respond_to_missing?`.
  - Fixed method-existence checks to return accurate results when response hooks are undefined.
  - Improved `defined?` behavior for missing methods, including cases where response hooks are removed or raise errors.
  - Existing methods continue to report their availability and visibility correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->