### PR TITLE
proc.c: let a `def` in a method written in a given block add to that class

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -663,6 +663,7 @@ mrb_value mrb_const_get_noraise(mrb_state *mrb, struct RClass *mod, mrb_sym sym)
 mrb_bool mrb_vm_cv_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sym sym);
 struct RClass *mrb_vm_cref_class(mrb_state *mrb, mrb_callinfo *ci);
 struct RClass *mrb_vm_definee_class(mrb_state *mrb, mrb_callinfo *ci);
+struct RProc *mrb_method_proc_new(mrb_state *mrb, const mrb_irep *irep);
 mrb_bool mrb_gv_defined(mrb_state *mrb, mrb_sym sym);
 #ifdef MRUBY_VARIABLE_H
 void mrb_gv_foreach(mrb_state *mrb, mrb_iv_foreach_func *func, void *p);

--- a/include/mruby/proc.h
+++ b/include/mruby/proc.h
@@ -151,14 +151,25 @@ struct RProc {
    it. */
 #define MRB_PROC_CREF 16384
 #define MRB_PROC_CREF_P(p) (((p)->flags & MRB_PROC_CREF) != 0)
+/* A method body written in a block that was given the class to run under:
+   a `Class.new`, `class_eval` or `instance_eval` block.  The class the proc
+   carries is the given one, where a `def` in the body adds, and not its
+   cref: the cref is the scope the block was written in, and a walk up the
+   `upper` chain looking for the cref, or for the scopes a constant or a
+   class variable is read from, passes over the proc as if it were a block.
+   The bit is an aspec bit on a cfunc proc, and a walk that reads it may
+   pass through one, so the test answers no for a cfunc proc. */
+#define MRB_PROC_GIVEN 32768
+#define MRB_PROC_GIVEN_P(p) (((p)->flags & (MRB_PROC_GIVEN | MRB_PROC_CFUNC_FL)) == MRB_PROC_GIVEN)
 #define MRB_PROC_ALIAS_P(p) (((p)->flags & MRB_PROC_ALIAS) != 0)
 
 /* Compressed aspec for cfunc procs (13 bits in RProc.flags).
- * Uses bits 0-6 and 14-19 to store a compressed argument spec.  Bit 14 is
- * also MRB_PROC_CREF; the two never meet, because only mrb_proc_new() makes
- * a proc that can be a scope and only mrb_proc_new_cfunc() makes one that
- * carries an aspec.  A walk that reads MRB_PROC_CREF off the `upper` chain
- * says so by stopping at MRB_PROC_CFUNC_P().
+ * Uses bits 0-6 and 14-19 to store a compressed argument spec.  Bits 14 and
+ * 15 are also MRB_PROC_CREF and MRB_PROC_GIVEN; the two never meet, because
+ * only mrb_proc_new() makes a proc that can be a scope and only
+ * mrb_proc_new_cfunc() makes one that carries an aspec.  A walk that reads
+ * MRB_PROC_CREF off the `upper` chain says so by stopping at
+ * MRB_PROC_CFUNC_P(), and MRB_PROC_GIVEN_P() tests for a cfunc proc itself.
  * Layout: block(0) kdict(1) key(2-3) post(4-5) rest(6) opt(14-16) req(17-19)
  * Field widths are smaller than the full 24-bit aspec: req/opt max 7, post/key max 3.
  * Values exceeding the compressed range are clamped and rest is forced to 1. */

--- a/mrbgems/mruby-class-ext/test/module.rb
+++ b/mrbgems/mruby-class-ext/test/module.rb
@@ -169,3 +169,29 @@ assert('a `def` in a block given to class_exec or module_exec adds to the receiv
   assert_true c.new.respond_to?(:hidden, true)
   assert_true c.new.respond_to?(:shown)
 end
+
+module ExecGivenMethodMaker
+  # Run in a method, for the same reason as above.
+  def self.on_class(c); c.class_exec { def direct; def from_direct; end; end; def in_block; [1].each { def from_block; end }; end }; end
+  def self.on_module(m); m.module_exec { def direct; def from_direct; end; end }; end
+end
+
+assert('a `def` in a method written in a block given to class_exec or module_exec adds to the receiver') do
+  # The method carries the class the block was given, not the cref of the
+  # block, so a `def` in its body, or in a block made there, adds to the
+  # receiver as the `def` written in the block does.
+  c = Class.new
+  ExecGivenMethodMaker.on_class(c)
+  c.new.direct
+  c.new.in_block
+  assert_true c.new.respond_to?(:from_direct)
+  assert_true c.new.respond_to?(:from_block)
+  assert_false Object.new.respond_to?(:from_direct, true)
+  assert_false Object.new.respond_to?(:from_block, true)
+
+  m = Module.new
+  ExecGivenMethodMaker.on_module(m)
+  Class.new { include m }.new.direct
+  assert_true Class.new { include m }.new.respond_to?(:from_direct)
+  assert_false Object.new.respond_to?(:from_direct, true)
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -737,3 +737,27 @@ assert('a string given to eval runs under the class the calling frame runs under
   assert_true Object.const_defined?(:EvalFrameClassConst, false)
   assert_false k.const_defined?(:EvalFrameClassConst, false)
 end
+
+module EvalGivenMethodMaker
+  # Run in a method, so that the block's cref is this module rather than the
+  # class `mrb_proc_new()` falls back to when a block at the top level of a
+  # compiled test file has no cref to answer with.
+  def self.klass
+    Class.new do
+      def in_string; eval("def from_string; end"); end
+      def in_binding; eval("def from_binding; end", binding); end
+    end
+  end
+end
+
+assert('a `def` in a string evaluated in a method written in a block given a class adds to that class') do
+  # The string's frame runs under the class the method was found in, and the
+  # method carries the class its block was given, so the `def` lands where
+  # one written in the method body does.
+  c = EvalGivenMethodMaker.klass
+  c.new.in_string
+  c.new.in_binding
+  assert_equal [:from_binding, :from_string, :in_binding, :in_string], c.instance_methods(false).sort
+  assert_false Object.new.respond_to?(:from_string, true)
+  assert_false Object.new.respond_to?(:from_binding, true)
+end

--- a/mrbgems/mruby-metaprog/src/metaprog.c
+++ b/mrbgems/mruby-metaprog/src/metaprog.c
@@ -680,18 +680,19 @@ mrb_mod_s_constants(mrb_state *mrb, mrb_value mod)
   }
 
   const struct RProc *proc = mrb->c->ci[-1].proc;
-  struct RClass *c = MRB_PROC_TARGET_CLASS(proc);
+  struct RClass *c = NULL;
   mrb_value ary = mrb_ary_new(mrb);
 
-  if (!c) c = mrb->object_class;
-  mrb_mod_const_at(mrb, c, ary);
-  proc = proc->upper;
-  while (proc) {
+  /* A method given its class carries that class for a `def`, not as a scope
+     constants are read from: passed over, wherever it is on the chain. */
+  for (; proc; proc = proc->upper) {
+    if (MRB_PROC_GIVEN_P(proc)) continue;
     struct RClass *c2 = MRB_PROC_TARGET_CLASS(proc);
     if (!c2) c2 = mrb->object_class;
+    if (!c) c = c2;
     mrb_mod_const_at(mrb, c2, ary);
-    proc = proc->upper;
   }
+  if (!c) c = mrb->object_class;
   while (c) {
     mrb_mod_const_at(mrb, c, ary);
     c = c->super;
@@ -710,7 +711,9 @@ mrb_mod_s_nesting(mrb_state *mrb, mrb_value mod)
   ary = mrb_ary_new(mrb);
   proc = mrb->c->ci[-1].proc;   /* callee proc */
   while (proc && !MRB_PROC_CFUNC_P(proc)) {
-    if (MRB_PROC_SCOPE_P(proc)) {
+    /* A method given its class is not in the nesting: CRuby leaves out the
+       cref the giving block pushed. */
+    if (MRB_PROC_SCOPE_P(proc) && !MRB_PROC_GIVEN_P(proc)) {
       struct RClass *c2 = MRB_PROC_TARGET_CLASS(proc);
 
       if (c2 != c) {

--- a/mrbgems/mruby-metaprog/test/metaprog.rb
+++ b/mrbgems/mruby-metaprog/test/metaprog.rb
@@ -710,3 +710,27 @@ assert('Module.nesting from a block given a class to run under') do
   end
   assert_equal([Test4NestingLex], Test4NestingLex.go)
 end
+
+assert('Module.nesting and Module.constants from a method written in a block given a class') do
+  # The class the block was given is where a `def` in the method adds; the
+  # nesting and the constants the method sees are those of the scope the
+  # block was written in, from the method body and from a block in it.
+  class Test4GivenNestingRecv
+    KR = :recv
+  end
+  module Test4GivenNestingLex
+    KL = :lex
+    def self.make
+      Class.new(Test4GivenNestingRecv) do
+        def nesting; Module.nesting; end
+        def nested_nesting; [1].map { Module.nesting }[0]; end
+        def consts; Module.constants; end
+      end
+    end
+  end
+  o = Test4GivenNestingLex.make.new
+  assert_equal([Test4GivenNestingLex], o.nesting)
+  assert_equal([Test4GivenNestingLex], o.nested_nesting)
+  assert_true o.consts.include?(:KL)
+  assert_false o.consts.include?(:KR)
+end

--- a/mrbgems/mruby-object-ext/test/object.rb
+++ b/mrbgems/mruby-object-ext/test/object.rb
@@ -85,3 +85,22 @@ assert('a `def` in a block given to instance_exec adds to the receiver') do
   assert_false Object.new.respond_to?(:from_block, true)
   assert_false Object.new.respond_to?(:from_nested_block, true)
 end
+
+module InstanceExecGivenMethodMaker
+  # Run in a method, for the same reason as above.
+  def self.on(o); o.instance_exec { def direct; def from_direct; end; end; def in_block; [1].each { def from_block; end }; end }; end
+end
+
+assert('a `def` in a method written in a block given to instance_exec adds to the receiver') do
+  # The method carries the singleton class the block was given, not the
+  # cref of the block, so a `def` in its body, or in a block made there,
+  # adds to the receiver as the `def` written in the block does.
+  o = Object.new
+  InstanceExecGivenMethodMaker.on(o)
+  o.direct
+  o.in_block
+  assert_true o.respond_to?(:from_direct)
+  assert_true o.respond_to?(:from_block)
+  assert_false Object.new.respond_to?(:from_direct, true)
+  assert_false Object.new.respond_to?(:from_block, true)
+end

--- a/src/proc.c
+++ b/src/proc.c
@@ -90,8 +90,10 @@ mrb_vm_cref_class(mrb_state *mrb, mrb_callinfo *ci)
    closes over that env and answers with the class it holds, which is how a
    `def` in a block inside the block reaches the same place, and how a string
    evaluated over a binding taken there does.  A scope of its own ends the
-   run: a method written in such a block adds to the given class, but the
-   blocks inside the method body belong to the method and follow its cref. */
+   run: a method written in such a block carries the given class itself,
+   marked MRB_PROC_GIVEN, and a `def` in its body, or in a block made
+   there, adds to that class as CRuby's does under the cref the block
+   pushed. */
 struct RClass*
 mrb_vm_definee_class(mrb_state *mrb, mrb_callinfo *ci)
 {
@@ -129,6 +131,30 @@ mrb_proc_new(mrb_state *mrb, const mrb_irep *irep)
   }
   p->body.irep = irep;
 
+  return p;
+}
+
+/* The proc for a method body written in the running frame.  Its class is
+   the frame's cref, the scope the body is written in, except where the
+   frame was given a class to run under, as a `Class.new`, `class_eval` or
+   `instance_eval` block is: a `def` in the body then adds to the given
+   class, as it does in the block, and the proc carries that class marked
+   MRB_PROC_GIVEN, so that the walks reading the cref pass over it to the
+   scope around the block.  A method written `def self.name` is included:
+   its body keeps the scope around it, which here is the given class. */
+struct RProc*
+mrb_method_proc_new(mrb_state *mrb, const mrb_irep *irep)
+{
+  struct RProc *p = mrb_proc_new(mrb, irep);
+  struct RClass *given = mrb_vm_definee_class(mrb, mrb->c->ci);
+
+  /* mrb_proc_new() left the cref in the proc, or the frame's class where
+     the chain holds no scope; the proc is new and white, so no barrier. */
+  p->flags |= MRB_PROC_SCOPE | MRB_PROC_CREF;
+  if (given && given != p->e.target_class) {
+    p->e.target_class = given;
+    p->flags |= MRB_PROC_GIVEN;
+  }
   return p;
 }
 

--- a/src/proc.c
+++ b/src/proc.c
@@ -66,13 +66,17 @@ given_class_env_p(const struct RProc *p)
    the block keeps looking constants up from the scope it was written in.
    An eval string is the other case: it opens a scope of its own, and one
    given a class carries that class as its cref, so it is on the chain and
-   this walk finds it. */
+   this walk finds it.
+
+   A method written in a block given a class carries that class for a `def`
+   in its body and not as its cref, MRB_PROC_GIVEN says so, and the walk
+   passes over it to the scope the block was written in. */
 struct RClass*
 mrb_vm_cref_class(mrb_state *mrb, mrb_callinfo *ci)
 {
   const struct RProc *p = ci->proc;
 
-  while (p && !MRB_PROC_CFUNC_P(p) && !MRB_PROC_CREF_P(p)) p = p->upper;
+  while (p && !MRB_PROC_CFUNC_P(p) && (!MRB_PROC_CREF_P(p) || MRB_PROC_GIVEN_P(p))) p = p->upper;
   return (p && !MRB_PROC_CFUNC_P(p)) ? MRB_PROC_TARGET_CLASS(p) : NULL;
 }
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -1214,6 +1214,11 @@ mrb_cv_defined(mrb_state *mrb, mrb_value mod, mrb_sym sym)
   return mrb_mod_cv_defined(mrb, mrb_class_ptr(mod), sym);
 }
 
+/* The class a class variable in the frame's scope is read from: the nearest
+   scope on the `upper` chain that carries a class of its own, a singleton
+   class passed over.  A method written in a block given a class carries the
+   given class for a `def` and is passed over too; the variable is read from
+   the scope the block was written in, as under the cref CRuby skips. */
 mrb_value
 mrb_vm_cv_get(mrb_state *mrb, mrb_sym sym)
 {
@@ -1223,7 +1228,7 @@ mrb_vm_cv_get(mrb_state *mrb, mrb_sym sym)
 
   for (;;) {
     c = MRB_PROC_TARGET_CLASS(p);
-    if (c && c->tt != MRB_TT_SCLASS) break;
+    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(p)) break;
     p = p->upper;
   }
   return mrb_mod_cv_get(mrb, c, sym);
@@ -1239,7 +1244,7 @@ mrb_vm_cv_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sym sym)
 
   for (;;) {
     c = MRB_PROC_TARGET_CLASS(proc);
-    if (c && c->tt != MRB_TT_SCLASS) break;
+    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(proc)) break;
     proc = proc->upper;
     if (!proc) { c = mrb->object_class; break; }
   }
@@ -1254,7 +1259,7 @@ mrb_vm_cv_set(mrb_state *mrb, mrb_sym sym, mrb_value v)
 
   for (;;) {
     c = MRB_PROC_TARGET_CLASS(p);
-    if (c && c->tt != MRB_TT_SCLASS) break;
+    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(p)) break;
     p = p->upper;
   }
   mrb_mod_cv_set(mrb, c, sym, v);
@@ -1364,10 +1369,15 @@ proc_class(mrb_state *mrb, const struct RProc *proc)
    is a scope, as its cref is in CRuby. The caller leaves out the proc
    with no `upper`, the top level: it is not a scope of its own, and
    its class is reached through the ancestors after the lexical scopes,
-   so that a superclass wins over a top-level constant. */
+   so that a superclass wins over a top-level constant.  A method written
+   in a block given a class carries that class for a `def` in its body and
+   is not a scope for the walk, as the cref CRuby pushes for such a block
+   is skipped: the class the block was given is not where a constant in
+   the method is read from. */
 static mrb_bool
 lexical_scope_p(mrb_state *mrb, const struct RProc *proc)
 {
+  if (MRB_PROC_GIVEN_P(proc)) return FALSE;
   if (MRB_PROC_SCOPE_P(proc)) return TRUE;
   return proc_class(mrb, proc) != proc_class(mrb, proc->upper);
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -3002,11 +3002,11 @@ vm_op_div(mrb_state *mrb, uint32_t a, mrb_sym *midp)
 static mrb_sym
 vm_define_method(mrb_state *mrb, struct RClass *tc, const mrb_irep *irep, uint16_t b, uint16_t c)
 {
-  struct RProc *p = mrb_proc_new(mrb, irep->reps[c]);
+  struct RProc *p = mrb_method_proc_new(mrb, irep->reps[c]);
   mrb_sym mid = irep->syms[b];
   mrb_method_t m;
 
-  p->flags |= MRB_PROC_SCOPE | MRB_PROC_STRICT | MRB_PROC_CREF;
+  p->flags |= MRB_PROC_STRICT;
   MRB_METHOD_FROM_PROC(m, p);
   MRB_METHOD_SET_VISIBILITY(m, MRB_METHOD_VDEFAULT_FL);
   mrb_define_method_raw(mrb, tc, mid, m);
@@ -4598,8 +4598,7 @@ RETRY_TRY_BLOCK:
       }
       else {
         /* OP_METHOD is the only one here without OP_L_CAPTURE: a method body */
-        p = mrb_proc_new(mrb, nirep);
-        p->flags |= MRB_PROC_SCOPE | MRB_PROC_CREF;
+        p = mrb_method_proc_new(mrb, nirep);
       }
       if (c & OP_L_STRICT) p->flags |= MRB_PROC_STRICT;
       regs[a] = mrb_obj_value(p);

--- a/test/t/class.rb
+++ b/test/t/class.rb
@@ -582,3 +582,66 @@ assert('a visibility change makes the method table it needs') do
     end
   end
 end
+
+module Test4GivenDefMaker
+  # Run in a method, so that the block's cref is this module rather than the
+  # class `mrb_proc_new()` falls back to when a block at the top level of a
+  # compiled test file has no cref to answer with.
+  def self.klass
+    Class.new do
+      def direct; def from_direct; end; end
+      def in_block; [1].each { def from_block; end }; end
+      def self.on_singleton; def from_singleton_body; end; end
+      def aliased; alias from_alias direct; end
+      def undefs; undef gone; end
+      def gone; end
+      private
+      def hidden; def from_hidden; end; end
+    end
+  end
+  def self.mod; Module.new { def direct; def from_direct; end; end }; end
+  def self.on_eval(c); c.class_eval { def direct; def from_direct; end; end }; end
+  def self.on_instance(o); o.instance_eval { def direct; def from_direct; end; end }; end
+end
+
+assert('a `def` in a method written in a block given a class adds to that class') do
+  # The method proc used to carry its cref, the scope the block was written
+  # in, and a `def` in its body went there: `Object` for a script. The
+  # class the block was given is what the method carries now, so a `def`
+  # or an `alias` in the body, in a block made in the body, or in the body
+  # of a `def self.name` written in the block, adds to that class. The
+  # `def` written under a `private` in the block is private; the one in
+  # its body starts at the default and is public.
+  c = Test4GivenDefMaker.klass
+  o = c.new
+  o.direct
+  o.in_block
+  c.on_singleton
+  assert_nothing_raised { o.aliased }
+  o.__send__(:hidden)
+  [:from_direct, :from_block, :from_singleton_body, :from_alias, :from_hidden].each do |name|
+    assert_true c.method_defined?(name), name.to_s
+    assert_false Object.new.respond_to?(name, true), name.to_s
+  end
+  assert_false c.method_defined?(:hidden)
+  assert_true c.method_defined?(:gone)
+  assert_nothing_raised { o.undefs }
+  assert_false c.method_defined?(:gone)
+
+  m = Test4GivenDefMaker.mod
+  Class.new { include m }.new.direct
+  assert_true m.method_defined?(:from_direct)
+  assert_false Object.new.respond_to?(:from_direct, true)
+
+  c = Class.new
+  Test4GivenDefMaker.on_eval(c)
+  c.new.direct
+  assert_true c.method_defined?(:from_direct)
+  assert_false Object.new.respond_to?(:from_direct, true)
+
+  o = Object.new
+  Test4GivenDefMaker.on_instance(o)
+  o.direct
+  assert_true o.respond_to?(:from_direct)
+  assert_false Object.new.respond_to?(:from_direct, true)
+end

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1516,3 +1516,60 @@ assert('constant definition: a block given a class to run under keeps its own') 
     assert_false recv.const_defined?(name, false), name.to_s
   end
 end
+
+class Test4GivenMethodSuper
+  KS = :recv
+  @@cvs = :recv
+  def self.read_cv; @@cvs; end
+end
+
+module Test4GivenMethodMaker
+  # Run in a method, so that the block's cref is this module rather than the
+  # class `mrb_proc_new()` falls back to when a block at the top level of a
+  # compiled test file has no cref to answer with.
+  KS = :lex
+  @@cvs = :lex
+  def self.make(sup)
+    Class.new(sup) do
+      def direct; KS; end
+      def nested; [1].map { KS }[0]; end
+      def cv; @@cvs; end
+      def cv_defined; defined?(@@cvs); end
+      def cv_write; @@cvs = :written; end
+    end
+  end
+  def self.read_cv; @@cvs; end
+  def self.install(recv)
+    recv.class_eval do
+      def own_direct; KO; end
+      def own_nested; [1].map { KO }[0]; end
+    end
+  end
+end
+
+class Test4GivenMethodOwn
+  KO = :recv
+end
+
+assert('constant and class variable lookup: a method written in a block given a class keeps the block\'s scope') do
+  # The class the block was given is where a `def` in the method adds, not
+  # where a constant or a class variable in the method is read from: those
+  # come from the scope the block was written in, here the module, and the
+  # superclass of the given class does not get in front of it.
+  c = Test4GivenMethodMaker.make(Test4GivenMethodSuper)
+  o = c.new
+  assert_equal(:lex, o.direct)
+  assert_equal(:lex, o.nested)
+  assert_equal(:lex, o.cv)
+  assert_equal("class variable", o.cv_defined)
+  o.cv_write
+  assert_equal(:written, Test4GivenMethodMaker.read_cv)
+  assert_equal(:recv, Test4GivenMethodSuper.read_cv)
+
+  # a constant only the given class has is out of reach from the method
+  # body and from a block made there, as the given class is not a scope
+  # the walk from the block reads
+  Test4GivenMethodMaker.install(Test4GivenMethodOwn)
+  assert_raise(NameError) { Test4GivenMethodOwn.new.own_direct }
+  assert_raise(NameError) { Test4GivenMethodOwn.new.own_nested }
+end


### PR DESCRIPTION
## Summary

A `def` in the body of a method written in a `Class.new`, `Module.new`, `class_eval`, `instance_eval`, `class_exec` or `instance_exec` block was added to the scope the block was written in, `Object` for a script, and so was an `alias`, a `def` in a block made in the body, and a `def` in a string evaluated there. The method proc carried the block's cref as its class, and that is where a `def` in the body looked. The proc now carries the class the block was given, marked `MRB_PROC_GIVEN`, and the walks that read the cref pass over it, so a constant, a class variable or `Module.nesting` in the method still answers from the scope around the block, as it does in CRuby under the cref such a block pushes.

## Changes

| File                                      | What                                                                                                                                                           |
| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `include/mruby/proc.h`                    | `MRB_PROC_GIVEN`: a method proc whose class is the one its block was given, not its cref                                                                       |
| `src/proc.c`                              | `mrb_method_proc_new()` makes the proc for a method body and marks it where the frame's definee and cref differ; `mrb_vm_cref_class()` passes over the mark    |
| `src/vm.c`                                | `OP_TDEF`, `OP_SDEF` and `OP_METHOD` make the proc through `mrb_method_proc_new()`                                                                             |
| `src/variable.c`                          | the constant walk and the three class variable walks pass over the mark                                                                                        |
| `mrbgems/mruby-metaprog/src/metaprog.c`   | `Module.nesting` and `Module.constants` pass over the mark                                                                                                     |
| `test/t/class.rb`                         | one test: `def`, `alias` and `undef` in a method written in a `Class.new`, `Module.new`, `class_eval` and `instance_eval` block                                |
| `test/t/module.rb`                        | one test: a constant and a class variable in such a method still come from the scope around the block, and a constant only the given class has is out of reach |
| `mrbgems/mruby-metaprog/test/metaprog.rb` | one test: `Module.nesting` and `Module.constants` in such a method                                                                                             |
| `mrbgems/mruby-class-ext/test/module.rb`  | one test: `class_exec` and `module_exec`                                                                                                                       |
| `mrbgems/mruby-object-ext/test/object.rb` | one test: `instance_exec`                                                                                                                                      |
| `mrbgems/mruby-eval/test/eval.rb`         | one test: a `def` in a string evaluated in such a method, with and without a binding                                                                           |

### Two classes on one proc

A method written in a block given a class has two classes: the given one, where a `def` in its body adds, and the scope the block was written in, its cref, where a constant or a class variable in the body is read from. CRuby keeps both as a cref the block pushes, which a `def` reads and the constant and class variable walks skip. The proc in mruby holds one class, and it held the cref: a `def` in the body then went to the scope around the block. Putting the given class there instead would send a constant in the body to the given class and its superclass before the scope around the block:

```ruby
X = 2
class Base; X = 1; end
Class.new(Base) { def pos; X; end }.new.pos   # CRuby: 2
```

So the proc holds the given class and says so with `MRB_PROC_GIVEN`, and every walk that reads the cref off the `upper` chain treats the marked proc as a block: `mrb_vm_cref_class()`, the constant walk's `lexical_scope_p()`, the three class variable walks, `Module.nesting` and `Module.constants`. `mrb_vm_definee_class()` reads it as the scope it is, so a `def` in the body, in a block made in the body, or in a string evaluated there lands on the given class. A method written `def self.name` in the block is marked the same way; its body keeps the scope around it, which is the given class, and CRuby agrees.

The mark is set only where the frame's definee and cref differ. A method written under a class body or in another method has the two equal and is not marked, so nothing changes for it.

### The readers first, the writer last

The four commits land the readers of the mark before anything sets it: `mrb_vm_cref_class()`, then the constant and class variable walks, then `Module.nesting` and `Module.constants`, each a no-op on its own. The tests those commits add pin what the tree answers today, which is what CRuby answers, and stay green once the last commit sets the mark: that is what shows the `def` moved and nothing else did.

## Behaviour

```ruby
c = Class.new { def pos; def q; end; end }
c.new.pos
c.method_defined?(:q)                      # master: false   this PR: true
Object.method_defined?(:q)                 # master: true    this PR: false

o = Object.new
o.instance_eval { def pos; [1].each { def q; end }; end }
o.pos
o.singleton_methods.sort                   # master: [:pos]  this PR: [:pos, :q]

k = Class.new { def pos; Module.nesting; end }
k.new.pos                                  # master: [Object]  this PR: []
```

CRuby answers as this PR does. A constant or a class variable in such a method answered from the scope around the block on master and does so still. A `def` in the block itself, outside any method, was right since #7538 and #7548 and is unchanged.

Out of scope but different from CRuby: a class variable read in a block made in the body of such a method comes from the class the method was found in, where CRuby reads it from the scope around the block. The block's env carries the frame's class, and the class variable walk reads that as a scope.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `edd066a5a`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,402,518 | 1,403,126 |  +608 |
| ascii-ctype      | 1,386,918 | 1,387,526 |  +608 |
| byte-string      | 1,363,894 | 1,364,502 |  +608 |
| cxx_abi          | 1,434,393 | 1,434,905 |  +512 |
| no-float         | 1,328,094 | 1,328,750 |  +656 |
| no-bigint        | 1,286,710 | 1,287,270 |  +560 |
| full-debug (-O0) | 1,998,774 | 1,999,030 |  +256 |

On bintest: `proc.o` +384 (`mrb_method_proc_new()`, and the mark test inlined into `mrb_proc_new()` and `mrb_vm_cref_class()`), `variable.o` +176 (four conditions), `metaprog.o` +48; `vm.o` is the same size, the three sites call one function. As a static function in `vm.c`, gcc inlined it at all three sites for +392 in `mrb_vm_exec()`. `MRB_PROC_GIVEN_P()` tests the cfunc bit along with its own, since bit 15 is an aspec bit on a cfunc proc and the constant and class variable walks pass through cfunc procs; that is one instruction at each of its eight readers.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,774 | 2,700 |   74 |   0 |     0 |       0 |
| bintest                          | 3,022 | 3,002 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 3,006 | 2,984 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,934 | 2,860 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,022 | 3,002 |   20 |   0 |     0 |       0 |
| no-float                         | 2,755 | 2,658 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,971 | 2,938 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,022 | 3,011 |   11 |   0 |     0 |       0 |

bintest passes on every build. The tests make every block in a method of a module, since a block at the top level of a compiled test file has no cref to answer with and falls back to the class it was given, which hides the bug. With the six test files on master, the four tests that check where a `def` lands fail and the two that pin constants, class variables, nesting and `Module.constants` pass.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/vm.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/vm.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/atomic-doodling-perlis=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/vm.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected method definitions created inside `Class.new`, `class_eval`, `module_exec`, and `instance_exec` blocks so they attach to the intended class, module, or singleton class.
  - Fixed constant, class-variable, and nesting resolution to preserve the block’s lexical scope instead of incorrectly using the given class.

- **Tests**
  - Added coverage for nested method definitions, `eval` forms, visibility changes, aliases, and scope lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->