### PR TITLE
variable.c: forget an irep's constant cache entries when the irep is freed

### DIFF
--- a/include/mruby/internal.h
+++ b/include/mruby/internal.h
@@ -670,6 +670,11 @@ mrb_value mrb_const_get_noraise(mrb_state *mrb, struct RClass *mod, mrb_sym sym)
 mrb_bool mrb_vm_cv_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sym sym);
 struct RClass *mrb_vm_cref_class(mrb_state *mrb, mrb_callinfo *ci);
 struct RClass *mrb_vm_definee_class(mrb_state *mrb, mrb_callinfo *ci);
+#ifndef MRB_NO_CONST_CACHE
+void mrb_const_cache_forget_irep(mrb_state *mrb, const struct mrb_irep *irep);
+#else
+#define mrb_const_cache_forget_irep(mrb, irep) ((void)0)
+#endif
 struct RProc *mrb_method_proc_new(mrb_state *mrb, const mrb_irep *irep);
 mrb_bool mrb_gv_defined(mrb_state *mrb, mrb_sym sym);
 #ifdef MRUBY_VARIABLE_H

--- a/mrbgems/mruby-eval/test/eval.c
+++ b/mrbgems/mruby-eval/test/eval.c
@@ -1,0 +1,59 @@
+#include <mruby.h>
+#include <mruby/compile.h>
+#include <mruby/proc.h>
+#include <mruby/irep.h>
+
+#ifndef MRB_NO_CONST_CACHE
+static mrb_bool
+const_cache_holds_irep(mrb_state *mrb, const mrb_irep *irep)
+{
+  for (int i=0; i<MRB_CONST_CACHE_SIZE; i++) {
+    if (mrb->const_cache[i].irep == irep) return TRUE;
+  }
+  return FALSE;
+}
+#endif
+
+/* Compiles a read of the named constant into its own irep, runs it once so
+   OP_GETCONST records the answer under that irep, lets the collector free
+   the irep along with its proc, and reports whether the constant cache
+   still holds an entry keyed by the freed address. Only the address is
+   compared; the irep is never read after the collection. Nothing in Ruby
+   can ask this: seeing the stale entry from Ruby needs the allocator to
+   hand the next irep the same address. Answers nil without a cache. */
+static mrb_value
+const_cache_dangles_after_irep_free(mrb_state *mrb, mrb_value self)
+{
+#ifndef MRB_NO_CONST_CACHE
+  const char *name;
+  mrb_get_args(mrb, "z", &name);
+
+  int ai = mrb_gc_arena_save(mrb);
+  mrb_ccontext *cxt = mrb_ccontext_new(mrb);
+  struct mrb_parser_state *p = mrb_parse_string(mrb, name, cxt);
+  struct RProc *proc = (p && p->nerr == 0) ? mrb_generate_code(mrb, p) : NULL;
+  if (p) mrb_parser_free(p);
+  mrb_ccontext_free(mrb, cxt);
+  if (!proc) mrb_raise(mrb, E_RUNTIME_ERROR, "the constant read did not compile");
+
+  const mrb_irep *irep = proc->body.irep;
+  mrb_top_run(mrb, proc, mrb_top_self(mrb), 0);
+  if (!const_cache_holds_irep(mrb, irep)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "the constant read did not fill the cache");
+  }
+
+  proc = NULL;
+  mrb_gc_arena_restore(mrb, ai);
+  mrb_full_gc(mrb);
+  return mrb_bool_value(const_cache_holds_irep(mrb, irep));
+#else
+  return mrb_nil_value();
+#endif
+}
+
+void
+mrb_mruby_eval_gem_test(mrb_state *mrb)
+{
+  struct RClass *cls = mrb_define_module(mrb, "ConstCacheTest");
+  mrb_define_module_function(mrb, cls, "dangles_after_irep_free?", const_cache_dangles_after_irep_free, MRB_ARGS_REQ(1));
+}

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -761,3 +761,35 @@ assert('a `def` in a string evaluated in a method written in a block given a cla
   assert_false Object.new.respond_to?(:from_string, true)
   assert_false Object.new.respond_to?(:from_binding, true)
 end
+
+module ConstCacheIrepReuse
+  X = :outer
+  class Inner
+    X = :inner
+  end
+end
+
+assert('constant read by an eval whose irep took a freed irep\'s address') do
+  # The constant cache is keyed by the irep's address. Once the irep of one
+  # eval string is collected, the next eval string can be compiled into the
+  # same address, and a read of the same constant name from another scope
+  # used to be answered from the stale entry.
+  seen = []
+  8.times do
+    seen << [ConstCacheIrepReuse::Inner.class_eval("X"),
+             ConstCacheIrepReuse.class_eval("X")]
+    GC.start
+  end
+  assert_equal [[:inner, :outer]] * 8, seen
+end
+
+ConstCacheTestValue = :probe
+
+assert('the constant cache forgets an irep when the irep is freed') do
+  # Same defect as above, seen from the cache itself: after the irep of a
+  # constant read is freed no entry may still be keyed by its address,
+  # whatever the allocator does with that address next.
+  dangles = ConstCacheTest.dangles_after_irep_free?("ConstCacheTestValue")
+  skip "this build has no constant cache" if dangles.nil?
+  assert_false dangles
+end

--- a/src/state.c
+++ b/src/state.c
@@ -166,6 +166,7 @@ mrb_irep_free(mrb_state *mrb, mrb_irep *irep)
   }
   mrb_free(mrb, (void*)irep->lv);
   mrb_debug_info_free(mrb, irep->debug_info);
+  mrb_const_cache_forget_irep(mrb, irep);
 #ifdef MRB_DEBUG
   memset(irep, -1, sizeof(*irep));
 #endif

--- a/src/variable.c
+++ b/src/variable.c
@@ -1498,6 +1498,19 @@ mrb_const_cache_clear(mrb_state *mrb)
     cc->irep = NULL;
   }
 }
+
+/* Forget the entries of one irep before its memory is freed. The cache is
+   keyed by the irep's address, so the next irep allocated at that address
+   would otherwise inherit answers resolved in another scope. */
+void
+mrb_const_cache_forget_irep(mrb_state *mrb, const mrb_irep *irep)
+{
+  struct mrb_const_cache_entry *cc = mrb->const_cache;
+
+  for (int i=0; i<MRB_CONST_CACHE_SIZE; cc++,i++) {
+    if (cc->irep == irep) cc->irep = NULL;
+  }
+}
 #endif
 
 MRB_API void


### PR DESCRIPTION
## Summary

The constant cache in `OP_GETCONST` is keyed by the irep's address, and nothing dropped an irep's entries when the irep was freed. Once the next irep landed at the same address, a read of the same constant name from another scope was answered from the stale entry. `mrb_irep_free()` now drops the entries keyed by the irep it frees.

## Changes

| File                              | What                                                                                                                                              |
| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/variable.c`                  | `mrb_const_cache_forget_irep()`: clears the entries whose key is the given irep                                                                   |
| `include/mruby/internal.h`        | its declaration, a no-op macro under `MRB_NO_CONST_CACHE` as `mrb_const_cache_clear()` has                                                        |
| `src/state.c`                     | `mrb_irep_free()` calls it before the irep's memory goes back to the allocator                                                                    |
| `mrbgems/mruby-eval/test/eval.rb` | two tests: the symptom through `class_eval` strings, and the cache asked from C whether an entry still points at a freed irep                     |
| `mrbgems/mruby-eval/test/eval.c`  | the C side of the second test: compiles a constant read, runs it once, lets the collector free the irep, scans `mrb->const_cache` for its address |

### Where the stale entry comes from

An entry holds the irep, the symbol and the value. The five places that change what a constant name resolves to clear the whole cache, so a live irep never sees a stale value. A freed irep is different: its entries stay, and the allocator hands the address to the next irep. Any code that compiles and discards ireps gets there, `eval` strings and repeated `mrb_load_string()` alike, and it needs no `MRB_GC_STRESS`.

The fix scans the 64 entries once per freed irep, off the `OP_GETCONST` path. Mixing a generation into the key would put a comparison back on that path, which 50bc8c613 removed on purpose.

### Two tests

The Ruby test reads `X` through `Inner.class_eval("X")` and `Outer.class_eval("X")` in turn with a `GC.start` between rounds. It shows the symptom, but it depends on the allocator handing the next irep the freed address; glibc does from the second round. The C test does not: it keeps the address of the irep it compiled, runs the read once so `OP_GETCONST` fills the cache, drops the proc and collects, then scans the cache for that address. Only the address is compared. It fails on master under any allocator, and answers nil, which the Ruby side reads as skip, on a build without a constant cache.

## Behaviour

```ruby
X = :top
class Foo
  X = :foo
  def self.b; binding; end
end
3.times { p [Foo.b.eval("X"), binding.eval("X")]; GC.start }
# CRuby: [:foo, :top] every time
# mruby: [:foo, :top], [:top, :top], [:top, :foo]
```

The wrong answer goes both ways: whichever scope reads the name first after the address is reused decides what the other one gets. This PR answers as CRuby does.

A proc run under another class through `define_method`, `class_eval` or `instance_eval` keeps the same irep and the same lexical answer in both mruby and CRuby, so the key needs no cref.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `f4ebd89e6`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,403,126 | 1,403,190 |   +64 |
| ascii-ctype      | 1,387,526 | 1,387,590 |   +64 |
| byte-string      | 1,364,502 | 1,364,566 |   +64 |
| cxx_abi          | 1,434,969 | 1,435,033 |   +64 |
| no-float         | 1,328,830 | 1,328,894 |   +64 |
| no-bigint        | 1,287,286 | 1,287,350 |   +64 |
| full-debug (-O0) | 1,999,142 | 1,999,238 |   +96 |

On bintest: `variable.o` +64, all of it `mrb_const_cache_forget_irep()` (55 bytes and padding); `state.o` is the same size, the call sits in the slack of `mrb_irep_free()`.

## Speed

Not a hot-path change, but the free path grows. callgrind instructions per iteration, `Ir(2N) - Ir(N)` over `N = 100,000`, host build, `CC=gcc`:

```ruby
X = 1
n = ARGV[0].to_i
i = 0
while i < n
  eval("X")        # compiles and, in steady state, frees one irep per round
  i += 1
end
```

| Case                                            | master | this PR | delta |
| ----------------------------------------------- | -----: | ------: | ----: |
| `eval("X")` per round                           | 45,722 |  46,054 |  +332 |
| `X; X; X; X` per round (the `OP_GETCONST` path) |    328 |     328 |     0 |
| `proc { i }` per round (no irep is freed)       |  1,011 |   1,011 |     0 |

The 332 instructions are the scan of the 64 entries for the one irep each round frees, 0.7% of an `eval` that compiles a one-token string. The two control cases match master to the instruction.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,779 | 2,705 |   74 |   0 |     0 |       0 |
| bintest                          | 3,027 | 3,007 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 3,011 | 2,989 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,939 | 2,865 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,027 | 3,007 |   20 |   0 |     0 |       0 |
| no-float                         | 2,760 | 2,663 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,976 | 2,943 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,027 | 3,016 |   11 |   0 |     0 |       0 |

bintest passes (147 examples, KO 0). With the two tests on master, the host mrbtest reports both as KO (2,779 tests, KO 2), and every build above gains the same 2 tests over master with no other change in its counts.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/host=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/string.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/string.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/resilient-humming-goblet=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed constant lookups after compiled code is collected and memory is reused.
  - Prevented stale cached constant values from being applied to newly allocated compiled code.

- **Tests**
  - Added coverage for constant resolution across repeated garbage collection and compiled-code reuse.
  - Added checks for correct behavior when constant caching is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->