### PR TITLE
build: compile from the build directory by relative names

### DIFF
--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -541,19 +541,21 @@ debug information that the `-g` of the `gcc` and `clang` toolchains writes, and
 the file names `mrbc` records for the backtrace of an mruby script under
 `enable_debug`. Every build keeps them out of it on its own.
 
-It compiles the sources by the names they have from the tree, `src/vm.c` and
-not the path of the checkout, and names the two directories they come from for
-whatever a name cannot carry: the tree, written as `.`, and the build
-directory, written as `build`. The build directory is written as the place it
-takes when nothing moves it, so that a build with `MRUBY_BUILD_DIR` pointing
-anywhere else compiles what a build inside the tree compiles. The names are
-written with `-ffile-prefix-map`, except for the directory a compiler records
-as the one it compiled in, which `clang` is told by `-ffile-compilation-dir`.
+It runs the compilers from the build directory and compiles by the names the
+sources and the generated files have from there, `../src/vm.c` and
+`host/src/symbol.c`, not the path of the checkout. The build directory is
+written as `build`, the place it takes when nothing moves it, so that a build
+with `MRUBY_BUILD_DIR` pointing anywhere else compiles what a build inside the
+tree compiles: the tree is then written as `..`, the name it has from there.
+The names are written with `-ffile-prefix-map`, except for the directory a
+compiler records as the one it compiled in, which `clang` is told by
+`-ffile-compilation-dir`.
 
-Two builds of the same commit in two checkouts therefore compile the same
-thing, and a compiler cache keyed on the command line, `ccache` or `sccache`,
-answers for one from what it learned of the other with nothing configured for
-it on the machine.
+Two builds of the same commit in two checkouts or in two build directories
+therefore compile the same thing, as long as the build directories sit at the
+same depth, and a compiler cache keyed on the command line, `ccache` or
+`sccache`, answers for one from what it learned of the other with nothing
+configured for it on the machine.
 
 The same holds across configs that name different gems, for the objects of
 the parts of the build the two configs agree on up to that point. The
@@ -597,8 +599,8 @@ conf.disable_file_prefix_map
 which is what a build to be debugged from outside the mruby tree wants: a
 debugger looks for the sources under the names the build wrote, and finds them
 only from the tree they are named against. Either tell the debugger where they
-are (`set substitute-path . /path/to/mruby` in gdb), run it from the tree, or
-take the names off this way.
+are (`set substitute-path build /path/to/build` in gdb), run it from the tree
+with the build directory in its place, or take the names off this way.
 
 Note that
 
@@ -610,9 +612,9 @@ Note that
 - The flags a build exports in `libmruby.flags.mak` name every directory in
   full: they are read where the package was installed, which is not where it
   was built, and whoever compiles against it rewrites them.
-- A directory the build cannot name from the tree, a gem or a build directory
-  somewhere else, reaches the compiler as this machine spells it, and is
-  written through the map.
+- A directory the build cannot name from the build directory, a gem outside
+  the tree, reaches the compiler as this machine spells it, and is written
+  through the map.
 
 ## Cross-Compilation
 

--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -247,11 +247,14 @@ module MRuby
     # it takes when nothing moves it, so that a build with `MRUBY_BUILD_DIR`
     # pointing anywhere else compiles what a build inside the tree compiles.
     #
-    # The tree is written as `.`, and under that name the build compiles the
-    # sources by the names they have from the tree, so that what it compiles
-    # is the same wherever the tree sits. A config that writes another name
-    # for the tree is asking for that name in the output, which no relative
-    # name carries, and its build compiles with the paths as they are.
+    # The tree is written as `.`, and under that name the build compiles by
+    # relative names: it runs the compilers from the build directory and
+    # names the sources and the generated files by where they sit from
+    # there, `../src/vm.c` and `host/src/symbol.c`, which is the same
+    # wherever the tree sits as long as the build directory sits at the
+    # same depth. A config that writes another name for the tree is asking
+    # for that name in the output, which no relative name carries, and its
+    # build compiles with the paths as they are.
     #
     # The two maps overlap where the build directory is inside the tree, and
     # both `gcc` and `clang` answer a path both cover with the longer prefix,
@@ -261,7 +264,8 @@ module MRuby
     #
     # No compiler flag reaches the file names `mrbc` records for a backtrace
     # under `enable_debug`: those are the names the build passes it, and the
-    # build passes the names of the tree wherever it compiles by them.
+    # build passes the names of the tree wherever it compiles by relative
+    # names.
     def enable_file_prefix_map(source: ".", build: source == "." ? "build" : "#{source}/build")
       file_prefix_map(MRUBY_ROOT, source)
       file_prefix_map(@build_root, build)
@@ -278,26 +282,59 @@ module MRuby
       @file_prefix_map_source = nil
     end
 
-    # Whether the compilers are handed the names the sources have from the
-    # tree, instead of the paths they have on this machine.
+    # Whether the compilers are handed relative names for the sources and
+    # the build directory, instead of the paths they have on this machine.
     #
     # This is the same question as whether the tree is written as `.`: a
-    # relative name is what a path under the tree looks like once the tree
-    # itself is dropped from it, so the build compiles under that name what
-    # the map would otherwise write. A build that keeps its paths, or that
-    # writes another name for the tree, has no such name to compile with.
+    # relative name is what a path looks like once the directory it is
+    # named from is dropped from it, so the build compiles under such names
+    # what the map would otherwise write. A build that keeps its paths, or
+    # that writes another name for the tree, has no such name to compile
+    # with.
     def compile_relative?
       @file_prefix_map_source == "."
     end
 
-    # The name a compile is given for +path+: the one it has from the tree,
-    # where it sits under the tree and the build compiles by such names, and
-    # the path as it is anywhere else.
+    # The directory a compile of this build runs from, which a relative name
+    # in the flags is written against: the build directory where the build
+    # compiles by relative names, so that the objects and the generated
+    # files are named from where they are and the tree from beside them,
+    # and the tree anywhere else.
+    def compile_dir
+      compile_relative? ? @build_root : MRUBY_ROOT
+    end
+
+    # The name a compile is given for +path+: the one it has from the
+    # directory the compile runs from, where the path sits under the tree or
+    # the build directory and the build compiles by relative names, and the
+    # path as it is anywhere else.
     #
     # A path this leaves alone is one no build of this tree can name the same
-    # way twice, an external gem or a build directory somewhere else, and it
-    # reaches the compiler as the machine spells it.
+    # way twice, an external gem outside both, and it reaches the compiler
+    # as the machine spells it. A relative path is one a config wrote, and
+    # a config writes it against the tree.
     def compile_path(path)
+      return path unless compile_relative?
+      path = File.expand_path(path, MRUBY_ROOT) unless Pathname.new(path).absolute?
+      return path unless [MRUBY_ROOT, @build_root].any? {|dir| path == dir || path.start_with?("#{dir}/") }
+      path.relative_path_from(@build_root)
+    rescue ArgumentError
+      # Another drive on Windows, which no relative name reaches.
+      path
+    end
+
+    # The path a name in a dependency file stands for: what the compiler was
+    # given, read back against the directory it ran from.
+    def resolve_compile_path(name)
+      File.expand_path(name, compile_dir)
+    end
+
+    # The name a path has from the tree, where the build compiles by
+    # relative names, and the path as it is anywhere else. This is what
+    # `mrbc` is given, since the name it records for a backtrace is read by
+    # people and not by the compiler; a path outside the tree is left as it
+    # is.
+    def tree_path(path)
       return path unless compile_relative?
       return "." if path == MRUBY_ROOT
       prefix = "#{MRUBY_ROOT}/"

--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -135,12 +135,13 @@ module MRuby
     # neither map a path nor be told which directory it compiled in is left
     # alone, and the paths it writes stand as they are.
     #
-    # A build that compiles by the names its sources have from the tree hands
-    # those names to the map too, so a directory of the machine is named here
-    # only where the build could not name it any other way. Two of them then
-    # answer for themselves: the tree, which every name is already written
-    # against, and a build directory that is already spelled the way the map
-    # would write it.
+    # A build that compiles by relative names hands those names to the map
+    # too, so a directory of the machine is named here only where the build
+    # could not name it any other way. The build directory answers for
+    # itself, since every name is written against it. The tree is named from
+    # it, and a build outside the tree names it by a path of the machine,
+    # relative as it is, so the name is mapped to the one the tree has from
+    # the build directory's written name: `..` from `build`.
     #
     # What no name of a source can carry is the directory the compiler records
     # as the one it compiled in, which it takes from the machine whatever it
@@ -151,14 +152,18 @@ module MRuby
       relative = build.compile_relative?
       flags = []
       file_prefix_maps.each do |from, to|
-        if relative && from == MRUBY_ROOT
-          if compilation_dir?
-            flags << option_compilation_dir % to
-            next
+        if relative
+          name = build.compile_path(from)
+          if name == "."
+            if compilation_dir?
+              flags << option_compilation_dir % to
+              next
+            end
+          elsif name != from
+            to = written_tree_name(to) if from == MRUBY_ROOT
+            next if name == to
+            from = name
           end
-        elsif relative
-          from = build.compile_path(from)
-          next if from == to
         end
         flags << option_file_prefix_map % [filename(from), to] if file_prefix_map?
       end
@@ -208,8 +213,8 @@ module MRuby
     # link against still answers.  Both it and the object go in a directory of
     # their own, which is removed afterwards; the compiler still runs where
     # the build runs, so that a relative path among the flags, an `-I` a
-    # configuration wrote without spelling out a root, names what it names
-    # during a compile.
+    # configuration wrote into them without spelling out a root, names what
+    # it names during a compile.
     #
     # The answer is kept for the life of the rake process, since a build has
     # four compilers and a config has several builds, and they name few
@@ -355,10 +360,11 @@ module MRuby
     # The flags a caller compiles with, or that a package carries away.
     #
     # +compiled+ says which of the two is asking. A compile is run from the
-    # tree and names the directories it reads by the names they have from it,
-    # where they have one; a package is compiled from somewhere else entirely,
-    # and its flags name every directory in full, for whoever rewrites them
-    # into the directories the package was installed in.
+    # build directory and names the directories it reads by the names they
+    # have from there, where they have one; a package is compiled from
+    # somewhere else entirely, and its flags name every directory in full,
+    # for whoever rewrites them into the directories the package was
+    # installed in.
     def all_flags(_defines=[], _include_paths=[], _flags=[], compiled: false)
       define_flags = [defines, internal_defines, _defines, build.defines].flatten
                        .map{ |d| option_define % d }
@@ -374,7 +380,7 @@ module MRuby
       opts, params = compile_invocation(outfile, infile, _defines, _include_paths, _flags)
       label = object_ext?(outfile) ? @label : "CPP"
       _pp label, infile.relative_path, outfile.relative_path
-      _run opts, params, chdir: (MRUBY_ROOT if build.compile_relative?)
+      _run opts, params, chdir: build.compile_dir
       # Recorded after the compile, so that a compile that failed leaves
       # nothing claiming a configuration its output was not built with.
       File.write(flags_file(outfile), flags_record(opts, params[:flags]))
@@ -507,13 +513,10 @@ module MRuby
         #    []
       end.flatten.uniq
       # The names a +.d+ file carries are the ones the compile was given, so a
-      # compile that names its sources against the tree leaves relative names
-      # here. They are read against the directory the compile ran in, since
-      # everything below compares them with the names of the tasks, and those
-      # are absolute.
-      header_deps.map! do |dep|
-        Pathname.new(dep).absolute? ? dep : File.join(MRUBY_ROOT, dep)
-      end
+      # compile by relative names leaves relative names here. They are read
+      # against the directory the compile ran in, since everything below
+      # compares them with the names of the tasks, and those are absolute.
+      header_deps.map! {|dep| build.resolve_compile_path(dep) }
       unless object_ext?(file)
         presym_dir = "#{build.presym.header_dir}/"
         header_deps.reject! {|dep| dep.start_with?(presym_dir) }
@@ -537,6 +540,15 @@ module MRuby
 
     private
 
+    # The name the tree has from the build directory once both are written
+    # by the names the map gives them, +tree+ and the build directory's:
+    # what a relative name for the tree is mapped to, so that a build
+    # outside the tree writes what one inside writes.
+    def written_tree_name(tree)
+      build_name = file_prefix_maps[build.build_root] || tree
+      Pathname.new(tree).relative_path_from(Pathname.new(build_name)).to_s
+    end
+
     # Whether the command this compiler names knows +option+, which is asked
     # of the command itself: a toolchain stands for a family of compilers, and
     # an option one of them takes is not in all of them.
@@ -555,7 +567,7 @@ module MRuby
     # What an answer about +source+ is kept under: everything that goes into
     # the compile, the extension included.
     def probe_key(source)
-      [build.filename(command), compile_options, source_exts.first, all_flags, source]
+      [build.filename(command), compile_options, source_exts.first, all_flags(compiled: true), source]
     end
 
     # Compile +source+ and answer whether it compiled.  The source and the
@@ -571,10 +583,12 @@ module MRuby
         outfile = "#{dir}/probe#{out_ext}"
         File.write(infile, source)
         options = compile_options % {
-          flags: all_flags, infile: filename(infile), outfile: filename(outfile)
+          flags: all_flags(compiled: true), infile: filename(infile), outfile: filename(outfile)
         }
-        opts = {out: File::NULL, err: File::NULL}
-        opts[:chdir] = MRUBY_ROOT if build.compile_relative?
+        # The build directory is made here where a probe is the first thing
+        # the build runs from it.
+        mkdir_p build.compile_dir
+        opts = {out: File::NULL, err: File::NULL, chdir: build.compile_dir}
         # `system` answers nil where the command is not there to run at all,
         # which is an answer of no like any other failure to compile.
         compiled = !!system("#{build.filename(command)} #{options}", **opts)
@@ -883,10 +897,10 @@ module MRuby
       opt = opt.sub(/\s-o-(?=\s|\z)/, %Q[ -o "#{filename tmpout}"])
       # The names given here are the ones `mrbc` records for a backtrace, so
       # they are the names the sources have from the tree wherever the build
-      # compiles by those, and `mrbc` is run from the tree to read them. This
-      # is what the compilers are told through their own options, which reach
-      # nothing `mrbc` writes.
-      sources = infiles.map {|f| build.compile_path(f) }
+      # compiles by relative names, and `mrbc` is run from the tree to read
+      # them. This is what the compilers are told through their own options,
+      # which reach nothing `mrbc` writes.
+      sources = infiles.map {|f| build.tree_path(f) }
       cmd = %["#{filename @command}" #{opt} #{filename(sources).map{|f| %["#{f}"]}.join(' ')}]
       puts cmd if Rake.verbose
       opts = build.compile_relative? ? {chdir: MRUBY_ROOT} : {}

--- a/lib/mruby/compile_commands.rb
+++ b/lib/mruby/compile_commands.rb
@@ -203,17 +203,17 @@ module MRuby
     # the block gives, or nothing where the source is not there.
     #
     # The rule and the record name the source the way the compile is given
-    # it, which is the name it has from the tree where the build compiles by
-    # those names. The command keeps that name, since it is the command that
-    # is run and `directory` says what it is written against, while `file`
-    # is answered in full: it is what a tool matches the file it has open
-    # against, and it has that one by its path.
+    # it, which is the name it has from the build directory where the build
+    # compiles by relative names. The command keeps that name, since it is
+    # the command that is run and `directory` says what it is written
+    # against, while `file` is answered in full: it is what a tool matches
+    # the file it has open against, and it has that one by its path.
     def entry(infile, outfile)
-      path = File.absolute_path(infile, MRUBY_ROOT)
+      path = @build.resolve_compile_path(infile)
       return nil unless File.exist?(path)
 
       {
-        "directory" => MRUBY_ROOT,
+        "directory" => @build.compile_dir,
         "file" => path,
         "command" => yield,
         "output" => outfile,

--- a/mrbgems/mruby-compiler/mrbgem.rake
+++ b/mrbgems/mruby-compiler/mrbgem.rake
@@ -89,24 +89,16 @@ MRuby::Gem::Specification.new('mruby-compiler') do |spec|
 
     # The templates write #line directives that name themselves against the
     # root of the prism repository ("prism/templates/..."), a path that
-    # resolves to nothing from MRUBY_ROOT, where mruby compiles: diagnostics
-    # point at a file the editor cannot open, and ccache drops its direct mode
-    # over the missing dependency. Rewrite the prefix to the gem's location in
-    # the tree. When the gem sits outside the tree no name from the tree
-    # reaches it, so there is nothing to write; on Windows a gem on another
-    # drive is outside with no relative path at all, which Pathname reports
-    # by raising instead of returning a ".."-prefixed path.
-    prism_rel_dir = begin
-      prism_dir.relative_path_from(MRUBY_ROOT)
-    rescue ArgumentError
-      nil
-    end
-    unless prism_rel_dir.nil? || prism_rel_dir.start_with?('..')
-      prism_generated_files.each do |path|
-        source = File.binread(path)
-        rewritten = source.gsub(/^(#line \d+ ")prism\//) { "#{$1}#{prism_rel_dir}/" }
-        File.binwrite(path, rewritten) unless rewritten == source
-      end
+    # resolves to nothing from where mruby compiles: diagnostics point at a
+    # file the editor cannot open, and ccache drops its direct mode over the
+    # missing dependency. Rewrite the prefix to the name the compile is given
+    # for the gem's location, which is the one every other source is named
+    # by, and the gem's path where the build compiles by paths.
+    prism_compile_dir = build.compile_path(prism_dir)
+    prism_generated_files.each do |path|
+      source = File.binread(path)
+      rewritten = source.gsub(/^(#line \d+ ")prism\//) { "#{$1}#{prism_compile_dir}/" }
+      File.binwrite(path, rewritten) unless rewritten == source
     end
   end
 


### PR DESCRIPTION
## Summary

A build with `MRUBY_BUILD_DIR` outside the tree named its build directory by its path, in `-I` and in the object it wrote, so two build directories compiled with different command lines and a compiler cache keyed on the command line, `ccache` or `sccache`, answered for neither from the other. The compilers now run from the build directory and spell every path under it or under the tree from there, so two build directories at the same depth compile the same thing, and `clang` is told no path of the machine at all.

## Changes

| File                                 | What                                                                                                                                                                                  |
| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `lib/mruby/build.rb`                 | `compile_dir`, the directory a compile runs from; `compile_path` names a path from it; `resolve_compile_path` reads such a name back; `tree_path`, the name from the tree, for `mrbc` |
| `lib/mruby/build/command.rb`         | compiles, probes and `mrbc` run from `compile_dir`; the tree's map is written as the name the tree has from `build`; the dependency file is read back through `resolve_compile_path`  |
| `mrbgems/mruby-compiler/mrbgem.rake` | the `#line` directives of the generated prism sources name the templates from where the build compiles                                                                                |
| `lib/mruby/compile_commands.rb`      | `directory` is `compile_dir`, and `file` is resolved against it                                                                                                                       |
| `doc/guides/compile.md`              | the paragraphs on the names a build compiles by                                                                                                                                       |

### The build directory is where a compile runs

The sources were already spelled from the tree, `src/vm.c`, and the tree was mapped to `.` (#7374); what stayed a path of the machine was the build directory, in `-I"/tmp/build/host/include"`, and no directory reaches both the tree and a build directory elsewhere by a fixed name. The compilers run from the build directory now, and everything under it or under the tree is spelled from there: `-I"host/include"`, `-o "host/src/vm.o"`, `../src/vm.c`. A build directory anywhere else is `build` in what the compilers write, as before, and the tree is `..` from it: a build outside the tree spells the tree by a path of the machine, relative as it is, and maps that to `..`, so that its output is the output of a build inside the tree. A debugger run from the tree resolves `build/../src/vm.c` for either.

`gcc` records the directory it ran from and is told what to write for it through the map of the build directory, `-ffile-prefix-map="/tmp/build=build"`, which `ccache` does not key on. `clang` is told `-ffile-compilation-dir="build"` and needs no map of the build directory, so a build inside the tree has no path of the machine on its command line, and a build outside it has only the relative one of the tree, which two build directories at the same depth share.

`ccache` keys the directory a compile ran from as the prefix maps rewrite it, or as `-ffile-compilation-dir` names it, and not the arguments of the maps; this was measured with ccache 4.14 in a private cache, one option changed at a time. Two build directories therefore share every object as long as they sit at the same depth, where the tree has the same relative name from both.

### What keeps its name

The generated prism sources carry `#line` directives naming their templates, which were written against the tree, so that ccache could find the file they name and keep its direct mode. They are written as the name the compile is given for the gem's directory now, `../mrbgems/mruby-compiler/lib/prism/templates/src/node.c.erb` from a build in `build/` under the tree, and as the gem's path where the build compiles by paths; a gem outside the tree, which the rewrite used to leave alone, gets its path too, which resolves from anywhere.

`mrbc` is still run from the tree and given the names the sources have from it, `mrblib/kernel.rb`, since the name it records is read by people in a backtrace and reaches nothing the C compiler keys on. A relative path a config writes into `include_paths` is still read against the tree, and named from the build directory from there. A gem outside both the tree and the build directory is named by its path as before. A build that writes another name for the tree, `enable_file_prefix_map source: "mruby"`, or that keeps its paths, `disable_file_prefix_map`, compiles from the tree with the paths as they are, as before.

## Behaviour

- `__FILE__`, which `mrb_assert` reports through `assert`, reads `../src/vm.c` where it read `src/vm.c`, and the debug information names the compilation directory `build` and the source `../src/vm.c` from it. Both are what a build in `build/` under the tree wrote, and `gdb` run from the tree finds the source under either.
- An object compiled before this change is compiled once more, since its recorded flags no longer match (#7236).
- The `directory` of `compile_commands.json` is the build directory, and `command` names the source from it.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, gcc, `size -A`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,000,502 | 2,000,502 |     0 |
| bintest          | 1,402,694 | 1,402,694 |     0 |
| cxx_abi          | 1,435,945 | 1,435,945 |     0 |
| byte-string      | 1,364,294 | 1,364,294 |     0 |
| ascii-ctype      | 1,387,318 | 1,387,318 |     0 |
| no-float         | 1,330,174 | 1,330,174 |     0 |
| no-bigint        | 1,288,454 | 1,288,454 |     0 |

Every object of every build has the same `.text`; what changes is the name the debug information gives the source and the compilation directory.

## Testing

`rake -m test`, `MRUBY_BUILD_DIR` under `/tmp`, gcc; each `bin/mrbtest` run on its own:

| Build               | Total |    OK | Skip |  KO | Crash | Warning |
| ------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`default.rb`) | 2,791 | 2,717 |   74 |   0 |     0 |       0 |
| full-debug          | 3,039 | 3,028 |   11 |   0 |     0 |       0 |
| bintest             | 3,039 | 3,019 |   20 |   0 |     0 |       0 |
| cxx_abi             | 3,039 | 3,019 |   20 |   0 |     0 |       0 |
| byte-string         | 2,951 | 2,877 |   74 |   0 |     0 |       0 |
| ascii-ctype         | 3,023 | 3,001 |   22 |   0 |     0 |       0 |
| no-float            | 2,772 | 2,675 |   97 |   0 |     0 |       0 |
| no-bigint           | 2,988 | 2,955 |   33 |   0 |     0 |       0 |

bintest: 130 (OK 129 / Skip 1) for `default.rb`, 147 (OK 146 / Skip 1) for `ci/gcc-clang.rb`.

- `ccache` in a private cache, a config built into two build directories under `/tmp` at the same depth, the second build: `minimal.rb` gcc 66 of 67 objects hit, clang 67 of 67; `host-debug.rb` gcc 238 of 239. The one miss each time is the probe `try_compile` runs, whose source sits in a temporary directory of its own. Before the `#line` rewrite followed the compile directory, `host-debug.rb` missed `prism/src/node.c` and `prism/src/serialize.c` too, the two generated sources that carry the directives: the ccache log says `Include file mrbgems/mruby-compiler/lib/prism/templates/src/node.c.erb does not exist, disabling direct mode`.
- A build in `build/` under a copy of the tree, one in `out/x` under it, and one with `enable_file_prefix_map source: "mruby", build: "mruby/build"` and one with `disable_file_prefix_map`: the compile lines and the `DW_AT_name` / `DW_AT_comp_dir` of `src/vm.o` are as described above, and the one in `build/` compiles with no `-ffile-prefix-map` under clang.
- A header touched after the build recompiles the objects that read it, 65 of 67 for `include/mruby/value.h`, and a second run compiles nothing; `mrblib.c` of a build under `enable_debug` records `mrblib/array.rb`.
- `prek run` passes on the changed files.

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Linux 7.0.0-31-generic x86_64                      |
| CPU        | AMD Ryzen 9 5950X                                  |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| clang      | Homebrew clang version 23.1.0                      |
| binutils   | GNU ld (GNU Binutils) 2.47.20260726                |
| ccache     | 4.14                                               |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| Rake       | 13.3.1                                             |

`src/string.c` of each build of `build_config/ci/gcc-clang.rb`, `MRUBY_BUILD_DIR=/tmp/build` outside the tree, with `-MMD -c`, `-I` and `-o` left out; the tree sits under a longer name in a git worktree and is written as `/home/takumi/mruby` here:

full-debug:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

bintest:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "../../../../home/takumi/mruby/src/string.c"
```

cxx_abi:

```console
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

byte-string:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

ascii-ctype:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

no-float:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

no-bigint:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../../../../home/takumi/mruby=.." -ffile-prefix-map="/tmp/build=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../../../home/takumi/mruby/src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builds using relative source paths, including projects outside the main source tree or on different drives.
  * Corrected compiler dependency resolution and compilation database path handling.
  * Improved source file locations shown in debugging information and generated compiler output.

* **Documentation**
  * Updated file-prefix mapping and debugger path-substitution guidance to reflect revised build-directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->