### PR TITLE
class.c: keep the constant `BasicObject` in `Object` so the class can be reopened

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -5027,6 +5027,7 @@ mrb_init_class(mrb_state *mrb)
 
   /* name basic classes */
   mrb_define_const_id(mrb, bob, MRB_SYM(BasicObject), mrb_obj_value(bob));
+  mrb_define_const_id(mrb, obj, MRB_SYM(BasicObject), mrb_obj_value(bob));
   mrb_define_const_id(mrb, obj, MRB_SYM(Object),      mrb_obj_value(obj));
   mrb_define_const_id(mrb, obj, MRB_SYM(Module),      mrb_obj_value(mod));
   mrb_define_const_id(mrb, obj, MRB_SYM(Class),       mrb_obj_value(cls));

--- a/test/t/basicobject.rb
+++ b/test/t/basicobject.rb
@@ -9,6 +9,27 @@ assert('BasicObject superclass') do
   assert_nil(BasicObject.superclass)
 end
 
+assert('BasicObject reopened at the top level is the class Object inherits from') do
+  # `class BasicObject` at the top level asks `Object` whether it holds the
+  # constant and, told it does not, makes a new class under `Object` by that
+  # name. The constant is kept in `Object` as well as in `BasicObject`
+  # itself, as CRuby keeps it, so the reopening reaches every object.
+  reopened = class BasicObject
+    def basic_object_reopen_probe; :reopened; end
+    self
+  end
+  begin
+    assert_same(Object.superclass, reopened)
+    assert_nil(reopened.superclass)
+    assert_equal(:reopened, nil.basic_object_reopen_probe)
+    assert_equal(:reopened, Class.new(BasicObject).new.basic_object_reopen_probe)
+  ensure
+    class BasicObject
+      undef_method :basic_object_reopen_probe
+    end
+  end
+end
+
 assert('BasicObject#== defined by a class is asked about the receiver itself') do
   # `OP_EQ` answers `obj == obj` from the identity of its operands, which it
   # may only do while the builtin `==` is what would be asked: CRuby's `opt_eq`


### PR DESCRIPTION
## Summary

`class BasicObject` at the top level made a new class under `Object` instead of reopening the class `Object` inherits from, because the constant `BasicObject` was bound in `BasicObject` itself and nowhere else. `mrb_init_class()` now binds it in `Object` as well, as CRuby does.

## Changes

| File                    | What                                                                                                               |
| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
| `src/class.c`           | `mrb_init_class()` binds the constant `BasicObject` in `Object` too, one `mrb_define_const_id()`                   |
| `test/t/basicobject.rb` | a test that the reopened class is `Object.superclass` and that a method written there reaches `nil` and a subclass |

### Where the new class came from

`mrb_vm_define_class()` asks the scope the statement is written in, `Object` at the top level, whether it holds the constant, through `mrb_obj_iv_defined()`, which reads that one object. Reading a constant walks the ancestors, so `BasicObject` as an expression found the one in `BasicObject`, while the class statement did not, made a class by that name under `Object`, and bound the constant there. From then on the name answered the new class: a method written in the body reached nothing that existed already, `BasicObject.superclass` was `Object`, and `BasicObject.instance_methods(false)` listed the new method alone. The original class and its eight methods were untouched.

CRuby's `boot_defclass()` binds the name in the class itself while `Object` does not exist yet, and `Init_class_hierarchy()` binds it in `Object` once it does, so both `Object.constants(false)` and `BasicObject.constants(false)` hold it. This PR leaves the one in `BasicObject` and adds the one in `Object`.

## Behaviour

```ruby
class BasicObject; def foo; "FOO"; end; end
BasicObject.superclass                 # CRuby: nil, mruby: Object
BasicObject.equal?(Object.superclass)  # CRuby: true, mruby: false
nil.respond_to?(:foo)                  # CRuby: true, mruby: false
```

This PR answers as CRuby does in all three. A `==` written in a reopened `BasicObject` now sets `MRB_FL_CLASS_EQ_DEFINED` on the class every other class inherits from, as one written in `Object` or `Kernel` already did.

## Size

`.text` of `bin/mruby` for the seven `build_config/ci/gcc-clang.rb` builds, `CC=gcc`, master `f4ebd89e6`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| bintest          | 1,403,126 | 1,403,142 |   +16 |
| ascii-ctype      | 1,387,526 | 1,387,542 |   +16 |
| byte-string      | 1,364,502 | 1,364,518 |   +16 |
| cxx_abi          | 1,434,969 | 1,434,985 |   +16 |
| no-float         | 1,328,830 | 1,328,846 |   +16 |
| no-bigint        | 1,287,286 | 1,287,302 |   +16 |
| full-debug (-O0) | 1,999,142 | 1,999,174 |   +32 |

The one added call sits in `mrb_init_class()` in `class.o`.

## Testing

| Build                            | Total |    OK | Skip |  KO | Crash | Warning |
| -------------------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`build_config/default.rb`) | 2,778 | 2,704 |   74 |   0 |     0 |       0 |
| bintest                          | 3,026 | 3,006 |   20 |   0 |     0 |       0 |
| ascii-ctype                      | 3,010 | 2,988 |   22 |   0 |     0 |       0 |
| byte-string                      | 2,938 | 2,864 |   74 |   0 |     0 |       0 |
| cxx_abi                          | 3,026 | 3,006 |   20 |   0 |     0 |       0 |
| no-float                         | 2,759 | 2,662 |   97 |   0 |     0 |       0 |
| no-bigint                        | 2,975 | 2,942 |   33 |   0 |     0 |       0 |
| full-debug                       | 3,026 | 3,015 |   11 |   0 |     0 |       0 |

bintest passes (147 examples, KO 0). With the test on master, the host mrbtest reports it as KO (2,778 tests, KO 1): `nil` does not respond to the method written in the reopened class. Every build above gains the same 1 test over master with no other change in its counts.

## Environment

<details>
<summary>Host, toolchain and the compile lines of each build</summary>

| Item     | Value                                                  |
| -------- | ------------------------------------------------------ |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0 x86_64                 |
| CPU      | AMD Ryzen 9 5950X                                      |
| C        | gcc 13.3.0 (`CC=gcc`)                                  |
| C++      | `gcc -x c++ -std=gnu++03` (g++ 13.3.0 links `cxx_abi`) |
| binutils | GNU ld 2.47                                            |
| CRuby    | ruby 4.0.6 (reference answers)                         |

```console
# host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK "src/string.c"
# full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "src/string.c"
# cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
# no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="/home/takumi/.usr/src/github.com/takumin/mruby/.claude/worktrees/parsed-hugging-ritchie=." -ffile-prefix-map="build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the `BasicObject` class through the top-level `BasicObject` constant.
  * Existing and newly created objects now reflect changes made through this constant.

* **Tests**
  * Added coverage for resolving, reopening, and cleaning up the top-level `BasicObject` constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->