### PR TITLE
mruby-compiler: bind a pattern capture to a local of an enclosing scope

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1974,6 +1974,15 @@ gen_assignment_lvar(mrc_codegen_scope *s, int sp, mrc_sym name, int depth, int v
   }
 }
 
+/* Bind what a pattern captured to the local its target names.  Prism records
+   how many scopes up that local lives, so a capture inside a block reaches a
+   local of the enclosing scope the way an assignment does. */
+static void
+gen_pattern_bind(mrc_codegen_scope *s, pm_local_variable_target_node_t *var, int src)
+{
+  gen_assignment_lvar(s, src, var->name, var->depth + s->for_depth, 1);
+}
+
 /* Load the anonymous forwarding variable `sym` (one of `*`, `**`, `&`) into
    cursp(). When `...` is forwarded from inside a block the variable lives in
    an enclosing method scope, so fall back to an upvar load instead of asserting
@@ -2866,11 +2875,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
   case PM_LOCAL_VARIABLE_TARGET_NODE:
     {
       CAST3(local_variable_target, pattern, var_target);
-      /* Bind the matched value to the variable */
-      int idx = lv_idx(s, var_target->name);
-      if (idx > 0) {
-        gen_move(s, idx, target, 1);  /* nopeep=1 to prevent optimization */
-      }
+      gen_pattern_bind(s, var_target, target);
       /* Variable pattern always matches */
     }
     break;
@@ -2938,10 +2943,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       codegen_pattern(s, (mrc_node *)pat_as->value, target, fail_pos, known_array_len);
       /* Then bind the value to the variable */
       CAST3(local_variable_target, pat_as->target, var_target);
-      int idx = lv_idx(s, var_target->name);
-      if (idx > 0) {
-        gen_move(s, idx, target, 0);
-      }
+      gen_pattern_bind(s, var_target, target);
     }
     break;
 
@@ -3020,7 +3022,6 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           pm_splat_node_t *splat = (pm_splat_node_t *)pat_arr->rest;
           if (splat->expression && nint(splat->expression) == PM_LOCAL_VARIABLE_TARGET_NODE) {
             pm_local_variable_target_node_t *rest_var = (pm_local_variable_target_node_t *)splat->expression;
-            int var_idx = lv_idx(s, rest_var->name);
             /* Generate: arr[pre_len..-(post_len+1)] or arr[pre_len..-1] if no post */
             int sp_save = cursp();
             gen_move(s, cursp(), arr_reg, 0);
@@ -3038,9 +3039,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             push(); pop();  /* touch block slot */
             s->sp = sp_save;
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);
-            if (var_idx > 0) {
-              gen_move(s, var_idx, cursp(), 1);
-            }
+            gen_pattern_bind(s, rest_var, cursp());
           }
         }
 
@@ -3102,7 +3101,6 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           pm_splat_node_t *splat = (pm_splat_node_t *)pat_arr->rest;
           if (splat->expression && nint(splat->expression) == PM_LOCAL_VARIABLE_TARGET_NODE) {
             pm_local_variable_target_node_t *rest_var = (pm_local_variable_target_node_t *)splat->expression;
-            int var_idx = lv_idx(s, rest_var->name);
             int sp_save = cursp();
             gen_move(s, cursp(), arr_reg, 0);
             push();
@@ -3119,9 +3117,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             s->sp = sp_save;
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);
             /* Result at R[sp_save] */
-            if (var_idx > 0) {
-              gen_move(s, var_idx, cursp(), 1);
-            }
+            gen_pattern_bind(s, rest_var, cursp());
           }
         }
 
@@ -3240,21 +3236,10 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             s->sp = val_reg;
             genop_3(s, OP_SEND, val_reg, new_sym(s, MRC_OPSYM_2(aref)), 1);
 
-            if (assoc->value) {
-              push(); /* keep the value below cursp() for the sub-pattern */
-              codegen_pattern(s, (mrc_node *)assoc->value, val_reg, fail_pos, -1);
-            }
-            else {
-              /* Shorthand form {a:} - bind to variable with same name as key */
-              if (nint(assoc->key) == PM_SYMBOL_NODE) {
-                pm_symbol_node_t *sym_node = (pm_symbol_node_t *)assoc->key;
-                mrc_sym var_name = nsym(s->c->p, sym_node->unescaped.source, sym_node->unescaped.length);
-                int idx = lv_idx(s, var_name);
-                if (idx > 0) {
-                  gen_move(s, idx, val_reg, 1);
-                }
-              }
-            }
+            /* Prism gives the shorthand `{a:}` an implicit local target
+               as its value, so there is always a sub-pattern to match. */
+            push(); /* keep the value below cursp() for the sub-pattern */
+            codegen_pattern(s, (mrc_node *)assoc->value, val_reg, fail_pos, -1);
             s->sp = loop_sp;
             key_idx++;
           }
@@ -3280,8 +3265,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           /* Named **var: capture remaining keys via hash.__except(keys_array) */
           if (splat->value && nint(splat->value) == PM_LOCAL_VARIABLE_TARGET_NODE) {
             pm_local_variable_target_node_t *rest_var = (pm_local_variable_target_node_t *)splat->value;
-            int var_idx = lv_idx(s, rest_var->name);
-            if (var_idx > 0) {
+            {
               int recv = cursp();
               gen_move(s, recv, hash_reg, 0);
               push(); /* protect receiver */
@@ -3306,7 +3290,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
                 s->sp = recv;
                 genop_3(s, OP_SEND, recv, new_sym(s, MRC_SYM_1(dup)), 0);
               }
-              gen_move(s, var_idx, recv, 1);
+              gen_pattern_bind(s, rest_var, recv);
             }
           }
           /* Anonymous **: do nothing */
@@ -3399,8 +3383,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             nint(pre_splat->expression) == PM_LOCAL_VARIABLE_TARGET_NODE) {
           pm_local_variable_target_node_t *pre_var =
               (pm_local_variable_target_node_t *)pre_splat->expression;
-          int var_idx = lv_idx(s, pre_var->name);
-          if (var_idx > 0) {
+          {
             /* pre = arr[0...idx] */
             gen_move(s, cursp(), arr_reg, 0);
             push();
@@ -3411,7 +3394,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             genop_1(s, OP_RANGE_EXC, cursp() - 1);
             pop(); pop();
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);
-            gen_move(s, var_idx, cursp(), 1);
+            gen_pattern_bind(s, pre_var, cursp());
           }
         }
       }
@@ -3422,8 +3405,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             nint(post_splat->expression) == PM_LOCAL_VARIABLE_TARGET_NODE) {
           pm_local_variable_target_node_t *post_var =
               (pm_local_variable_target_node_t *)post_splat->expression;
-          int var_idx = lv_idx(s, post_var->name);
-          if (var_idx > 0) {
+          {
             /* post = arr[(idx+elems_len)..-1] */
             gen_move(s, cursp(), arr_reg, 0);
             push();
@@ -3436,7 +3418,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
             genop_1(s, OP_RANGE_INC, cursp() - 1);
             pop(); pop();
             genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_OPSYM_2(aref)), 1);
-            gen_move(s, var_idx, cursp(), 1);
+            gen_pattern_bind(s, post_var, cursp());
           }
         }
       }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1518,6 +1518,60 @@ assert('pattern matching - a clause that names `**rest` keeps its own value') do
   assert_equal [1, {b: 2, c: 3}, 2, {a: 1, c: 3}], r
 end
 
+assert('pattern matching - a capture in a block binds the local of the enclosing scope') do
+  # A capture looked its variable up in the scope of the block alone and
+  # bound nothing when the local lived outside it, so the block left the
+  # outer local as it was.
+  v = w = r = pre = post = h = nil
+  f = ->(x) {
+    x => [v]
+    x => [Integer => w]
+    x => [*r]
+    x => [*pre, 1, *post]
+    {k: 2} => {k: h}
+  }
+  f.call([1])
+  assert_equal [1, 1, [1], [], [], 2], [v, w, r, pre, post, h]
+
+  k = rest = nil
+  [{k: 3, m: 4}].each { |x| x => {k:, **rest} }
+  assert_equal [3, {m: 4}], [k, rest]
+
+  # a `case` in a block
+  a = nil
+  [[5, 6]].each do |x|
+    case x
+    in [_, a] then nil
+    end
+  end
+  assert_equal 6, a
+
+  # the local of an enclosing block, two scopes up
+  z = nil
+  [1].each { [[7]].each { |y| y => [z] } }
+  assert_equal 7, z
+
+  # a `for` body is not a scope of its own, and a block inside it is
+  b = c = nil
+  for x in [[8]]
+    x => [b]
+    [x].each { x => [c] }
+  end
+  assert_equal [8, 8], [b, c]
+
+  # an array literal subject takes the path that knows its length
+  r = nil
+  [3].each do |x|
+    case [x, x]
+    in [*r] then nil
+    end
+  end
+  assert_equal [3, 3], r
+
+  # a local of the block's own scope is bound as before
+  assert_equal [9], [[9]].map { |x| x => [q]; q }
+end
+
 assert('pattern matching - value patterns as a hash value') do
   # a value pattern is the receiver of `===`, the hash value its argument
   case {a: 1}


### PR DESCRIPTION
## Summary

A pattern capture looked its variable up in the scope of the pattern alone and bound nothing when the local lived in an enclosing scope, so a pattern in a block left the outer local as it was. Every capture now binds through the depth Prism records for its target, which is how an assignment reaches such a local.

## Changes

| File                                   | What                                                                                                                     |
| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| `mrbgems/mruby-compiler/src/codegen.c` | route the seven capture sites of `codegen_pattern()` through `gen_pattern_bind()`, drop the unreachable shorthand branch |
| `test/t/syntax.rb`                     | every capture form in a lambda, a block, a nested block and a `for` body                                                 |

### Where the binding went

Each capture site of `codegen_pattern()` asked `lv_idx()` for the register of its variable and skipped the move when the answer was 0, which is what `lv_idx()` answers for a local of any enclosing scope. Prism marks every `LocalVariableTargetNode` with the depth of the scope that owns the local, and `gen_assignment_lvar()` already turns that depth into a move or an `OP_SETUPVAR`. `gen_pattern_bind()` hands the target's name and depth to it, with the `for_depth` correction that `gen_assignment()` applies for a `for` body. The three rest captures that computed their slice only when `lv_idx()` answered no longer test for it, since a named rest always has a local to land in.

### The shorthand branch

The hash pattern had a second binding for a shorthand key whose assoc carries no value. Prism never builds one: `{a:}` gets an `ImplicitNode` around a `LocalVariableTargetNode` for its value, and a non-symbol key with no value is a syntax error, so the branch was never taken and goes.

## Behaviour

```ruby
a = nil
[[1]].each { |x| x => [a] }
a  # CRuby: 1, mruby: nil

k = rest = nil
[{k: 3, m: 4}].each { |x| x => {k:, **rest} }
[k, rest]  # CRuby: [3, {m: 4}], mruby: [nil, nil]

z = nil
[1].each { [[7]].each { |y| y => [z] } }
z  # CRuby: 7, mruby: nil
```

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,999,926 | 1,999,446 | -480  |
| bintest          | 1,403,574 | 1,403,046 | -528  |
| cxx_abi          | 1,435,481 | 1,434,905 | -576  |
| byte-string      | 1,364,950 | 1,364,422 | -528  |
| ascii-ctype      | 1,387,974 | 1,387,446 | -528  |
| no-float         | 1,329,310 | 1,328,766 | -544  |
| no-bigint        | 1,287,670 | 1,287,142 | -528  |

The seven `lv_idx()` walks and their guards in `codegen_pattern()` become calls to one helper, and the shorthand branch with its `nsym()` call goes.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2785  | 2711 | 74   | 0   | 0     | 0       |
| full-debug  | 3033  | 3022 | 11   | 0   | 0     | 0       |
| bintest     | 3033  | 3013 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3033  | 3013 | 20   | 0   | 0     | 0       |
| byte-string | 2945  | 2871 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3017  | 2995 | 22   | 0   | 0     | 0       |
| no-float    | 2766  | 2669 | 97   | 0   | 0     | 0       |
| no-bigint   | 2982  | 2949 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 1 skip, 0 KO.

The new test binds a plain variable, `=> var`, `*rest`, both rests of a find pattern, a hash value and `**rest` from inside a lambda, a `case` inside a block, a local two blocks up, and a `for` body with and without a block in it, the rest of an array literal subject whose length the compiler knows, and checks that a local of the block's own scope still binds. On master the host build fails at the first assertion. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch mrbgems/mruby-compiler/src/codegen.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pattern-matching captures inside blocks so they correctly bind to local variables from enclosing scopes.
  - Corrected captures in nested blocks, `case/in`, `for`, array-rest, hash-rest, and find patterns.
  - Fixed hash pattern shorthand such as `{a:}` so captured values are matched consistently.
- **Tests**
  - Added regression coverage for pattern matching across nested and enclosing scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->