### PR TITLE
mruby-io: reject a recursive array in File.join

### DIFF
--- a/mrbgems/mruby-io/src/file.c
+++ b/mrbgems/mruby-io/src/file.c
@@ -911,40 +911,32 @@ mrb_file_path(mrb_state *mrb, mrb_value klass)
   return filename;
 }
 
-// Forward declaration for recursive join processing
-static mrb_value mrb_file_join_process_args(mrb_state *mrb, const mrb_value *argv, mrb_int argc);
-
-static mrb_value
-mrb_file_join_process_args(mrb_state *mrb, const mrb_value *argv, mrb_int argc)
+/* Flattens the arguments of File.join into `names`, checking each value
+   is a String as it lands. `seen` holds the arrays currently being walked,
+   innermost last, so an array that contains itself (directly or through
+   another array) is caught on re-entry the way CRuby catches it. Only
+   the ancestors are kept, so the same array may appear twice as siblings. */
+static void
+mrb_file_join_flatten(mrb_state *mrb, mrb_value names, mrb_value seen, const mrb_value *argv, mrb_int argc)
 {
-  mrb_value result = mrb_ary_new_capa(mrb, argc);
-
   for (mrb_int i = 0; i < argc; i++) {
     mrb_value arg = argv[i];
 
     if (mrb_array_p(arg)) {
-      // Check for recursive arrays using mruby's built-in detection
-      if (MRB_RECURSIVE_UNARY_P(mrb, MRB_SYM(join), arg)) {
-        mrb_raise(mrb, E_ARGUMENT_ERROR, "recursive array");
+      for (mrb_int k = 0; k < RARRAY_LEN(seen); k++) {
+        if (mrb_obj_eq(mrb, RARRAY_PTR(seen)[k], arg)) {
+          mrb_raise(mrb, E_ARGUMENT_ERROR, "recursive array");
+        }
       }
-
-      // Recursively process the array
-      mrb_value nested = mrb_file_join_process_args(mrb, RARRAY_PTR(arg), RARRAY_LEN(arg));
-
-      // Append nested results to our result
-      mrb_int nested_len = RARRAY_LEN(nested);
-      for (mrb_int k = 0; k < nested_len; k++) {
-        mrb_ary_push(mrb, result, RARRAY_PTR(nested)[k]);
-      }
+      mrb_ary_push(mrb, seen, arg);
+      mrb_file_join_flatten(mrb, names, seen, RARRAY_PTR(arg), RARRAY_LEN(arg));
+      mrb_ary_pop(mrb, seen);
     }
     else {
-      // Convert to string (raises TypeError if not convertible)
       mrb_ensure_string_type(mrb, arg);
-      mrb_ary_push(mrb, result, arg);
+      mrb_ary_push(mrb, names, arg);
     }
   }
-
-  return result;
 }
 
 /*
@@ -970,8 +962,8 @@ mrb_file_join(mrb_state *mrb, mrb_value klass)
     return mrb_str_new_lit(mrb, "");
   }
 
-  // Process arguments and flatten arrays
-  mrb_value names = mrb_file_join_process_args(mrb, argv, argc);
+  mrb_value names = mrb_ary_new_capa(mrb, argc);
+  mrb_file_join_flatten(mrb, names, mrb_ary_new(mrb), argv, argc);
 
   mrb_int names_len = RARRAY_LEN(names);
   if (names_len == 0) {

--- a/mrbgems/mruby-io/test/file.rb
+++ b/mrbgems/mruby-io/test/file.rb
@@ -238,6 +238,14 @@ assert('File.join') do
   assert_equal "a/b/c", File.join("a/", "/b/", "/c")
   assert_equal "a/b/c", File.join(["a", "b", "c"])
   assert_equal "a/b/c", File.join("a", ["b", ["c"]])
+
+  a = ["a"]
+  assert_equal "a/a", File.join(a, a)
+  a << a
+  assert_raise(ArgumentError) { File.join(a) }
+  b = ["b"]
+  b << [b]
+  assert_raise(ArgumentError) { File.join("x", b) }
 end
 
 assert('File.realpath') do


### PR DESCRIPTION
## Summary

`File.join` walks nested arrays by plain C recursion, and the guard it carried against an array that contains itself could never fire, so such an array ran the C stack out and killed the process with SIGSEGV. Keep the arrays being walked in a small stack and raise `ArgumentError` on re-entry, which is what CRuby answers.

## Changes

| File                            | What                                                                       |
| ------------------------------- | -------------------------------------------------------------------------- |
| `mrbgems/mruby-io/src/file.c`   | the flatten walk carries the arrays it is inside and raises on meeting one |
| `mrbgems/mruby-io/test/file.rb` | the direct and the indirect cycle, and the same array twice as siblings    |

### Why the guard never fired

The walk checked each array with `MRB_RECURSIVE_UNARY_P(mrb, MRB_SYM(join), arg)`. That looks through the call frames for one whose method is `join` and whose receiver is `arg`. The frame of `File.join` has `File` as its receiver, and the nested walk is a direct C call that pushes no frame, so no frame can ever match. The check is replaced rather than repaired: nothing frame-based can see a recursion that lives entirely in C locals.

### The stack

`mrb_file_join_flatten()` takes an array of the arrays it is currently inside, innermost last. Entering an array first compares it by identity against every entry and raises `ArgumentError` with CRuby's message on a hit, then pushes it and pops it on the way out. Only the ancestors are kept, so `File.join(a, a)` still joins. The stack is as deep as the nesting, so a linear scan is enough, and the walk also drops the intermediate array per level it used to build and copy: the strings land in one `names` array directly.

## Behaviour

```ruby
a = ["x"]; a << a
File.join(a)        # CRuby: ArgumentError (recursive array), mruby before: SIGSEGV, after: ArgumentError
b = ["b"]; b << [b]
File.join("x", b)   # CRuby: ArgumentError (recursive array), mruby before: SIGSEGV, after: ArgumentError
c = ["c"]
File.join(c, c)     # CRuby: "c/c", mruby before and after: "c/c"
```

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,999,142 | 1,999,190 | +48   |
| bintest          | 1,403,126 | 1,403,126 | 0     |
| cxx_abi          | 1,434,969 | 1,434,921 | -48   |
| byte-string      | 1,364,502 | 1,364,502 | 0     |
| ascii-ctype      | 1,387,526 | 1,387,526 | 0     |
| no-float         | 1,328,830 | 1,328,830 | 0     |
| no-bigint        | 1,287,286 | 1,287,286 | 0     |

The change is confined to `file.o` of mruby-io. At `-O3` the walk shrinks by 33 bytes and `mrb_file_join` grows by 32, so `.text` of the object is unchanged; the two builds that move are the one without optimisation and the C++ one laying the pair out differently.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2777  | 2703 | 74   | 0   | 0     | 0       |
| full-debug  | 3025  | 3014 | 11   | 0   | 0     | 0       |
| bintest     | 3025  | 3005 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3025  | 3005 | 20   | 0   | 0     | 0       |
| byte-string | 2937  | 2863 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3009  | 2987 | 22   | 0   | 0     | 0       |
| no-float    | 2758  | 2661 | 97   | 0   | 0     | 0       |
| no-bigint   | 2974  | 2941 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 1 Skip, 0 KO.

The new assertions in `File.join` cover an array that contains itself, one that contains itself through another array, and the same array passed twice as siblings, which must still join. On master the first two take `bin/mruby` down with SIGSEGV.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch mrbgems/mruby-io/src/file.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-io/src/file.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-io/src/file.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `File.join` now correctly handles arrays that appear multiple times as separate arguments.
  - Recursive arrays still raise an `ArgumentError`, including direct and nested self-references.

- **Tests**
  - Added coverage for repeated arrays and recursive array inputs in `File.join`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->