### PR TITLE
internal.h: say that the unicode case walk raises

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -579,7 +579,14 @@ enum mrb_case_mode {
    or empty. A caller takes -1 as "the ASCII loop I have is the whole answer",
    which is what every build without the tables answers to every string.
    `swapcase` lives in mruby-string-ext and reaches the tables through this, so
-   they are asked about in one place. */
+   they are asked about in one place.
+   The walk raises rather than answering in two cases: `ArgumentError` for a
+   run of bytes that spells no character, which is what CRuby answers for the
+   same input, and `FrozenError` for a frozen receiver it would convert, raised
+   before anything is read. A string it answers -1 for is not looked at for
+   freezing: the caller's own loop is the one that writes it, and the one that
+   refuses it. A refused conversion leaves the receiver as it was: the answer
+   is built beside the string and taken only at the end. */
 #if defined(MRB_UTF8_STRING) && !defined(MRB_USE_ASCII_CTYPE)
 int mrb_str_case_convert_unicode(mrb_state *mrb, mrb_value str, enum mrb_case_mode mode);
 #else


### PR DESCRIPTION
## Summary

The declaration comment on `mrb_str_case_convert_unicode()` in `include/mruby/internal.h` describes its three return values and nothing else, so it reads as a function that always answers. It has two ways not to, both deliberate and both tested, and one caller outside core already depends on one of them. This adds the two exceptions and the condition for each to the comment. Comment only.

## Changes

| File                       | What                                                                                                                                                                                                                                       |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `include/mruby/internal.h` | two sentences on the end of the comment on `mrb_str_case_convert_unicode()`: `ArgumentError` for a run of bytes that spells no character, `FrozenError` for a frozen receiver, and that a refused conversion leaves the receiver as it was |

### Why the declaration should say it

Both raises live in `src/string.c`: `str_case_convert_utf8()` raises `ArgumentError` with `input string invalid` when `mrb_utf8_decode()` answers a single byte for a lead byte above ASCII, which is what CRuby raises for the same input, and `mrb_str_case_convert_unicode()` runs `mrb_check_frozen()` before the walk reads anything. Neither was written where a caller looks.

The `ArgumentError` is the one a caller already leans on. `str_casecmp_p()` in mruby-string-ext calls the walk on two copies and never checks for broken input itself; the `ArgumentError` that `"\xC3ABC".casecmp?("a")` raises comes entirely from here, and the gem's README documents it as `casecmp?` behaviour. A future caller reading only the comment would have no reason to expect it.

The last sentence records a property of the implementation that is what makes the bang forms safe to call on input that might be broken: the answer is built beside the string and taken only at the end, so a receiver whose conversion was refused still holds what it held.

```ruby
s = "\xC3ABC"; s.upcase! rescue nil; s   # CRuby: "\xC3ABC", mruby: "\xC3ABC"
```

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2768  | 2694 | 74   | 0   | 0     | 0       |
| full-debug  | 3016  | 3005 | 11   | 0   | 0     | 0       |
| bintest     | 3016  | 2996 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3016  | 2996 | 20   | 0   | 0     | 0       |
| byte-string | 2928  | 2854 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3000  | 2978 | 22   | 0   | 0     | 0       |
| no-float    | 2749  | 2652 | 97   | 0   | 0     | 0       |
| no-bigint   | 2965  | 2932 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 1 skip, 0 KO. The header compiles as before in every build; nothing in the diff is outside a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified error behavior for Unicode case conversion, including when frozen strings raise `FrozenError` and invalid byte sequences raise `ArgumentError`.
  - Documented that conversions returning `-1` do not check whether the string is frozen.
  - Documented that refused or failed conversions leave the original string unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->