### PR TITLE
variable.c: read a class variable in a block from the cref the block was written under

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1214,24 +1214,30 @@ mrb_cv_defined(mrb_state *mrb, mrb_value mod, mrb_sym sym)
   return mrb_mod_cv_defined(mrb, mrb_class_ptr(mod), sym);
 }
 
-/* The class a class variable in the frame's scope is read from: the nearest
-   scope on the `upper` chain that carries a class of its own, a singleton
-   class passed over.  A method written in a block given a class carries the
-   given class for a `def` and is passed over too; the variable is read from
-   the scope the block was written in, as under the cref CRuby skips. */
+/* The class a class variable written in the scope of `p` is read from: the
+   nearest cref on the `upper` chain, as mrb_vm_cref_class() finds it, with a
+   singleton class passed over.  A block is not a cref and carries the class
+   of the frame it was made in, which is the receiver's class where that
+   frame was given one to run under, as a `Class.new` or `class_eval` block
+   is; the variable is read from the scope the block was written in, as
+   under the cref CRuby skips.  A method written in such a block carries the
+   given class for a `def` and is passed over the same way.  Off the end of
+   the chain the variable is read from `Object`, as at the top level. */
+static struct RClass*
+cv_scope_class(mrb_state *mrb, const struct RProc *p)
+{
+  for (; p && !MRB_PROC_CFUNC_P(p); p = p->upper) {
+    if (!MRB_PROC_CREF_P(p) || MRB_PROC_GIVEN_P(p)) continue;
+    struct RClass *c = MRB_PROC_TARGET_CLASS(p);
+    if (c && c->tt != MRB_TT_SCLASS) return c;
+  }
+  return mrb->object_class;
+}
+
 mrb_value
 mrb_vm_cv_get(mrb_state *mrb, mrb_sym sym)
 {
-  struct RClass *c;
-
-  const struct RProc *p = mrb->c->ci->proc;
-
-  for (;;) {
-    c = MRB_PROC_TARGET_CLASS(p);
-    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(p)) break;
-    p = p->upper;
-  }
-  return mrb_mod_cv_get(mrb, c, sym);
+  return mrb_mod_cv_get(mrb, cv_scope_class(mrb, mrb->c->ci->proc), sym);
 }
 
 /* Non-raising class-variable lookup for `defined?(@@v)`. Resolves the class
@@ -1240,29 +1246,13 @@ mrb_vm_cv_get(mrb_state *mrb, mrb_sym sym)
 mrb_bool
 mrb_vm_cv_defined_p(mrb_state *mrb, const struct RProc *proc, mrb_sym sym)
 {
-  struct RClass *c;
-
-  for (;;) {
-    c = MRB_PROC_TARGET_CLASS(proc);
-    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(proc)) break;
-    proc = proc->upper;
-    if (!proc) { c = mrb->object_class; break; }
-  }
-  return mrb_mod_cv_defined(mrb, c, sym);
+  return mrb_mod_cv_defined(mrb, cv_scope_class(mrb, proc), sym);
 }
 
 void
 mrb_vm_cv_set(mrb_state *mrb, mrb_sym sym, mrb_value v)
 {
-  struct RClass *c;
-  const struct RProc *p = mrb->c->ci->proc;
-
-  for (;;) {
-    c = MRB_PROC_TARGET_CLASS(p);
-    if (c && c->tt != MRB_TT_SCLASS && !MRB_PROC_GIVEN_P(p)) break;
-    p = p->upper;
-  }
-  mrb_mod_cv_set(mrb, c, sym, v);
+  mrb_mod_cv_set(mrb, cv_scope_class(mrb, mrb->c->ci->proc), sym, v);
 }
 
 static void

--- a/test/t/module.rb
+++ b/test/t/module.rb
@@ -1644,9 +1644,14 @@ module Test4GivenMethodMaker
       def cv; @@cvs; end
       def cv_defined; defined?(@@cvs); end
       def cv_write; @@cvs = :written; end
+      def cv_nested; [1].map { @@cvs }[0]; end
+      def cv_nested_defined; [1].map { defined?(@@cvs) }[0]; end
+      def cv_nested_write; [1].each { @@cvs = :nested }; end
     end
   end
   def self.read_cv; @@cvs; end
+  def self.read_under(recv); recv.class_eval { @@cvs }; end
+  def self.write_under(recv); recv.class_eval { @@cvs = :under }; end
   def self.install(recv)
     recv.class_eval do
       def own_direct; KO; end
@@ -1672,6 +1677,21 @@ assert('constant and class variable lookup: a method written in a block given a 
   assert_equal("class variable", o.cv_defined)
   o.cv_write
   assert_equal(:written, Test4GivenMethodMaker.read_cv)
+  assert_equal(:recv, Test4GivenMethodSuper.read_cv)
+
+  # a block made in the method carries the given class, as a `def` in it
+  # adds there, and is no scope of its own either: the variable is still
+  # read from and written to the module
+  assert_equal(:written, o.cv_nested)
+  assert_equal("class variable", o.cv_nested_defined)
+  o.cv_nested_write
+  assert_equal(:nested, Test4GivenMethodMaker.read_cv)
+  assert_equal(:recv, Test4GivenMethodSuper.read_cv)
+
+  # the same for the block given the class itself
+  assert_equal(:nested, Test4GivenMethodMaker.read_under(Test4GivenMethodSuper))
+  Test4GivenMethodMaker.write_under(Test4GivenMethodSuper)
+  assert_equal(:under, Test4GivenMethodMaker.read_cv)
   assert_equal(:recv, Test4GivenMethodSuper.read_cv)
 
   # a constant only the given class has is out of reach from the method


### PR DESCRIPTION
## Summary

A class variable in a block made under a frame that was given a class to run under, a `Class.new`, `class_eval` or `instance_eval` block or a method written in one, was read from the receiver's class and its ancestors rather than from the scope the block was written in. The class variable walk now reads the cref the way `mrb_vm_cref_class()` does, passing over a block and a method marked `MRB_PROC_GIVEN`, so that such a block answers from the scope around it as CRuby's does under the cref it skips.

## Changes

| File               | What                                                                                                                                                                                                      |
| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/variable.c`   | `cv_scope_class()`: the one walk `mrb_vm_cv_get()`, `mrb_vm_cv_set()` and `mrb_vm_cv_defined_p()` share, over the crefs on the `upper` chain, with a singleton class passed over and `Object` off the end |
| `test/t/module.rb` | a class variable read, tested with `defined?` and written from a block in a method written in a `Class.new` block, and from a `class_eval` block                                                          |

### The class a block carries

A block carries the class of the frame it was made in, and that is the class a `def` in the block adds to, which is the given class under a `Class.new` or `class_eval` block and in a method written in one (#7553). The old walk took the first proc on the `upper` chain that carried a class, so a block made under such a frame answered with the given class. A method written in the block was already passed over by the mark #7553 put on it; a block made in that method, or in the given block itself, was not. The walk now takes the crefs only, which is what `mrb_vm_cref_class()` reads for a `def`, and a block made under a class body or a plain method sees no difference: the nearest cref is that scope, the class the block carried before.

Off the end of the chain the variable is read from `Object`, as at the top level; a script's top-level proc carries `Object`, and the old walk stopped there.

## Behaviour

```ruby
class Sup; @@x = :sup; end
module Outer
  @@x = :outer
  K = Class.new(Sup) { def pos; [1].map { @@x }[0]; end }
  def self.under; Sup.class_eval { [1].map { @@x }[0] }; end
end
Outer::K.new.pos   # CRuby: :outer, mruby: :sup
Outer.under        # CRuby: :outer, mruby: :sup
```

A write and `defined?` from the same places move with the read. A `Class.new` or `class_eval` block written at the top level of a script keeps writing its class variables to `Object`, the class the top level carries; CRuby raises `RuntimeError` for a class variable reached from the top level, which this PR does not add.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc`.

| Build            | master    | this PR   | delta |
| ---------------- | --------- | --------- | ----- |
| full-debug (-O0) | 2,000,502 | 2,000,406 | -96   |
| bintest          | 1,402,694 | 1,402,966 | +272  |
| cxx_abi          | 1,435,945 | 1,436,217 | +272  |
| byte-string      | 1,364,294 | 1,364,566 | +272  |
| ascii-ctype      | 1,387,318 | 1,387,590 | +272  |
| no-float         | 1,330,174 | 1,330,446 | +272  |
| no-bigint        | 1,288,454 | 1,288,726 | +272  |

All of it is `variable.o`. gcc inlines `cv_scope_class()` at its three sites, and then inlines `mrb_mod_cv_defined()` into `mrb_vm_cv_defined_p()` as well, a second copy of 227 bytes next to the exported one; the two walks that raise are 31 and 30 bytes larger than the loops they replace. At -O0 the one loop is smaller than three.

## Testing

| Build       | Total | OK   | Skip | KO  | Crash | Warning |
| ----------- | ----- | ---- | ---- | --- | ----- | ------- |
| host        | 2791  | 2717 | 74   | 0   | 0     | 0       |
| full-debug  | 3039  | 3028 | 11   | 0   | 0     | 0       |
| bintest     | 3039  | 3019 | 20   | 0   | 0     | 0       |
| cxx_abi     | 3039  | 3019 | 20   | 0   | 0     | 0       |
| byte-string | 2951  | 2877 | 74   | 0   | 0     | 0       |
| ascii-ctype | 3023  | 3001 | 22   | 0   | 0     | 0       |
| no-float    | 2772  | 2675 | 97   | 0   | 0     | 0       |
| no-bigint   | 2988  | 2955 | 33   | 0   | 0     | 0       |

bintest: 147 total, 146 OK, 0 KO.

The added assertions read, test with `defined?` and write a class variable from a block in a method written in a `Class.new` block, and read and write one from a `class_eval` block, checking that the module the block was written in answers and the superclass of the given class is untouched. On master the read answers the superclass's value and the write lands there. The same assertions pass under CRuby 4.0.6.

## Environment

<details>

|          |                                                    |
| -------- | -------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS, Linux 7.0.0-31-generic, x86_64 |
| CPU      | AMD Ryzen 9 5950X                                  |
| gcc      | 13.3.0                                             |
| binutils | 2.47                                               |
| CRuby    | 4.0.6                                              |

Compile lines, `touch src/variable.c; rake --verbose` with `-MMD -c`, `-I`, `-o` and `-ffile-prefix-map` dropped:

```
full-debug:  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
bintest:     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/variable.c
cxx_abi:     gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
byte-string: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
ascii-ctype: gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
no-float:    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
no-bigint:   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/variable.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved class-variable scope resolution for methods and nested blocks created with `class_eval`.
  - Class variables can now be read, checked for definition, and updated consistently when accessed through an evaluated class or receiver.
  - Added fallback behavior to ensure class-variable lookups resolve correctly when no more specific class scope applies.

- **Tests**
  - Expanded coverage for nested class-variable reads, writes, and definedness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->