### PR TITLE
mruby-compiler: let a private setter be called on a written self

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -2253,7 +2253,15 @@ gen_assignment(mrc_codegen_scope *s, mrc_node *tree, mrc_node *rhs, int sp, int 
     case PM_CALL_TARGET_NODE:
     {
       CAST(call_target);
-      codegen(s, cast->receiver, VAL);
+      /* a written `self` is a call on self, so OP_SSEND, which fills the
+         receiver register itself */
+      int noself = nint(cast->receiver) == PM_SELF_NODE;
+      if (noself) {
+        push();
+      }
+      else {
+        codegen(s, cast->receiver, VAL);
+      }
       /* the value to assign lives in sp (set by the caller for multiple
          assignment) and goes in the register after the receiver, which the
          `aset` arm above reserves the same way: the OP_SEND below reads its
@@ -2263,7 +2271,7 @@ gen_assignment(mrc_codegen_scope *s, mrc_node *tree, mrc_node *rhs, int sp, int 
       push();  /* reserve the value register so nregs accounts for it */
       push(); pop();  /* touch block slot so nregs covers the OP_SEND */
       pop_n(2);
-      genop_3(s, OP_SEND, cursp(), new_sym(s, cast->name), 1);
+      genop_3(s, noself ? OP_SSEND : OP_SEND, cursp(), new_sym(s, cast->name), 1);
       break;
     }
     default:
@@ -2458,11 +2466,22 @@ gen_call_assign(mrc_codegen_scope *s, mrc_node *tree, int val, int safe, int rec
     push();                    /* room for retval */
     callsp = cursp();
 
-    /* receiver (an attribute write always has an explicit receiver; an
-       explicit `self` must be materialized so OP_SETIDX can read it) */
+    /* receiver: a written `self` is a call on self, which OP_SSEND makes
+       so that a private setter is reachable as in CRuby; the register is
+       still loaded where an instruction reads it before the send, that
+       is for OP_SETIDX and for the `&.` nil check */
     if (cast->receiver == NULL) {
       noself = 1;
       push();
+    }
+    else if (nint(cast->receiver) == PM_SELF_NODE) {
+      noself = 1;
+      if (opt_op || safe) {
+        codegen(s, cast->receiver, VAL);
+      }
+      else {
+        push();
+      }
     }
     else {
       codegen(s, cast->receiver, VAL);
@@ -5024,6 +5043,10 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       int base;
       int idx, vsp = -1;
+      /* a written `self` is a call on self for both the read and the
+         write, so a private accessor is reachable as in CRuby; the
+         receiver is still loaded for the `&.` nil check and the copy */
+      int op_send = (nint(receiver) == PM_SELF_NODE) ? OP_SSEND : OP_SEND;
       if (val) {
         vsp = cursp();
         push();
@@ -5040,7 +5063,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       /* copy receiver and arguments */
       gen_move(s, cursp(), base, 1);
       push_n(2); pop_n(2); /* space for receiver, arguments and a block */
-      genop_3(s, OP_SEND, cursp(), idx, 0);
+      genop_3(s, op_send, cursp(), idx, 0);
 
       if (-1 != (int32_t)binary_operator) {
         push();
@@ -5064,7 +5087,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       pop();
       idx = new_sym(s, write_name);
-      genop_3(s, OP_SEND, cursp(), idx, 1);
+      genop_3(s, op_send, cursp(), idx, 1);
       if (0 < pos) { dispatch(s, pos); }
       if (safe) { dispatch(s, skip); }
       break;

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -2572,7 +2572,14 @@ gen_call(mrc_codegen_scope *s, mrc_node *tree, int val, int safe, int recv_ready
   }
   else if (nint(cast->receiver) == PM_SELF_NODE) {
     noself = noop = 1;
-    push();
+    /* OP_SSEND fills the receiver register itself; only the nil check of
+       `self&.m` reads it before then, so it is loaded for that */
+    if (safe) {
+      codegen(s, cast->receiver, VAL);
+    }
+    else {
+      push();
+    }
   }
   else {
     codegen(s, cast->receiver, VAL); /* receiver */

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -266,6 +266,23 @@ assert('safe navigation operator-assignment short-circuits on nil') do
   assert_equal 7, d.x
 end
 
+class SelfSafeCall
+  def y(*); :called; end
+  # `[nil].first` leaves nil in the first temporary register, which is
+  # the one the nil check of the call below reads when the receiver is
+  # not loaded; a receiver written as `self` is never nil
+  def bare;  [nil].first; self&.y;     end
+  def args;  [nil].first; self&.y(1);  end
+  def value; [nil].first; x = self&.y; x; end
+end
+
+assert('a safe navigation call on a written self is made') do
+  o = SelfSafeCall.new
+  assert_equal :called, o.bare
+  assert_equal :called, o.args
+  assert_equal :called, o.value
+end
+
 assert('local variable or/and-assignment yields its value') do
   # gen_assignment_lvar() only moves, so the local-variable branch has to push
   # the result the way the other branches do. Without it the expression yields

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -2623,3 +2623,51 @@ assert('pattern matching - a deconstruction hook has to answer a Hash') do
   end.new
   assert_true((good in {a: 1}))
 end
+
+class SelfAttrWrite
+  def plain;    self.a = 1;             @a;       end
+  def value;    x = (self.a = 1);       [x, @a];  end
+  def opasgn;   @c = 1; self.c += 1;    @c;       end
+  def orasgn;   @c = nil; self.c ||= 5; @c;       end
+  def andasgn;  @c = 1; self.c &&= 6;   @c;       end
+  def multi;    self.a, self.b = 1, 2;  [@a, @b]; end
+  def safe;     self&.a = 3;            @a;       end
+  def safe_op;  @c = 1; self&.c += 3;   @c;       end
+  def index;    self[0] = 9;            @i;       end
+  def index3;   self[0, 1] = 7;         @i;       end
+  def aliased;  x = self; x.a = 1;      @a;       end
+
+  private
+  attr_writer :a, :b
+  attr_accessor :c
+  def []=(i, j = nil, v); @i = v; end
+end
+
+assert('a private setter is callable on a written self') do
+  o = SelfAttrWrite.new
+  # the forms CRuby exempts: an attribute write whose receiver is the
+  # literal `self`, as a statement or a value, in the op-assign,
+  # multiple, safe and index forms too
+  assert_equal 1, o.plain
+  assert_equal [1, 1], o.value
+  assert_equal 2, o.opasgn
+  assert_equal 5, o.orasgn
+  assert_equal 6, o.andasgn
+  assert_equal [1, 2], o.multi
+  assert_equal 3, o.safe
+  assert_equal 4, o.safe_op
+  assert_equal 9, o.index
+  assert_equal 7, o.index3
+
+  # only the literal `self` is exempt: a local holding self is not, and
+  # neither is a call from outside
+  assert_raise_with_message_pattern(NoMethodError, "private method 'a=' called for SelfAttrWrite") do
+    o.aliased
+  end
+  assert_raise_with_message_pattern(NoMethodError, "private method 'a=' called for SelfAttrWrite") do
+    o.a = 1
+  end
+  assert_raise_with_message_pattern(NoMethodError, "private method 'c' called for SelfAttrWrite") do
+    o.c
+  end
+end


### PR DESCRIPTION
## Summary

A private setter written to through `self` was refused: an attribute write, an operator write and a multiple assignment loaded `self` as a receiver and sent to it as to any object, so the VM's private check turned them down, while a plain call on a written `self` had always been compiled as a call on self. The three sites now choose OP_SSEND for a written `self` the way the plain call does. On the way, the nil check of `self&.m` read the receiver register before OP_SSEND had filled it, so whether the call was made depended on a leftover value; the receiver is loaded for that check.

## Changes

| File                                   | What                                                                                                                                                      |
| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | `gen_call()`: load `self` when the call is `self&.m`; `gen_call_assign()`, the `PM_CALL_TARGET_NODE` arm and the `call_*_write` case: OP_SSEND for `self` |
| `test/t/syntax.rb`                     | `self&.m` with a nil left in the register; every write form on a written `self` against a private target, and the forms that stay refused                 |

### Why the compiler and not the VM

CRuby's exemption is for a receiver written as `self`, not for a receiver that is self: `x = self; x.a = 1` is refused. The VM sees only the value in the register, so it cannot tell the two apart; the compiler can, and it already has OP_SSEND for a call on self, which the private check lets through. The change is one of instruction selection, with nothing added to the send path.

### The register a written `self` leaves behind

A call on a written `self` does not load the receiver, because OP_SSEND copies `self` into the receiver register itself. Two instructions read that register before the send: OP_SETIDX, for `self[i] = v`, and the OP_JMPNIL of `&.`. `gen_call_assign()` already loaded `self` for the first; both it and `gen_call()` now load it for the second, and leave the register alone otherwise.

## Behaviour

```ruby
class C
  def initialize; self.a = 1; end   # CRuby: 1, mruby: NoMethodError: private method 'a=' called for C
  private
  attr_writer :a
end

class D
  def bump; self.n += 1; end        # CRuby: 1, mruby: NoMethodError: private method 'n' called for D
  private
  attr_accessor :n
  def initialize; @n = 0; end
end

def f; [nil].first; self&.to_s; end
f  # CRuby: "main", mruby: nil
```

A local holding `self`, and a call from outside, are still refused as in CRuby. `self[i] = v` on a private `[]=` was already accepted, by OP_SETIDX, and is unchanged.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,999,142 | 1,999,382 | +240  |
| bintest          | 1,403,126 | 1,403,494 | +368  |
| cxx_abi          | 1,434,969 | 1,435,337 | +368  |
| byte-string      | 1,364,502 | 1,364,870 | +368  |
| ascii-ctype      | 1,387,526 | 1,387,894 | +368  |
| no-float         | 1,328,830 | 1,329,230 | +400  |
| no-bigint        | 1,287,286 | 1,287,654 | +368  |

All of it is in `codegen.o`: `gen_call()`, which has `gen_call_assign()` inlined into it, grows by 230 bytes for the two receiver branches, and `gen_assignment()` by 112 for the OP_SSEND arm of the multiple assignment. No function changed its inlining.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2779  | 2705 | 74   | 0   | 0     | 0       |
| full-debug  | 3027  | 3016 | 11   | 0   | 0     | 0       |
| bintest     | 3027  | 3007 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3027  | 3007 | 20   | 0   | 0     | 0       |
| byte-string | 2939  | 2865 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3011  | 2989 | 22   | 0   | 0     | 0       |
| no-float    | 2760  | 2663 | 97   | 0   | 0     | 0       |
| no-bigint   | 2976  | 2943 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 0 KO.

The first test leaves a nil in the temporary register with `[nil].first` and then calls `self&.y` bare, with an argument and as a value; on master all three answer nil. The second writes to a private setter through `self` as a statement, as a value, with `+=`, `||=` and `&&=`, in a multiple assignment, with `&.`, and with `[]=` for one and two indices, and checks that a local holding `self` and a call from outside are still refused; on master the value, operator, multiple and `&.` forms fail. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch mrbgems/mruby-compiler/src/codegen.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calls explicitly targeting `self` so private methods, setters, accessors, and compound assignments behave consistently with Ruby semantics.
  * Corrected safe-navigation calls using `self` to avoid incorrect nil handling.
  * Ensured indexed and attribute assignment forms correctly recognize an explicit `self` receiver.

* **Tests**
  * Added coverage for self-targeted calls, private writers, safe navigation, compound assignments, and indexed assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->