### PR TITLE
mruby-compiler: give the frame back what `**rest` borrowed, and no more

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -3281,7 +3281,6 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
                 genop_3(s, OP_SEND, recv, new_sym(s, MRC_SYM_1(dup)), 0);
               }
               gen_move(s, var_idx, recv, 1);
-              pop(); /* release recv */
             }
           }
           /* Anonymous **: do nothing */

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1450,6 +1450,57 @@ assert('pattern matching - hash patterns') do
   end
 end
 
+assert('pattern matching - a clause that names `**rest` keeps its own value') do
+  # Capturing `**rest` left the frame one register short of where the pattern
+  # began, so the value the clause produced landed where the `case` read it
+  # from, and what came out was the rest Hash, or whatever else that register
+  # held.
+  h = {a: 1, b: 2, c: 3}
+  r = case h
+      in {a:, **rest} then [a, rest]
+      end
+  assert_equal [1, {b: 2, c: 3}], r
+
+  r = case h
+      in {a:, **rest} then :body
+      end
+  assert_equal :body, r
+
+  # no key of its own: the rest is a copy of the whole subject
+  r = case h
+      in {**rest} then [:all, rest]
+      end
+  assert_equal [:all, {a: 1, b: 2, c: 3}], r
+
+  # the value of `in` is the match, not the captured Hash
+  r = (h in {a:, **rest})
+  assert_equal [true, {b: 2, c: 3}], [r, rest]
+
+  # the statement after `=>` reads its locals from the shifted frame
+  f = ->(x) { x => {a:, **rest}; [a, rest] }
+  assert_equal [1, {b: 2, c: 3}], f.call(h)
+
+  # a rest clause that does not match must leave the subject to the next
+  # clause and to `else`
+  r = case {z: 0}
+      in {a:, **rest} then :no
+      in {z:} then [:z, z]
+      end
+  assert_equal [:z, 0], r
+
+  r = case {z: 0}
+      in {a:, **rest} then :no
+      else :else
+      end
+  assert_equal :else, r
+
+  # each `**rest` of a nested pattern captures from its own subject
+  r = case [h, h]
+      in [{a:, **r1}, {b:, **r2}] then [a, r1, b, r2]
+      end
+  assert_equal [1, {b: 2, c: 3}, 2, {a: 1, c: 3}], r
+end
+
 assert('pattern matching - value patterns as a hash value') do
   # a value pattern is the receiver of `===`, the hash value its argument
   case {a: 1}


### PR DESCRIPTION
## Summary

A hash pattern that captures a named `**rest` left the frame one register short of where the pattern began, so the value of the clause landed below the register the `case` reads, and every clause after a failed `**rest` clause matched against a shifted subject. The capture pushed a register for the receiver of its `__except` or `dup` send, reset `sp` to release it, and then popped it a second time; the second pop goes.

## Changes

| File                                   | What                                                          |
| -------------------------------------- | ------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | drop the pop that followed the `sp` reset in `**rest` capture |
| `test/t/syntax.rb`                     | the clause value, `in`, `=>`, later clauses, nested rests     |

### Where the register went

The `**rest` branch of `codegen_pattern()` moves the subject into `cursp()`, pushes to keep it across the code that builds the key array, emits the send, and sets `s->sp = recv` so the send's result is the top of the frame. That reset already undoes the push. The `pop()` after the move into the rest variable took one more, so the code after the pattern ran with `sp` one below the register the pattern was handed. The `*rest` branch of the array pattern keeps its push and pop paired and is unaffected.

## Behaviour

```ruby
def m(h) = case h
           in {a:, **rest} then [a, rest]
           end
m({a: 1, b: 2, c: 3})  # CRuby: [1, {b: 2, c: 3}], mruby: {b: 2, c: 3}

case {z: 0}
in {a:, **rest} then :no
in {z:} then :z
end  # CRuby: :z, mruby: NoMethodError: undefined method 'deconstruct_keys' for TrueClass

f = ->(x) { x => {a:, **rest}; [a, rest] }
f.call({a: 1, b: 2})  # CRuby: [1, {b: 2}], mruby: [1, 1]
```

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,999,142 | 1,999,126 | -16   |
| bintest          | 1,403,126 | 1,403,078 | -48   |
| cxx_abi          | 1,434,969 | 1,435,017 | +48   |
| byte-string      | 1,364,502 | 1,364,454 | -48   |
| ascii-ctype      | 1,387,526 | 1,387,478 | -48   |
| no-float         | 1,328,830 | 1,328,798 | -32   |
| no-bigint        | 1,287,286 | 1,287,238 | -48   |

The change removes one call from `codegen_pattern()`; the spread across builds is the inliner laying that function out again.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2778  | 2704 | 74   | 0   | 0     | 0       |
| full-debug  | 3026  | 3015 | 11   | 0   | 0     | 0       |
| bintest     | 3026  | 3006 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3026  | 3006 | 20   | 0   | 0     | 0       |
| byte-string | 2938  | 2864 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3010  | 2988 | 22   | 0   | 0     | 0       |
| no-float    | 2759  | 2662 | 97   | 0   | 0     | 0       |
| no-bigint   | 2975  | 2942 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 0 KO.

The new test reads the value of a `**rest` clause as a method result, as the value of `in`, and from the statement after `=>` in a lambda, and runs a failing `**rest` clause ahead of a later clause and of `else`. On master the host build fails all of them, and the later clause crashes on `deconstruct_keys` sent to `true`. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch mrbgems/mruby-compiler/src/codegen.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pattern matching with `**rest` captures so captured hashes retain the correct value.
  - Ensured `in` expressions return the matched clause’s result rather than the captured rest hash.
  - Corrected local variable access and clause fallthrough behavior after rest captures.
  - Improved correctness for nested patterns using independent rest captures.

- **Tests**
  - Added coverage for hash rest captures, nested patterns, match results, and fallback clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->