### PR TITLE
build: run a link probe where a link runs

### DIFF
--- a/lib/mruby/build/command.rb
+++ b/lib/mruby/build/command.rb
@@ -565,18 +565,24 @@ module MRuby
     end
 
     # What an answer about +source+ is kept under: everything that goes into
-    # the compile, the extension included.
+    # the compile, the extension and the directory it runs from included. The
+    # answers are kept for the whole run, which builds every target of a
+    # config, and a relative name in the flags stands for a file of the
+    # directory the compile runs from.
     def probe_key(source)
-      [build.filename(command), compile_options, source_exts.first, all_flags(compiled: true), source]
+      [build.filename(command), compile_options, source_exts.first,
+       build.compile_dir, all_flags(compiled: true), source]
     end
 
     # Compile +source+ and answer whether it compiled.  The source and the
     # object are named inside a directory that is removed on the way out; the
     # compiler is run from the directory a compile runs from, which is what a
     # relative path in the flags is written against.  A block is given the
-    # directory, the object and the options the compiler ran with, while the
-    # directory is still there, and its answer stands for an object that
-    # compiled.
+    # directory, the object and the options that keep the output out of the
+    # way, while the directory is still there, and its answer stands for an
+    # object that compiled.  The directory the compile ran from is not among
+    # them, since it is the compiler's own and what the block runs is not a
+    # compile.
     def run_compile_probe(source)
       Dir.mktmpdir("mruby-probe") do |dir|
         infile = "#{dir}/probe#{source_exts.first || '.c'}"
@@ -588,10 +594,10 @@ module MRuby
         # The build directory is made here where a probe is the first thing
         # the build runs from it.
         mkdir_p build.compile_dir
-        opts = {out: File::NULL, err: File::NULL, chdir: build.compile_dir}
+        opts = {out: File::NULL, err: File::NULL}
         # `system` answers nil where the command is not there to run at all,
         # which is an answer of no like any other failure to compile.
-        compiled = !!system("#{build.filename(command)} #{options}", **opts)
+        compiled = !!system("#{build.filename(command)} #{options}", **opts, chdir: build.compile_dir)
         compiled && block_given? ? yield(dir, outfile, opts) : compiled
       end
     end
@@ -732,7 +738,12 @@ module MRuby
 
     # Link the one +objfile+ into +outfile+, with +params+ from `link_params`,
     # and answer whether it linked, saying nothing either way.  +opts+ are
-    # `system`'s, as the compile probe ran with them.
+    # `system`'s, the ones that keep the output out of the way.
+    #
+    # The link runs where `run` links from, and not where the probe compiled:
+    # a relative path a config writes in `library_paths` is written against
+    # the tree and reaches the link line as it is, so a link run from the
+    # build directory would ask about a directory no link of the build names.
     def run_probe(outfile, objfile, params, **opts)
       options = link_options % params.merge(:outfile => filename(outfile), :objs => %Q["#{filename(objfile)}"])
       !!system("#{build.filename(command)} #{options}", **opts)


### PR DESCRIPTION
## Summary

A probe that links, which `check_func` runs to see whether a name resolves, ran its link from the build directory, where the compile of a probe runs since #7567. A link of the build runs from the tree, and a relative path a configuration writes in `library_paths` reaches the link line as it stands, so the probe asked the linker about a directory no link of the build names.

## Changes

| File                         | What                                                                                                                                                                                                                                                             |
| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `lib/mruby/build/command.rb` | the compile of a probe is given the directory a compile runs from, and the block that links is given the options that keep the output out of the way; `Linker#run_probe` links where `Linker#run` links from; `probe_key` names the directory a compile ran from |

### The two halves of a link probe

`try_link` compiles a source and links the object into a program, and the two halves run where the build runs each of them. The compile runs from the build directory, which is what the relative names on a compile line are written against, `-I"host/include"` and `../src/vm.c`. The link is written against nothing of the kind: `Linker#run` links from where the build runs, and `Linker#all_flags` writes a path of `library_paths` on the link line as the configuration wrote it, so `library_paths << "vendor/lib"` names a directory of the tree in every link of the build.

The probe handed the options of its compile to the link, the directory among them, and the linker then looked for `vendor/lib` under the build directory. The block is given the options that keep the output of a probe out of the way now, and the directory each half runs from is the half's own.

### What an answer is kept under

An answer is kept for the whole run, which builds every target of a configuration, and `probe_key` names what goes into the compile it came from. A relative name in `flags` reaches the compile line as the configuration wrote it, so it stands for a file of the directory the compile runs from, and that directory is part of the key now. Two targets given build directories of their own, at the same depth so that the names they have for the tree agree, asked the same question of two directories and were answered from one.

## Behaviour

- `check_func` answers about a name a library under a relative `library_paths` defines as the link that resolves it answers: a gem asking after a name of its own library, `check_func(name, header: header, link: spec.linker)`, was answered no while the binary that links that library linked, and the define the answer turns into was left out of the compile.
- `check_header` and `check_func` answer each target of a configuration about the directory that target compiles from, where the targets have build directories of their own.
- Every `library_paths` of the tree's build configurations is absolute, so no build here answers differently than it did.

## Size

`.text` of `bin/mruby`, `build_config/ci/gcc-clang.rb`, gcc, `size -A`:

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,001,094 | 2,001,094 |     0 |
| bintest          | 1,399,926 | 1,399,926 |     0 |
| cxx_abi          | 1,436,601 | 1,436,601 |     0 |
| byte-string      | 1,361,526 | 1,361,526 |     0 |
| ascii-ctype      | 1,384,550 | 1,384,550 |     0 |
| no-float         | 1,327,294 | 1,327,294 |     0 |
| no-bigint        | 1,285,670 | 1,285,670 |     0 |

Nothing here reaches a compile line, and no probe of these configurations answers differently, so every object is the object master builds.

## Testing

`rake -m test`, each `bin/mrbtest` run on its own:

| Build               | Total |    OK | Skip |  KO | Crash | Warning |
| ------------------- | ----: | ----: | ---: | --: | ----: | ------: |
| host (`default.rb`) | 2,792 | 2,718 |   74 |   0 |     0 |       0 |
| full-debug          | 3,040 | 3,029 |   11 |   0 |     0 |       0 |
| bintest             | 3,040 | 3,020 |   20 |   0 |     0 |       0 |
| cxx_abi             | 3,040 | 3,020 |   20 |   0 |     0 |       0 |
| byte-string         | 2,952 | 2,878 |   74 |   0 |     0 |       0 |
| ascii-ctype         | 3,024 | 3,002 |   22 |   0 |     0 |       0 |
| no-float            | 2,773 | 2,676 |   97 |   0 |     0 |       0 |
| no-bigint           | 2,989 | 2,956 |   33 |   0 |     0 |       0 |

bintest: 130 (OK 129 / Skip 1) for `default.rb`, 147 (OK 146 / Skip 1) for `ci/gcc-clang.rb`.

- The answer this changes was measured with a gem that asks after a name of a library of its own: `spec.linker.library_paths << "probe_vendor/lib"` names a directory of the tree holding an archive that defines the name, a header of the gem declares it, and `spec.cc.check_func(name, header: header, link: spec.linker)` asks from `spec.build_settings` with `MRUBY_BUILD_DIR` under the tree. The answer is `false` on master and `true` with this; `can_link?`, which links nothing of the gem, answers yes either way.
- The cache key was measured with two targets given build directories of their own at the same depth, `cc.flags << "-Iprobe_inc"`, a header under the first of the two alone, and `cc.option_file_prefix_map = nil` for a compiler that knows no such option, which leaves the flags of the two the same text: `check_header` answers yes and yes on master, and yes and no with this.
- `prek run` passes on the changed file.

## Environment

<details>
<summary>Host, compilers, and the compile lines</summary>

|            |                                                    |
| ---------- | -------------------------------------------------- |
| OS         | Linux 7.0.0-31-generic x86_64                      |
| CPU        | AMD Ryzen 9 5950X                                  |
| C compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0        |
| clang      | Homebrew clang version 23.1.0                      |
| binutils   | GNU ld (GNU Binutils) 2.47.20260726                |
| CRuby      | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |
| Rake       | 13.3.1                                             |

`src/string.c` of each build of `build_config/ci/gcc-clang.rb`, `MRUBY_BUILD_DIR` at `build/pr` under the tree, with `-MMD -c`, `-I` and `-o` left out; the tree sits under a longer name in a git worktree and is written as `/home/takumi/mruby` here:

full-debug:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

bintest:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK "../../src/string.c"
```

cxx_abi:

```console
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

byte-string:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

ascii-ctype:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

no-float:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

no-bigint:

```console
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="/home/takumi/mruby/build/pr=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER "../../src/string.c"
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compiler and linker capability checks during builds, including more reliable handling of command execution and unavailable tools.
  - Build probes now run from the appropriate build directory, improving consistency with normal compilation and linking behavior.

- **Documentation**
  - Clarified how build directories are managed for compiler and linker checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->