### PR TITLE
array.c: document what the comparison block of sort and its kin is to return

### DIFF
--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -374,8 +374,9 @@ module Enumerable
   #
   #  Returns two elements array which contains the minimum and the
   #  maximum value in the enumerable. The first form assumes all
-  #  objects implement `Comparable`; the second uses the
-  #  block to return <em>a <=> b</em>.
+  #  objects implement `Comparable`; the second orders each pair
+  #  of elements by the block, read as the block of `Array#sort!`
+  #  is, which states what the block is to return.
   #
   #     a = %w(albatross dog horse)
   #     a.minmax                                  #=> ["albatross", "horse"]

--- a/mrblib/array.rb
+++ b/mrblib/array.rb
@@ -84,6 +84,9 @@ class Array
   #   array.sort {|a, b| ... } -> new_array
   #
   # Returns a new Array whose elements are those from `self`, sorted.
+  #
+  # With a block, the block orders each pair of elements as it does for
+  # `Array#sort!`, which states what the block is to return.
   def sort(&block)
     self.dup.sort!(&block)
   end

--- a/mrblib/enum.rb
+++ b/mrblib/enum.rb
@@ -220,7 +220,9 @@ module Enumerable
   # Return the maximum value of all elements
   # yield by `each`. If no block is given <=>
   # will be invoked to define this value. If
-  # a block is given it will be used instead.
+  # a block is given it will be used instead,
+  # read as the block of `Array#sort!` is,
+  # which states what the block is to return.
   #
   # ISO 15.3.2.2.13
   def max(&block)
@@ -264,7 +266,9 @@ module Enumerable
   # Return the minimum value of all elements
   # yield by `each`. If no block is given <=>
   # will be invoked to define this value. If
-  # a block is given it will be used instead.
+  # a block is given it will be used instead,
+  # read as the block of `Array#sort!` is,
+  # which states what the block is to return.
   #
   # ISO 15.3.2.2.14
   def min(&block)
@@ -360,7 +364,9 @@ module Enumerable
   # is given <=> will be invoked on each
   # element to define the order. Otherwise
   # the given block will be used for
-  # sorting.
+  # sorting, as it is by `Array#sort!`,
+  # which states what the block is to
+  # return.
   #
   # ISO 15.3.2.2.19
   def sort(&block)

--- a/src/array.c
+++ b/src/array.c
@@ -2502,6 +2502,25 @@ insertion_sort(mrb_state *mrb, mrb_value ary, mrb_value *a, mrb_int size, mrb_va
  *
  *  Sort all elements and replace `self` with these
  *  elements.
+ *
+ *  With no block, each pair of elements is ordered by `<=>`, and a pair
+ *  that `<=>` cannot order raises `ArgumentError`.
+ *
+ *  With a block, the block is called with two elements and its answer
+ *  orders them: negative when `a` is to come before `b`, zero when the
+ *  two are tied, positive when `a` is to come after `b`. An Integer is
+ *  read for its sign. `nil` means the pair has no order and raises
+ *  `ArgumentError`. Any other object is asked `> 0` and then `< 0`, and
+ *  is a tie when neither holds.
+ *
+ *  `Array#sort`, `Enumerable#sort`, `Enumerable#max`, `Enumerable#min`
+ *  and `Enumerable#minmax` read their block the same way. Each asks only
+ *  the operator it needs, so an object that answers one of `>` and `<`
+ *  but not the other is outside the contract and may pass one of these
+ *  methods and raise in another.
+ *
+ *     [3, 1, 2].sort!                    #=> [1, 2, 3]
+ *     [3, 1, 2].sort! {|a, b| b <=> a }  #=> [3, 2, 1]
  */
 static mrb_value
 mrb_ary_sort_bang(mrb_state *mrb, mrb_value ary)


### PR DESCRIPTION
## Summary

`Array#sort`, `Array#sort!` and `Enumerable#sort` take a comparison block and none of their rdoc says what the block is to return; `Enumerable#max`, `#min` and `#minmax` say only that the block stands in for `<=>`. This writes the contract out once, on `Array#sort!`, and points the other five at it.

## Changes

| File                                    | What                                                                                                                                   |
| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
| `src/array.c`                           | `Array#sort!`: state the no-block case and the full reading of a block's answer, name the five methods that share it, add two examples |
| `mrblib/array.rb`                       | `Array#sort`: point at `Array#sort!` for the block                                                                                     |
| `mrblib/enum.rb`                        | `Enumerable#sort`, `#max`, `#min`: same pointer                                                                                        |
| `mrbgems/mruby-enum-ext/mrblib/enum.rb` | `Enumerable#minmax`: same pointer, in place of "uses the block to return a <=> b"                                                      |

### What is written

The answer of the block is read the same way by all six methods: negative when `a` is to come before `b`, zero when the two are tied, positive when `a` is to come after `b`. An Integer is read for its sign, `nil` means the pair has no order and raises `ArgumentError`, and any other object is asked `> 0` and then `< 0` and is a tie when neither holds. That is what `cmpint()` in `src/array.c` does, and what the `cmp > 0` / `cmp < 0` tests in `Enumerable#max`, `#min` and `#minmax` do with the same answers.

CRuby's rdoc for `Array#sort` gives only the numeric form of this, while its `rb_cmpint()` takes an object that merely answers `>` and `<`. The paragraph here states the whole map, since both engines implement it and a reader of the doc otherwise has no way to know a non-Integer answer is accepted.

### Where it lives

`Array#sort!` holds the implementation, so the map is written out there and the other five carry a one-line pointer rather than a copy each that can drift.

## Testing

Every arm of the paragraph was run against `bin/mruby` and CRuby 4.0 and answered the same in both: an Integer answer, a Bignum answer, a Float answer, an object that only defines `>` and `<`, a `nil` answer under `sort`, `max`, `min` and `minmax`, and an `Enumerable` receiver that is not an Array.

| Build | Total |   OK | Skip |  KO | Crash | Warning |
| ----- | ----: | ---: | ---: | --: | ----: | ------: |
| host  |  2768 | 2694 |   74 |   0 |     0 |       0 |

No code changes; the doc-only diff was checked with `SKIP=markdownlint,actionlint prek run --all-files`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified comparison and ordering behavior for array sorting methods.
  * Documented how comparison blocks are interpreted, including return values and unorderable elements.
  * Clarified that Enumerable methods such as `min`, `max`, `minmax`, and `sort` use comparison blocks consistently with array sorting.
  * Added examples illustrating sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->