### PR TITLE
vm.c: check visibility on the send an operator instruction falls back to

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -5184,6 +5184,10 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       int base, nargs = 0;
       int idx, callargs = -1, vsp = -1;
       int32_t pos = -1;
+      /* a written `self` is a call on self for both the read and the
+         write, so a private `[]` or `[]=` is reachable as in CRuby; the
+         receiver is still loaded for the copy */
+      int op_send = (nint(receiver) == PM_SELF_NODE) ? OP_SSEND : OP_SEND;
       if (val) {
         vsp = cursp();
         push();
@@ -5206,7 +5210,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         gen_move(s, cursp()+i+1, base+i+1, 1);
       }
       push_n(nargs + 2); pop_n(nargs + 2); /* space for receiver, arguments and a block */
-      genop_3(s, OP_SEND, cursp(), idx, callargs);
+      genop_3(s, op_send, cursp(), idx, callargs);
       if (-1 != (int32_t)binary_operator) {
         push();
         codegen(s, value, VAL);
@@ -5236,7 +5240,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       pop();
       idx = new_sym(s, MRC_OPSYM_2(aset));
-      genop_3(s, OP_SEND, cursp(), idx, callargs);
+      genop_3(s, op_send, cursp(), idx, callargs);
       if (0 <= pos) { dispatch(s, pos); }
       break;
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -3724,20 +3724,36 @@ RETRY_TRY_BLOCK:
         ci->mid = mid;
         /* visibility is checked only when the method is actually found;
            the `method_missing` fallback dispatches regardless of its own
-           visibility, as in CRuby */
-        if (insn == OP_SEND || insn == OP_SEND0 || insn == OP_SENDB) {
-          mrb_bool priv = TRUE;
-          if (m.flags & MRB_METHOD_PRIVATE_FL) {
-          vis_err:;
-            mrb_value args = (ci->n == 15) ? regs[1] : mrb_ary_new_from_values(mrb, ci->n, regs+1);
-            vis_error(mrb, mid, args, recv, priv);
+           visibility, as in CRuby. A call on a written `self` is exempt,
+           which OP_SSEND says of a named call. The send an operator
+           instruction falls back to has no operand that says how its
+           receiver was written, so it is exempt while the receiver is the
+           caller's own `self`: that admits `x = self; x[0] = 1`, which CRuby
+           rejects, and no other receiver. */
+        if (mrb_unlikely(m.flags & (MRB_METHOD_PRIVATE_FL | MRB_METHOD_PROTECTED_FL))) {
+          mrb_bool exempt;
+          if (insn == OP_SEND || insn == OP_SEND0 || insn == OP_SENDB) {
+            exempt = FALSE;
           }
-          /* protected methods are callable when the caller's `self` belongs
-             to the class (or module) where the method is defined */
-          else if ((m.flags & MRB_METHOD_PROTECTED_FL) &&
-                   !mrb_obj_is_kind_of(mrb, ci[-1].stack[0], ci->u.target_class)) {
-            priv = FALSE;
-            goto vis_err;
+          else if (insn == OP_SSEND || insn == OP_SSEND0 || insn == OP_SSENDB || insn == OP_SUPER) {
+            exempt = TRUE;
+          }
+          else {
+            exempt = mrb_obj_eq(mrb, recv, ci[-1].stack[0]);
+          }
+          if (!exempt) {
+            mrb_bool priv = TRUE;
+            if (m.flags & MRB_METHOD_PRIVATE_FL) {
+            vis_err:;
+              mrb_value args = (ci->n == 15) ? regs[1] : mrb_ary_new_from_values(mrb, ci->n, regs+1);
+              vis_error(mrb, mid, args, recv, priv);
+            }
+            /* protected methods are callable when the caller's `self` belongs
+               to the class (or module) where the method is defined */
+            else if (!mrb_obj_is_kind_of(mrb, ci[-1].stack[0], ci->u.target_class)) {
+              priv = FALSE;
+              goto vis_err;
+            }
           }
         }
       }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -2937,3 +2937,147 @@ assert('a private index accessor is callable in an op-assign on a written self')
     o[0] += 1
   end
 end
+
+class PrivateOperator
+  def initialize; @h = {0 => 1, 1 => 3}; end
+
+  # a written `self` reaches them, in a block too; `[0]` and `[1]` are two
+  # instructions, as are `+ 1` and `+ o`
+  def own_aref;  self[0];                end
+  def own_aref1; self[1];                end
+  def own_aset;  self[0] = 2; @h[0];     end
+  def own_plus;  self + 1;               end
+  def own_add;   self + self;            end
+  def own_eq;    self == 1;              end
+  def own_lt;    self < 1;               end
+  def own_block; [1].map { self[0] }[0]; end
+
+  # another object does not, whichever instruction makes the call
+  def aref(o);  o[0];     end
+  def aref1(o); o[1];     end
+  def aset(o);  o[0] = 2; end
+  def plus(o);  o + 1;    end
+  def add(o);   o + o;    end
+  def eq(o);    o == 1;   end
+  def lt(o);    o < 1;    end
+
+  private
+  def [](i);     @h[i];     end
+  def []=(i, v); @h[i] = v; end
+  def +(o);      :plus;     end
+  def ==(o);     :eq;       end
+  def <(o);      :lt;       end
+end
+
+class ProtectedOperator
+  def eq(o);   o == 1; end
+  def aref(o); o[0];   end
+
+  protected
+  def ==(o); :eq;   end
+  def [](i); :aref; end
+end
+
+class ProtectedOperatorSub < ProtectedOperator
+end
+
+class ProtectedOperatorOther
+  def eq(o); o == 1; end
+end
+
+class SuperOperator
+  private
+  def [](i); :aref; end
+  def +(o);  :plus; end
+  protected
+  def ==(o); :eq;   end
+end
+
+class SuperOperatorSub < SuperOperator
+  def own_aref; self[0]; end
+  def own_plus; self + 1; end
+  def eq(o);    o == 1;  end
+
+  private
+  def [](i); super; end
+  def +(o);  super; end
+  protected
+  def ==(o); super; end
+end
+
+class PrivateArefArray < Array
+  private
+  def [](i); :sub; end
+end
+
+assert('an operator instruction checks visibility on the send it falls back to') do
+  o = PrivateOperator.new
+  assert_equal 1, o.own_aref
+  assert_equal 3, o.own_aref1
+  assert_equal 2, o.own_aset
+  assert_equal :plus, o.own_plus
+  assert_equal :plus, o.own_add
+  assert_equal :eq, o.own_eq
+  assert_equal :lt, o.own_lt
+  assert_equal 2, o.own_block
+
+  other = PrivateOperator.new
+  assert_raise_with_message(NoMethodError, "private method '[]' called for PrivateOperator") do
+    o.aref(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '[]' called for PrivateOperator") do
+    o.aref1(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '[]=' called for PrivateOperator") do
+    o.aset(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '+' called for PrivateOperator") do
+    o.plus(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '+' called for PrivateOperator") do
+    o.add(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '==' called for PrivateOperator") do
+    o.eq(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '<' called for PrivateOperator") do
+    o.lt(other)
+  end
+  assert_raise_with_message(NoMethodError, "private method '[]' called for PrivateOperator") do
+    o[0]
+  end
+  assert_raise_with_message(NoMethodError, "private method '[]=' called for PrivateOperator") do
+    o[0] = 2
+  end
+
+  # a protected operator is reachable while the caller's `self` is of the
+  # class that defines it, a subclass included
+  p = ProtectedOperator.new
+  assert_equal :eq, p.eq(ProtectedOperator.new)
+  assert_equal :aref, p.aref(ProtectedOperator.new)
+  assert_equal :eq, ProtectedOperatorSub.new.eq(p)
+  assert_raise_with_message(NoMethodError, "protected method '==' called for ProtectedOperator") do
+    ProtectedOperatorOther.new.eq(p)
+  end
+  assert_raise_with_message(NoMethodError, "protected method '==' called for ProtectedOperator") do
+    p == 1
+  end
+  assert_raise_with_message(NoMethodError, "protected method '[]' called for ProtectedOperator") do
+    p[0]
+  end
+
+  # the Array fast path leaves a subclass to the send, which is checked
+  assert_raise_with_message(NoMethodError, "private method '[]' called for PrivateArefArray") do
+    PrivateArefArray.new[0]
+  end
+end
+
+assert('super reaches a private or protected operator') do
+  o = SuperOperatorSub.new
+  assert_equal :aref, o.own_aref
+  assert_equal :plus, o.own_plus
+  assert_equal :eq, o.eq(SuperOperator.new)
+  assert_raise_with_message(NoMethodError, "protected method '==' called for SuperOperatorSub") do
+    o == 1
+  end
+end

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -2907,3 +2907,33 @@ assert('pattern matching - a guard the compiler can answer for itself, on a hook
                     in [1, 2] then :b
                     end)
 end
+
+class SelfIndexOpAssign
+  def opasgn;  @h = {0 => 1}; self[0] += 1;                 @h[0];     end
+  def orasgn;  @h = {};       self[0] ||= 5;                @h[0];     end
+  def andasgn; @h = {0 => 1}; self[0] &&= 6;                @h[0];     end
+  def value;   @h = {0 => 1}; x = (self[0] += 1);           [x, @h[0]]; end
+  def two;     @h = {0 => 1}; self[0, 1] += 1;              @h[0];     end
+  def splat;   @h = {0 => 1}; i = [0]; self[*i] += 1;       @h[0];     end
+
+  private
+  def [](i, j = nil); @h[i]; end
+  def []=(i, j = nil, v); @h[i] = v; end
+end
+
+assert('a private index accessor is callable in an op-assign on a written self') do
+  o = SelfIndexOpAssign.new
+  # the forms CRuby exempts: both the `[]` and the `[]=` of an op-assign
+  # whose receiver is the literal `self`
+  assert_equal 2, o.opasgn
+  assert_equal 5, o.orasgn
+  assert_equal 6, o.andasgn
+  assert_equal [2, 2], o.value
+  assert_equal 2, o.two
+  assert_equal 2, o.splat
+
+  # a call from outside is not
+  assert_raise_with_message(NoMethodError, "private method '[]' called for SelfIndexOpAssign") do
+    o[0] += 1
+  end
+end


### PR DESCRIPTION
## Summary

A private or protected `[]`, `[]=`, `+`, `==`, `<` or any other method an operator instruction dispatches was callable from anywhere: the visibility check in the send path was keyed to OP_SEND, OP_SEND0 and OP_SENDB, and the send that OP_GETIDX, OP_SETIDX, OP_ADD, OP_EQ, OP_LT and the rest fall back to was not one of them. The check now covers that send too, and exempts a receiver that is the caller's own `self`, which is how far the exemption CRuby grants a written `self` can be read off a register. On the way, `self[0] += 1` on a private `[]` or `[]=` was refused where CRuby accepts it; the index op-assign now makes both of its sends a call on self, as `self.a += 1` already did.

## Changes

| File                                   | What                                                                                                                                                     |
| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/vm.c`                             | `L_SENDB_SYM`: the visibility check is skipped for OP_SSEND, OP_SSEND0, OP_SSENDB and OP_SUPER, and for an operator instruction whose receiver is `self` |
| `mrbgems/mruby-compiler/src/codegen.c` | the `PM_INDEX_*_WRITE_NODE` case: OP_SSEND for the `[]` and `[]=` of an op-assign whose receiver is a written `self`                                     |
| `test/t/syntax.rb`                     | the operator forms on a written `self` and from outside, a protected operator, a private `[]` on an Array subclass, and the index op-assign forms        |

### The exemption an operator instruction can grant

CRuby exempts a receiver written as `self`, not a receiver that is self: `x = self; x.a = 1` is refused. A named call keeps that rule through OP_SSEND, which the compiler selects on the written form. An operator instruction has no operand that says how its receiver was written, and compiling `self[i]` or `self + 1` as OP_SSEND would take `Array#each`, `Integer#succ` and every other mrblib method that writes `self[idx]` or `self + 1` off their fast paths. So the send it falls back to reads the exemption off the object: a receiver that is the caller's `self` is let through, and no other receiver is. That admits `x = self; x[0] = 1` and `x = self; x + 1`, which CRuby refuses; every other form answers as CRuby does.

### Protected

A protected operator was reachable from anywhere too, for the same reason. It now takes the same test as a protected named method: the caller's `self` has to be of the class that defines it, so `other == self` inside the class stays reachable and `obj == 1` from outside is refused.

## Behaviour

```ruby
class K
  def m; @h = {0 => 1}; self[0] += 1; @h[0]; end   # CRuby: 2, mruby: NoMethodError: private method '[]' called for K
  private
  def [](i); @h[i]; end
  def []=(i, v); @h[i] = v; end
  def +(o); o; end
end
K.new[0]    # CRuby: NoMethodError: private method '[]' called for K, mruby: nil
K.new + 1   # CRuby: NoMethodError: private method '+' called for K, mruby: 1
```

`self[0]`, `self[0] = v`, `self + 1`, `self == x` and `self < x` on a private operator are accepted as before, in a block as well. A local holding `self` is still accepted for an operator instruction, where CRuby refuses it; for a named call it is refused as before. A multiple assignment `self[0], self[1] = 1, 2` on a private `[]=` is refused by CRuby; mruby accepts it for one index and refuses it for two, as before, and this PR does not touch it.

## Speed

Ir per iteration, callgrind, `Ir(200000) - Ir(100000)` over 100,000, `CC=gcc -O3`.

```ruby
class V
  def +(o); o; end
  def [](i); i; end
  def m(o); o; end
  def own; self + 1; end
  def own_idx; self[1]; end
end
v = V.new; ary = [1]; a = 0; b = 1
v + 1        # plus: a Ruby `+`, the fallback send of OP_ADD
v[1]         # aref: a Ruby `[]`, the fallback send of OP_GETIDX
v.own        # own: `self + 1` inside the class
v.own_idx    # own_idx: `self[1]` inside the class
v.m(1)       # send: a named call, OP_SEND
a + b        # intadd: the Integer fast path of OP_ADD
ary[0]       # aryidx: the Array fast path of OP_GETIDX
```

| Case    | master | this PR | delta |
| ------- | ------ | ------- | ----- |
| plus    | 550    | 554     | +4    |
| aref    | 562    | 563     | +1    |
| own     | 823    | 822     | -1    |
| own_idx | 823    | 822     | -1    |
| send    | 536    | 531     | -5    |
| intadd  | 321    | 319     | -2    |
| aryidx  | 255    | 255     | 0     |

The two fallback sends pay the receiver comparison only after the method is found private or protected; a public one now takes a single flag test where OP_SEND took three instruction tests and two flag tests, which is the -5 on `send`.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta  |
| ---------------- | --------- | --------- | ------ |
| full-debug (-O0) | 1,999,926 | 2,000,102 | +176   |
| bintest          | 1,403,574 | 1,402,086 | -1,488 |
| cxx_abi          | 1,435,481 | 1,435,321 | -160   |
| byte-string      | 1,364,950 | 1,363,686 | -1,264 |
| ascii-ctype      | 1,387,974 | 1,386,710 | -1,264 |
| no-float         | 1,329,310 | 1,329,470 | +160   |
| no-bigint        | 1,287,670 | 1,287,846 | +176   |

All of it is `mrb_vm_exec()`, which loses 1,515 bytes in bintest; `codegen.o` is unchanged in size. No function the send path calls is called from more or fewer sites than before, so the difference is how gcc lays the path out once the visibility test is a single branch behind one flag test.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2787  | 2713 | 74   | 0   | 0     | 0       |
| full-debug  | 3035  | 3024 | 11   | 0   | 0     | 0       |
| bintest     | 3035  | 3015 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3035  | 3015 | 20   | 0   | 0     | 0       |
| byte-string | 2947  | 2873 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3019  | 2997 | 22   | 0   | 0     | 0       |
| no-float    | 2768  | 2671 | 97   | 0   | 0     | 0       |
| no-bigint   | 2984  | 2951 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 0 KO.

The first test writes to a private `[]` and `[]=` through `self[0] += 1`, `||=`, `&&=`, as a value, with two indices and with a splat, and checks that `o[0] += 1` from outside is refused; on master the six `self` forms fail. The second calls a private `[]`, `[]=`, `+`, `==` and `<` on a written `self`, in a block too, and on another object from inside the class and from the top level, with `[0]` and `[1]` and with `+ 1` and `+ o` so that OP_GETIDX0, OP_GETIDX, OP_ADDI and OP_ADD are each reached; calls a protected `==` and `[]` from an instance of the same class, of a subclass, of another class and from the top level; and calls a private `[]` on an Array subclass. On master the thirteen refusals do not happen. The third pins that `super` reaches a private `[]` and `+` and a protected `==`, which it did before and does through the OP_SUPER exemption now. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch src/vm.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/vm.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/vm.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed operator calls on `self` so private and protected methods, including indexing, addition, equality, and comparison, work correctly.
  - Corrected indexed and compound assignments involving private or protected operators.
  - Private and protected methods now enforce visibility rules consistently across direct calls and calls on other receivers.
  - Protected operators remain accessible from valid subclasses, while invalid calls now raise the appropriate visibility error.
  - Improved pattern-matching behavior for captures, deconstruction reuse, guards, and fallthrough cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->