### PR TITLE
mruby-array-ext: raise on flattening a recursive array

### DIFF
--- a/mrbgems/mruby-array-ext/src/array.c
+++ b/mrbgems/mruby-array-ext/src/array.c
@@ -1273,6 +1273,19 @@ flatten_internal(mrb_state *mrb, mrb_value self, mrb_int level, mrb_bool *modifi
       idx++;
 
       if (mrb_array_p(e) && (level < 0 || depth <= level)) {
+        /* check recursive: e must not be an ancestor on the current path.
+           A bounded level terminates on its own, so only the unbounded
+           walk checks (CRuby does the same). */
+        if (level < 0) {
+          if (mrb_obj_equal(mrb, e, ary)) {
+            mrb_raise(mrb, E_ARGUMENT_ERROR, "tried to flatten recursive array");
+          }
+          for (mrb_int j = 0; j < RARRAY_LEN(stack); j += 3) {
+            if (mrb_obj_equal(mrb, e, RARRAY_PTR(stack)[j])) {
+              mrb_raise(mrb, E_ARGUMENT_ERROR, "tried to flatten recursive array");
+            }
+          }
+        }
         *modified = TRUE;
         // Push current state back
         mrb_ary_push(mrb, stack, ary);

--- a/mrbgems/mruby-array-ext/test/array.rb
+++ b/mrbgems/mruby-array-ext/test/array.rb
@@ -390,6 +390,32 @@ assert("Array#flatten!") do
   assert_equal [1, 2, 3, 4, 5, 6], [1, 2, [3, [4, 5], 6]].flatten!
 end
 
+assert("Array#flatten detects recursion") do
+  a = [1]
+  a << a
+  msg = "tried to flatten recursive array"
+  assert_raise_with_message(ArgumentError, msg) { a.flatten }
+  assert_raise_with_message(ArgumentError, msg) { a.flatten! }
+  # the failed flatten! leaves the receiver as it was
+  assert_equal 2, a.size
+  assert_equal 1, a[0]
+  assert_same a, a[1]
+
+  x = [1]
+  y = [x]
+  x << y
+  assert_raise_with_message(ArgumentError, msg) { x.flatten }
+  assert_raise_with_message(ArgumentError, msg) { x.flatten! }
+  assert_same y, x[1]
+
+  # a level that stops above the cycle leaves it in place
+  assert_equal [1, 1, a], a.flatten(1)
+
+  # the same array under two siblings is not a cycle
+  s = [1, [2]]
+  assert_equal [1, 2, 1, 2], [s, [s]].flatten
+end
+
 assert("Array#compact") do
   a = [1, nil, "2", nil, :t, false, nil]
   assert_equal [1, "2", :t, false], a.compact


### PR DESCRIPTION
## Summary

`Array#flatten` and `Array#flatten!` never notice that the array they are descending into is already on the path, so a self-referencing array keeps descending until the internal stack array hits `MRB_ARY_LENGTH_MAX` and the walk fails with an unrelated "array size too big". This PR makes them raise `ArgumentError` ("tried to flatten recursive array") when the cycle is seen, as CRuby does.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-array-ext/src/array.c` | `flatten_internal()` compares the array it is about to descend into with the current frame and every frame on its stack by identity, and raises on a hit |
| `mrbgems/mruby-array-ext/test/array.rb` | direct and indirect cycles raise; `flatten!` leaves the receiver as it was; a bounded `level` and a shared sibling still pass |

### The check

The walk already keeps its own stack of `(array, index, depth)` frames, so the ancestors on the current path are the arrays at every third slot. The check is the one `Array#join` in `src/array.c` runs before descending: compare the candidate with the current array and with each stacked array by identity. The same array under two siblings is not an ancestor and still flattens.

The check runs only for the unbounded walk. A bounded `level` terminates on its own, and CRuby leaves the cycle in place there too, so `a.flatten(1)` on a self-referencing `a` stays `[1, 1, a]`.

`flatten!` raises before `mrb_ary_replace()` runs, so the receiver is unchanged.

Outside the scope of this PR, `flatten` here expands only arrays; CRuby also expands an element that answers `to_ary`.

## Behaviour

```ruby
a = [1]
a << a
a.flatten          # CRuby: ArgumentError (tried to flatten recursive array), mruby: ArgumentError (array size too big)
x = [1]; y = [x]; x << y
x.flatten          # CRuby: ArgumentError (tried to flatten recursive array), mruby: ArgumentError (array size too big)
a.flatten(1)       # CRuby: [1, 1, [...]], mruby: [1, 1, [...]] (unchanged)
```

With `MRB_ARY_LENGTH_MAX` set to 0 the walk on master runs until memory is exhausted.

## Size

`.text` of `bin/mruby`, ci/gcc-clang builds, gcc 13.3.0:

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| host | 1,309,390 | 1,309,566 | +176 |
| ascii-ctype | 1,387,526 | 1,387,702 | +176 |
| bintest | 1,403,126 | 1,403,302 | +176 |
| byte-string | 1,364,502 | 1,364,678 | +176 |
| cxx_abi | 1,434,969 | 1,435,145 | +176 |
| full-debug (-O0) | 1,999,142 | 1,999,462 | +320 |
| no-bigint | 1,287,286 | 1,287,462 | +176 |
| no-float | 1,328,830 | 1,329,006 | +176 |

The whole delta is the identity loop in `flatten_internal()` in `mruby-array-ext`'s `array.o`.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2778 | 2704 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3010 | 2988 | 22 | 0 | 0 | 0 |
| bintest | 3026 | 3006 | 20 | 0 | 0 | 0 |
| byte-string | 2938 | 2864 | 74 | 0 | 0 | 0 |
| cxx_abi | 3026 | 3006 | 20 | 0 | 0 | 0 |
| full-debug | 3026 | 3015 | 11 | 0 | 0 | 0 |
| no-bigint | 2975 | 2942 | 33 | 0 | 0 | 0 |
| no-float | 2759 | 2662 | 97 | 0 | 0 | 0 |

bintest on the `bintest` build: 147 total, 146 OK, 1 skip, 0 KO.

The new test covers a direct cycle (`a << a`) and an indirect one (`x << [x]`) for both `flatten` and `flatten!` with the exact message, checks that a failed `flatten!` leaves the receiver's elements and self-reference as they were, and pins the two shapes that must keep passing: `flatten(1)` on a cyclic array, and the same array reached through two siblings.

## Environment

<details>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile line for `mrbgems/mruby-array-ext/src/array.c` per build (`-MMD -c`, `-I`, `-o` dropped):

- host

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT mrbgems/mruby-array-ext/src/array.c
  ```

- ascii-ctype

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```

- bintest

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-array-ext/src/array.c
  ```

- byte-string

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```

- cxx_abi

  ```
  gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```

- full-debug

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```

- no-bigint

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```

- no-float

  ```
  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRBGEM_MRUBY_ARRAY_EXT_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-array-ext/src/array.c
  ```


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Array#flatten` now raises `ArgumentError` instead of recursing indefinitely when processing directly or indirectly self-referential arrays.
  * Failed `flatten!` operations preserve the original array.
  * Depth-limited flattening and shared, non-cyclic subarrays retain their existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->