### PR TITLE
mruby-compiler: keep what deconstruct answered across the clauses of a case

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1835,7 +1835,7 @@ mrc_generate_code(mrc_ccontext *c, mrc_node *node)
 static void gen_massignment(mrc_codegen_scope *s, mrc_node *tree, int rhs, int val);
 static void gen_lvar(mrc_codegen_scope *s, mrc_sym name, int depth);
 static void codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target,
-                            uint32_t *fail_pos, int known_array_len);
+                            uint32_t *fail_pos, int known_array_len, int cache);
 
 static mrc_sym
 nsym(mrc_parser_state *p, const uint8_t *start, size_t length)
@@ -2751,7 +2751,7 @@ gen_pattern_eqq(mrc_codegen_scope *s, mrc_node *value, int target, uint32_t *fai
    before it sends, so a subject with no deconstruction hook simply does not
    match, the way CRuby has it, rather than raising NoMethodError. */
 static void
-gen_pattern_respond_to(mrc_codegen_scope *s, int target, mrc_sym mid, uint32_t *fail_pos)
+gen_pattern_respond_to(mrc_codegen_scope *s, int target, mrc_sym mid, uint32_t *fail_pos, int cache)
 {
   int reg = cursp();
 
@@ -2762,16 +2762,87 @@ gen_pattern_respond_to(mrc_codegen_scope *s, int target, mrc_sym mid, uint32_t *
   push(); pop();                /* touch block slot */
   s->sp = reg;
   genop_3(s, OP_SEND, reg, new_sym(s, MRC_SYM_2(respond_to_p)), 1);
+  if (cache) gen_move(s, cache, reg, 1);
   *fail_pos = genjmp2(s, OP_JMPNOT, reg, *fail_pos, 1);
+}
+
+/* Send `deconstruct` to `target` and leave the array in cursp().  `cache` is
+   the register an enclosing `case/in` keeps for the answer across its
+   clauses, or 0 for a pattern with none: `nil` until a clause asks, `false`
+   once the subject has turned out to have no hook, the array otherwise.  A
+   later clause reads it instead of asking again, as CRuby does. */
+static void
+gen_pattern_deconstruct(mrc_codegen_scope *s, int target, uint32_t *fail_pos, int cache)
+{
+  int reg = cursp();
+  uint32_t ask = JMPLINK_START, have = JMPLINK_START;
+
+  if (cache) {
+    ask = genjmp2(s, OP_JMPNIL, cache, JMPLINK_START, 1);
+    *fail_pos = genjmp2(s, OP_JMPNOT, cache, *fail_pos, 1);
+    gen_move(s, reg, cache, 1);
+    have = genjmp(s, OP_JMP, JMPLINK_START);
+    dispatch(s, ask);
+  }
+  gen_pattern_respond_to(s, target, MRC_SYM_1(deconstruct), fail_pos, cache);
+  gen_move(s, reg, target, 0);
+  push_n(2); pop_n(2);          /* space for receiver and a block */
+  genop_3(s, OP_SEND, reg, new_sym(s, MRC_SYM_1(deconstruct)), 0);
+  if (cache) {
+    gen_move(s, cache, reg, 1);
+    dispatch(s, have);
+  }
+}
+
+/* Whether `pattern`, at the top of an `in` clause, would send `deconstruct`
+   to the subject: it is an array or find pattern, or holds one under a
+   guard, a capture or an alternative. */
+static int
+pattern_deconstructs(mrc_node *pattern)
+{
+  for (;;) {
+    switch (nint(pattern)) {
+    case PM_IF_NODE:
+      {
+        pm_if_node_t *n = (pm_if_node_t *)pattern;
+        if (!n->statements || n->statements->body.size == 0) return FALSE;
+        pattern = n->statements->body.nodes[0];
+      }
+      break;
+    case PM_UNLESS_NODE:
+      {
+        pm_unless_node_t *n = (pm_unless_node_t *)pattern;
+        if (!n->statements || n->statements->body.size == 0) return FALSE;
+        pattern = n->statements->body.nodes[0];
+      }
+      break;
+    case PM_CAPTURE_PATTERN_NODE:
+      pattern = (mrc_node *)((pm_capture_pattern_node_t *)pattern)->value;
+      break;
+    case PM_ALTERNATION_PATTERN_NODE:
+      {
+        pm_alternation_pattern_node_t *n = (pm_alternation_pattern_node_t *)pattern;
+        if (pattern_deconstructs((mrc_node *)n->left)) return TRUE;
+        pattern = (mrc_node *)n->right;
+      }
+      break;
+    case PM_ARRAY_PATTERN_NODE:
+    case PM_FIND_PATTERN_NODE:
+      return TRUE;
+    default:
+      return FALSE;
+    }
+  }
 }
 
 /* Generate pattern matching code for a single pattern.
  * target: stack position of the value being matched
  * fail_pos: linked list of jump positions for pattern match failure
  * known_array_len: -1 if unknown, >= 0 if target is known to be an array of that length
+ * cache: register of the `case/in` that keeps what `deconstruct` answered, or 0
  */
 static void
-codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *fail_pos, int known_array_len)
+codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *fail_pos, int known_array_len, int cache)
 {
   uint32_t tmp;
 
@@ -2793,7 +2864,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       if (stmts->body.size > 0) {
         /* Extract and match the inner pattern first */
         mrc_node *inner_pattern = stmts->body.nodes[0];
-        codegen_pattern(s, inner_pattern, target, fail_pos, known_array_len);
+        codegen_pattern(s, inner_pattern, target, fail_pos, known_array_len, cache);
       }
     }
     /* Generate the guard condition */
@@ -2818,7 +2889,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       if (stmts->body.size > 0) {
         /* Extract and match the inner pattern first */
         mrc_node *inner_pattern = stmts->body.nodes[0];
-        codegen_pattern(s, inner_pattern, target, fail_pos, known_array_len);
+        codegen_pattern(s, inner_pattern, target, fail_pos, known_array_len, cache);
       }
     }
     /* Generate the guard condition */
@@ -2879,7 +2950,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
     {
       /* Unwrap implicit node and process inner value */
       pm_implicit_node_t *implicit = (pm_implicit_node_t *)pattern;
-      codegen_pattern(s, (mrc_node *)implicit->value, target, fail_pos, known_array_len);
+      codegen_pattern(s, (mrc_node *)implicit->value, target, fail_pos, known_array_len, 0);
     }
     break;
 
@@ -2890,7 +2961,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       uint32_t success_pos = JMPLINK_START;
 
       /* Try left pattern */
-      codegen_pattern(s, (mrc_node *)pat_alt->left, target, &left_fail, known_array_len);
+      codegen_pattern(s, (mrc_node *)pat_alt->left, target, &left_fail, known_array_len, cache);
 
       /* Optimize JMPNOT+JMP to JMPIF when possible.
          Only when the left pattern's tail is an OP_JMPNOT (BS format, so the
@@ -2922,7 +2993,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       if (left_fail != JMPLINK_START) {
         dispatch_linked(s, left_fail);
       }
-      codegen_pattern(s, (mrc_node *)pat_alt->right, target, fail_pos, known_array_len);
+      codegen_pattern(s, (mrc_node *)pat_alt->right, target, fail_pos, known_array_len, cache);
 
       /* Dispatch success jumps */
       if (success_pos != JMPLINK_START) {
@@ -2935,7 +3006,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
     {
       CAST3(capture_pattern, pattern, pat_as);
       /* First match the inner pattern */
-      codegen_pattern(s, (mrc_node *)pat_as->value, target, fail_pos, known_array_len);
+      codegen_pattern(s, (mrc_node *)pat_as->value, target, fail_pos, known_array_len, cache);
       /* Then bind the value to the variable */
       CAST3(local_variable_target, pat_as->target, var_target);
       int idx = lv_idx(s, var_target->name);
@@ -3011,7 +3082,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           push();
           /* Element is now at sp */
           /* Match element pattern (elements are not known arrays) */
-          codegen_pattern(s, pat_arr->requireds.nodes[i], sp, fail_pos, -1);
+          codegen_pattern(s, pat_arr->requireds.nodes[i], sp, fail_pos, -1, 0);
           pop();
         }
 
@@ -3052,17 +3123,12 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           push(); pop();  /* space for the index */
           genop_1(s, OP_GETIDX, cursp() - 1);
           /* Element is now at cursp-1 */
-          codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1);
+          codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1, 0);
           pop();
         }
       }
       else {
-        gen_pattern_respond_to(s, target, MRC_SYM_1(deconstruct), fail_pos);
-
-        /* Call target.deconstruct() */
-        gen_move(s, cursp(), target, 0);
-        push_n(2); pop_n(2);  /* space for receiver and a block */
-        genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(deconstruct)), 0);
+        gen_pattern_deconstruct(s, target, fail_pos, cache);
         arr_reg = cursp();
         push();  /* protect arr_reg on stack */
 
@@ -3093,7 +3159,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           int sp = cursp();
           genop_3(s, OP_AREF, sp, arr_reg, i);
           push();
-          codegen_pattern(s, pat_arr->requireds.nodes[i], sp, fail_pos, -1);
+          codegen_pattern(s, pat_arr->requireds.nodes[i], sp, fail_pos, -1, 0);
           pop();
         }
 
@@ -3132,7 +3198,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
           gen_int(s, cursp(), -(post_len - i));
           push(); pop();  /* space for the index */
           genop_1(s, OP_GETIDX, cursp() - 1);
-          codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1);
+          codegen_pattern(s, pat_arr->posts.nodes[i], cursp() - 1, fail_pos, -1, 0);
           pop();
         }
         pop();  /* release arr_reg */
@@ -3161,7 +3227,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
       /* Call target.deconstruct_keys(keys_array or nil).
        * Pass keys_array only when no rest pattern (partial-match optimization).
        * Pass nil when any ** is present so deconstruct_keys returns all keys. */
-      gen_pattern_respond_to(s, target, MRC_SYM_1(deconstruct_keys), fail_pos);
+      gen_pattern_respond_to(s, target, MRC_SYM_1(deconstruct_keys), fail_pos, 0);
 
       hash_reg = cursp();
       gen_move(s, hash_reg, target, 0);
@@ -3242,7 +3308,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
 
             if (assoc->value) {
               push(); /* keep the value below cursp() for the sub-pattern */
-              codegen_pattern(s, (mrc_node *)assoc->value, val_reg, fail_pos, -1);
+              codegen_pattern(s, (mrc_node *)assoc->value, val_reg, fail_pos, -1, 0);
             }
             else {
               /* Shorthand form {a:} - bind to variable with same name as key */
@@ -3331,12 +3397,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
         gen_pattern_eqq(s, (mrc_node *)pat_find->constant, target, fail_pos);
       }
 
-      gen_pattern_respond_to(s, target, MRC_SYM_1(deconstruct), fail_pos);
-
-      /* Call deconstruct on target */
-      gen_move(s, cursp(), target, 0);
-      push_n(2); pop_n(2);  /* space for receiver and a block */
-      genop_3(s, OP_SEND, arr_reg, new_sym(s, MRC_SYM_1(deconstruct)), 0);
+      gen_pattern_deconstruct(s, target, fail_pos, cache);
       push(); /* protect arr_reg */
 
       /* Check if deconstruct returned nil */
@@ -3388,7 +3449,7 @@ codegen_pattern(mrc_codegen_scope *s, mrc_node *pattern, int target, uint32_t *f
         push_n(2); pop_n(2);  /* space for the index and the ADD operand */
         genop_1(s, OP_GETIDX, cursp() - 1);
         int elem_reg = cursp() - 1;
-        codegen_pattern(s, pat_find->requireds.nodes[i], elem_reg, &match_fail, -1);
+        codegen_pattern(s, pat_find->requireds.nodes[i], elem_reg, &match_fail, -1, 0);
         pop();
       }
 
@@ -6128,7 +6189,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       int head = cursp();
       codegen(s, (mrc_node *)cast->value, VAL);
       uint32_t fail_pos = JMPLINK_START;
-      codegen_pattern(s, (mrc_node *)cast->pattern, head, &fail_pos, -1);
+      codegen_pattern(s, (mrc_node *)cast->pattern, head, &fail_pos, -1, 0);
       genop_1(s, OP_LOADTRUE, head);
       uint32_t done = genjmp(s, OP_JMP, JMPLINK_START);
       if (fail_pos != JMPLINK_START) dispatch_linked(s, fail_pos);
@@ -6145,7 +6206,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       int head = cursp();
       codegen(s, (mrc_node *)cast->value, VAL);
       uint32_t fail_pos = JMPLINK_START;
-      codegen_pattern(s, (mrc_node *)cast->pattern, head, &fail_pos, -1);
+      codegen_pattern(s, (mrc_node *)cast->pattern, head, &fail_pos, -1, 0);
       uint32_t ok = genjmp(s, OP_JMP, JMPLINK_START);
       if (fail_pos != JMPLINK_START) dispatch_linked(s, fail_pos);
       genop_1(s, OP_LOADFALSE, cursp());
@@ -6182,9 +6243,25 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
 
       /* Generate code for the case value */
+      int cache = 0;
       if (cast->predicate) {
         head = cursp();
         codegen(s, (mrc_node *)cast->predicate, VAL);
+
+        /* A register that keeps what `deconstruct` answered across the
+           clauses, when more than one of them could ask (an array literal
+           subject is never asked). */
+        if (known_array_len < 0 && cast->conditions.size > 1) {
+          for (size_t i = 0; i < cast->conditions.size; i++) {
+            pm_in_node_t *in_n = (pm_in_node_t *)cast->conditions.nodes[i];
+            if (in_n->pattern && pattern_deconstructs((mrc_node *)in_n->pattern)) {
+              cache = cursp();
+              genop_1(s, OP_LOADNIL, cache);
+              push();
+              break;
+            }
+          }
+        }
       }
 
       /* Iterate through in clauses */
@@ -6194,7 +6271,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
 
         /* Generate pattern matching code */
         if (in_n->pattern) {
-          codegen_pattern(s, (mrc_node *)in_n->pattern, head, &fail_pos, known_array_len);
+          codegen_pattern(s, (mrc_node *)in_n->pattern, head, &fail_pos, known_array_len, cache);
         }
 
         /* Guard clauses on patterns are handled inside codegen_pattern (via PM_IF_NODE/PM_UNLESS_NODE wrappers) */
@@ -6233,12 +6310,12 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         /* Move result to original case value position */
         if (head) {
           gen_move(s, head, cursp(), 0);
-          pop();
+          pop_n(cache ? 2 : 1);
         }
         push();
       }
       else {
-        if (head) pop();
+        if (head) pop_n(cache ? 2 : 1);
       }
       break;
     }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -2605,6 +2605,93 @@ assert('pattern matching - what a pin may name') do
   assert_equal :no, (case [1, 2]; in [a, ^a] then :ok; else :no; end)
 end
 
+assert('pattern matching - the clauses of a case share one deconstruct') do
+  # Each array or find clause sent `respond_to?` and `deconstruct` to the
+  # subject afresh, so a subject with a costly hook paid for it once per
+  # clause.  CRuby keeps the first answer for the rest of the `case`.
+  counted = Class.new do
+    attr_reader :sent, :asked
+    def initialize(v); @v = v; @sent = 0; @asked = 0; end
+    def deconstruct; @sent += 1; @v; end
+    def respond_to?(m, priv = false); @asked += 1 if m == :deconstruct; super; end
+  end
+
+  d = counted.new([1, 2])
+  r = case d
+      in [3] then :no
+      in [1, 2, 3] then :no
+      in [1, *] then :yes
+      end
+  assert_equal [:yes, 1, 1], [r, d.sent, d.asked]
+
+  # a guard, a capture and an alternative read the same answer
+  d = counted.new([1, 2])
+  r = case d
+      in [3] | [4] then :no
+      in [1, x] => whole if x == 9 then :no
+      in [1, x] unless x == 2 then :no
+      in [1, 2] then :yes
+      end
+  assert_equal [:yes, 1, 1], [r, d.sent, d.asked]
+
+  # a find pattern shares with an array pattern
+  d = counted.new([0, 1, 2])
+  r = case d
+      in [*, 9, *] then :no
+      in [0, *] then :yes
+      end
+  assert_equal [:yes, 1], [r, d.sent]
+
+  # a subject with no hook is asked once and falls through to else
+  bare = Class.new do
+    attr_reader :asked
+    def initialize; @asked = 0; end
+    def respond_to?(m, priv = false); @asked += 1 if m == :deconstruct; super; end
+  end
+  b = bare.new
+  r = case b
+      in [1] then :no
+      in [*] then :no
+      in [*, 1, *] then :no
+      else :else
+      end
+  assert_equal [:else, 1], [r, b.asked]
+
+  # a nested pattern deconstructs its own subject in every clause
+  d = counted.new([1])
+  x = [d, d]
+  r = case x
+      in [[3], _] then :no
+      in [[1], _] then :yes
+      end
+  assert_equal [:yes, 2], [r, d.sent]
+
+  # a case that is the whole body of a method returns through the register
+  cls = Class.new do
+    def self.pick(d)
+      case d
+      in [3] then :a
+      in [1, *] then :b
+      end
+    end
+  end
+  assert_equal :b, cls.pick(counted.new([1, 2]))
+
+  # the value of the case and the subject are where the clauses left them
+  d = counted.new([7])
+  r = case d
+      in [8] then :no
+      in Integer then :no
+      in [q] then [q, d.sent]
+      end
+  assert_equal [7, 1], r
+  r = case counted.new([1])
+      in [2] then 1
+      else 2
+      end
+  assert_equal 2, r
+end
+
 assert('pattern matching - a subject with no deconstruction hook does not match') do
   # The pattern asks whether the subject answers the hook before it sends one,
   # as CRuby does, so a subject that has none fails the pattern rather than


### PR DESCRIPTION
## Summary

Every array or find clause of a `case/in` asked the subject whether it answers `deconstruct` and then sent it, so a subject with a costly hook paid for it once per clause. A `case/in` with more than one clause and such a pattern at the top of any of them now keeps a register for the answer, and each such clause reads it before asking, which is what CRuby does.

## Changes

| File                                   | What                                                                                                              |
| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | `gen_pattern_deconstruct()` reads and fills the register, the `case/in` driver allocates it                       |
| `test/t/syntax.rb`                     | how often `respond_to?` and `deconstruct` are sent across clauses, guards, alternatives, find and nested patterns |

### What the register holds

The register is `nil` until a clause asks, `false` once `respond_to?` has answered that the subject has no hook, and the array `deconstruct` answered otherwise. A clause that finds `nil` asks as before and stores what it learns; one that finds `false` fails without asking; one that finds the array reads it. This is the state machine CRuby keeps in its `deconstructed_cache` slot. A hook that answers `nil` leaves the register `nil`, so the next clause asks again; CRuby raises `TypeError` on such an answer and mruby has the clause not match, so no well-formed hook reaches that path.

### Which patterns share it

The driver hands the register to the top pattern of each clause, and `codegen_pattern()` passes it on only through the wrappers that keep the same subject: a guard, a capture (`=> var`) and both sides of an alternative. A nested pattern has a subject of its own and always asks, as in CRuby. The register is allocated only when the `case` has more than one clause and `pattern_deconstructs()` finds an array or find pattern at the top of one of them; a `case` on an array literal never asks and gets none, so the bytecode of every other `case/in` and of the one-line forms is unchanged.

## Behaviour

```ruby
class D; def deconstruct; puts "sent"; [1, 2]; end; end
case D.new
in [3] then :no
in [1, 2, 3] then :no
in [1, *] then :yes
end  # CRuby: prints "sent" once, mruby: three times
```

## Speed

```ruby
Point = Struct.new(:x, :y)
p = Point.new(1, 2)
n = 0
i = 0
while i < 1_000_000
  case p
  in [0, _] then n += 1
  in [_, 0] then n += 2
  in [1, 2] then n += 3
  end
  i += 1
end
```

Host build, `bin/mruby`, best of three:

| Case                    | master | this PR | ratio |
| ----------------------- | ------ | ------- | ----- |
| three array clauses, 1M | 0.36 s | 0.25 s  | 1.44x |

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 1,999,926 | 2,000,806 | +880  |
| bintest          | 1,403,574 | 1,404,550 | +976  |
| cxx_abi          | 1,435,481 | 1,436,313 | +832  |
| byte-string      | 1,364,950 | 1,365,926 | +976  |
| ascii-ctype      | 1,387,974 | 1,388,950 | +976  |
| no-float         | 1,329,310 | 1,330,270 | +960  |
| no-bigint        | 1,287,670 | 1,288,646 | +976  |

`gen_pattern_deconstruct()` is 381 bytes and `pattern_deconstructs()` 137 in the host build; the rest is the `case/in` driver in `codegen()` and the extra argument threaded through `codegen_pattern()` and `gen_pattern_respond_to()`.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2785  | 2711 | 74   | 0   | 0     | 0       |
| full-debug  | 3033  | 3022 | 11   | 0   | 0     | 0       |
| bintest     | 3033  | 3013 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3033  | 3013 | 20   | 0   | 0     | 0       |
| byte-string | 2945  | 2871 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3017  | 2995 | 22   | 0   | 0     | 0       |
| no-float    | 2766  | 2669 | 97   | 0   | 0     | 0       |
| no-bigint   | 2982  | 2949 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 1 skip, 0 KO.

The new test counts `respond_to?` and `deconstruct` across three array clauses, across a guard, a capture and an alternative, across a find and an array clause, on a subject with no hook, and on a nested subject that has to be asked in every clause, reads the value of the `case` and the subject after the clauses, and returns through the register from a method whose body is the `case`. On master the host build fails at the first count. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch mrbgems/mruby-compiler/src/codegen.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DMRC_DEBUG -DMRC_DUMP_PRETTY -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_DEBUG -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK mrbgems/mruby-compiler/src/codegen.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DPRISM_XALLOCATOR -DPRISM_DEPTH_MAXIMUM=256 -DMRC_TARGET_MRUBY -DPRISM_BUILD_MINIMAL -DMRBGEM_MRUBY_COMPILER_VERSION=0.0.0 -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER mrbgems/mruby-compiler/src/codegen.c
```

</details>
