### PR TITLE
build: drop the config file from the prerequisites of every object

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -566,6 +566,10 @@ they are while the gems named before it do, and a gem added at the end of
 the config leaves every object of the others as it was. `src/symbol.c`,
 which carries the table, is the one object that follows the whole config.
 
+An edit to the config file alone rebuilds nothing by itself: an object is
+compiled again when its flags change, which the build compares against a
+record kept beside it, or when a source or header it read does.
+
 To write the two names yourself:
 
 ```ruby

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -451,9 +451,15 @@ module MRuby
 
     protected
 
-    # The prerequisites of an output besides its source: the config file and
-    # the headers the last compile of it read. Protected, not private, so the
-    # rules one compiler defines can ask the compiler they run.
+    # The prerequisites of an output besides its source: the headers the last
+    # compile of it read. Protected, not private, so the rules one compiler
+    # defines can ask the compiler they run.
+    #
+    # The config file is not among them. What it decides reaches a compile
+    # through the flags, which +discard_foreign_output+ compares, and through
+    # the sources and headers, which are prerequisites of their own; its
+    # mtime would only compile everything again after an edit that changed
+    # none of that, a gem added for another build or a comment.
     #
     # === Example of +.d+ file
     #
@@ -486,7 +492,7 @@ module MRuby
     #
     def get_dependencies(file, source)
       discard_foreign_output(file) if rule_applies?(source)
-      deps = [MRUBY_CONFIG]
+      deps = []
       dep_file = file.ext(".d")
       return deps unless File.exist?(dep_file)
 
@@ -614,11 +620,12 @@ module MRuby
     # so that the rule that would have found it up to date builds it again.
     #
     # Nothing else in the build tells the two apart. A +.d+ file lists header
-    # dependencies only, and the config file is a dependency by path, so its
-    # mtime does not move when another config takes over the same build
-    # directory. Left uncompared, the output stays up to date against every
-    # dependency it has, and the build silently keeps the flags of whichever
-    # config wrote it first, its defines above all.
+    # dependencies only, and the config file is no dependency at all (see
+    # +get_dependencies+); even as one by path, its mtime would not move when
+    # another config takes over the same build directory. Left uncompared,
+    # the output stays up to date against every dependency it has, and the
+    # build silently keeps the flags of whichever config wrote it first, its
+    # defines above all.
     #
     # An output with no record at all counts as foreign too, since what
     # produced it is unknown.

--- a/lib/mruby/presym.rb
+++ b/lib/mruby/presym.rb
@@ -107,6 +107,18 @@ module MRuby
       File.binwrite(list_path, presyms.join("\n") << "\n")
     end
 
+    # Whether the layers the list was last made from are these. The list is
+    # remade from the preprocessed files that are newer than it, which says
+    # nothing about a file that left the build (a gem taken out of the
+    # config) or about a layer that moved, and both change the numbers.
+    def layers_changed?(layers)
+      !File.exist?(layers_path) || File.binread(layers_path) != layers_record(layers)
+    end
+
+    def write_layers(layers)
+      File.binwrite(layers_path, layers_record(layers))
+    end
+
     # The numbers, as macros, or as the enumerators of `enum mruby_presym`
     # under `MRB_PRESYM_ENUM`.
     #
@@ -187,6 +199,10 @@ module MRuby
       @list_path ||= "#{@build.build_dir}/presym".freeze
     end
 
+    def layers_path
+      @layers_path ||= "#{list_path}.layers".freeze
+    end
+
     def header_dir
       @header_dir ||= "#{@build.build_dir}/include/mruby/presym".freeze
     end
@@ -204,6 +220,10 @@ module MRuby
     end
 
     private
+
+    def layers_record(layers)
+      layers.map {|paths| paths.join("\n") << "\n"}.join("\n")
+    end
 
     def read_preprocessed(presym_hash, path)
       File.binread(path).scan(/<@! (.*?) !@>/) do |part,|

--- a/tasks/presym.rake
+++ b/tasks/presym.rake
@@ -67,13 +67,16 @@ MRuby.each_target do |build|
         presym.send("write_#{type}_header", presyms)
       end
     end
+    presym.write_layers(layers)
   end
 
   # The list is the file of the task above, so Rake runs it only when a
   # preprocessed file is newer than the list. The headers are made from the
-  # list, so a header that is gone needs the task too, with the list as it is.
+  # list, so a header that is gone needs the task too, with the list as it
+  # is; and so do layers other than the ones the list was made from, since
+  # a file that left the build or a layer that moved is newer than nothing.
   presym_task.define_singleton_method :needed? do
-    super() || !presym.headers_exist?
+    super() || !presym.headers_exist? || presym.layers_changed?(layers)
   end
 
   # Don't directly write dependency tasks in the "task" arguments.


### PR DESCRIPTION
## Summary

Drops the config file from the prerequisites of every object, so that an edit to the config that changes neither the flags nor a source compiles nothing again. The presym list records the layers it was made from and is remade when they differ, which covers a gem taken out of the config. Builds on the layered presym numbering of #7554.

## Changes

| File                         | What                                                                                           |
| ---------------------------- | ---------------------------------------------------------------------------------------------- |
| `lib/mruby/build/command.rb` | `get_dependencies` no longer lists `MRUBY_CONFIG`                                              |
| `lib/mruby/presym.rb`        | `layers_changed?`, `write_layers`; the record beside the list (`build/<target>/presym.layers`) |
| `tasks/presym.rake`          | writes the record; the list task is needed when the layers differ                              |
| `doc/guides/compile.md`      | what an edit to the config rebuilds                                                            |

### What a config decides reaches a compile some other way

What a config decides reaches a compile through the flags, which the record beside each output already compares (`discard_foreign_output`), and through the sources and headers, which are dependencies of their own. An edit to the config that changes neither compiles nothing again and does not rerun the presym scan over every source. The gem loader's generated source keeps the config as a dependency by design.

### The presym list needs its own record

The list is remade from the preprocessed files that are newer than it, which says nothing about a file that left the build (a gem taken out of the config) or a layer that moved. With the config among every object's prerequisites an edit to it regenerated every preprocessed file and so the list; without it nothing would. The list therefore records the layers it was made from and the task runs when they differ.

## Behaviour

- Touching the config file compiles the gem loader alone (`rake --verbose`: one compile, `mrbgems/gem_init.c`); touching `src/array.c` preprocesses and compiles `array.c` alone (one `-E`, one compile).
- Taking a gem out of the config remakes the presym list: the default config, then the same config plus `mruby-os-memsize` and `mruby-string-bitops` in the same build directory (1,599 to 1,616 presyms), then the default config again reproduces the original list byte for byte, and mrbtest passes on the result.

## Testing

`build/host/bin/mrbtest`, `CC=gcc`:

| Build                 | Total | OK    | Skip | KO  | Crash | Warning |
| --------------------- | ----- | ----- | ---- | --- | ----- | ------- |
| host (default config) | 2,784 | 2,710 | 74   | 0   | 0     | 0       |

bintest: host 130 (129 OK, 1 skip). The behaviours above were checked with `rake --verbose` after each edit in the same build directory.

## Environment

<details>

|          |                                         |
| -------- | --------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                      |
| Kernel   | 7.0.0-31-generic                        |
| CPU      | AMD Ryzen 9 5950X                       |
| gcc      | 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | 2.47.20260726                           |
| CRuby    | 4.0.6                                   |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rebuild decisions now accurately reflect recorded compiler flags and source or header changes.
  - Presym lists are regenerated when build layers are added, removed, or reordered.

- **Documentation**
  - Clarified when changes to build configuration trigger recompilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->