### PR TITLE
vm.c: count the keyword dictionary in the env length `OP_ARGARY` needs

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2536,7 +2536,7 @@ vm_op_argary(mrb_state *mrb, uint32_t a, uint16_t b)
   else {
     struct REnv *e = uvenv(mrb, lv-1);
     if (!e) goto L_NOSUPER;
-    if (MRB_ENV_LEN(e) <= m1+r+m2+1)
+    if (MRB_ENV_LEN(e) <= m1+r+m2+kd+1)
       goto L_NOSUPER;
     stack = e->stack + 1;
   }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -117,6 +117,31 @@ assert('super forwards the keyword arguments at their current values') do
   assert_equal [1, {c: 2}], anon.new.rest(a: 1, c: 2)
 end
 
+assert('super forwards from a scope that has closed') do
+  # A block that outlives its method reads the method's locals through an
+  # env moved off the stack when the frame popped, holding exactly the
+  # locals the scope declared.  The argument slots, the keyword dictionary
+  # and the block all reach `super` through that copy, so what it was sized
+  # for is what a `super` running this late can forward.
+  base = Class.new do
+    def kw(a, k: 1); [a, k, block_given? ? yield : nil]; end
+    def rest(a:, **o); [a, o]; end
+    def post(a, *r, z, k: 1); [a, r, z, k]; end
+  end
+  sub = Class.new(base) do
+    def kw(a, k: 1); -> { super }; end
+    def rest(a:, **o); -> { super }; end
+    def post(a, *r, z, k: 1); -> { super }; end
+  end
+
+  fwd = sub.new.kw(1, k: 2) { :caller }
+  assert_equal [1, 2, :caller], fwd.call
+  assert_equal [1, 2, :caller], fwd.call
+  assert_equal [9, 1, :caller], sub.new.kw(9) { :caller }.call
+  assert_equal [1, {c: 2}], sub.new.rest(a: 1, c: 2).call
+  assert_equal [1, [2, 3], 4, 5], sub.new.post(1, 2, 3, 4, k: 5).call
+end
+
 assert('yield', '11.3.5') do
 # it's syntax error now
 #  assert_raise LocalJumpError do


### PR DESCRIPTION
## Summary

`OP_ARGARY` reads the block one slot past the keyword dictionary when the frame it forwards has keywords, but the length it demands of the env it reads through does not count that slot, so a `kd` frame reads one value past the end of a closed env. `OP_BLKPUSH` counts the same slot, since 1348daa68.

## Changes

| File               | What                                                   |
| ------------------ | ------------------------------------------------------ |
| `src/vm.c`         | count `kd` in the env length `vm_op_argary()` requires |
| `test/t/syntax.rb` | cover a `super` that runs after its scope closed       |

### The slot the length does not count

`vm_op_argary()` reads the frame it forwards through `stack = e->stack + 1`, and the last slot it touches is `stack[m1+r+m2+kd]`: the block, which sits one past the keyword dictionary when `kd` is set. Reaching it needs `MRB_ENV_LEN(e)` to be at least `m1+r+m2+kd+2`, and the guard asked for `kd` fewer. `vm_op_blkpush()` reads that same block slot and spells the bound as `MRB_ENV_LEN(e) <= offset+1` for `offset = m1+r+m2+kd`, which is what this makes `OP_ARGARY` ask for as well.

### What the bound rejects

Nothing a compiler produces. `gen_blkmove()` puts the block in local `m1+r+m2+kd+1`, and the length an env is made with is the scope's `nlocals`, so the stricter bound is one every method already answers. Sixteen argument shapes were checked against the `OP_ARGARY` operand their `super` was given, from `def m(a)` through `def m(a, b=1, c=2, *r, d, e, k1: 1, k2: 2, **kw, &blk)`; the tightest is `def m(a, **kw)`, whose `nlocals` of 4 equals the bound exactly. What the guard is left for is an irep that arrived by another road, which is why it reads a length at all.

### The test

The length this corrects describes an env that has closed, the copy `mrb_env_unshare()` makes when the frame pops, sized to the locals. No test read a `super` through one. Every `super` the file exercised ran while the frame it forwards was still alive, the lambda in `super forwards the keyword arguments at their current values` included, since it is called where it is made. A block that outlives its method is the shape that leaves the arguments, the keyword dictionary and the block in that copy. The assertions answer the same on master, so they are coverage of the shape the bound is about rather than a regression test for the bound.

Out of scope but next door: the same operand carries the scope level in four bits and the compiler masks it without a check, so at a block nesting of 16 a bare `super` forwards another frame's registers and `yield` raises `LocalJumpError`. Refusing that belongs to the compiler, would turn code that compiles today into a `too many nested blocks/methods` error, and reaches `OP_BLKPUSH` as much as `OP_ARGARY`, so it wants a change of its own rather than a rider on a bounds check.

```ruby
base = Class.new { def m(a, k: 1); [a, k]; end }
# the child's `def m(a, k: 1)` wraps a bare `super` in sixteen `[0].each { }`
sub.new.m(1, k: 2)   # CRuby: [1, 2], mruby: [nil, 2]
```

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`:

| Build            |    master |   This PR | Delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,001,334 | 2,001,350 |   +16 |
| bintest          | 1,400,134 | 1,400,070 |   -64 |
| cxx_abi          | 1,435,113 | 1,435,097 |   -16 |
| byte-string      | 1,361,734 | 1,361,670 |   -64 |
| ascii-ctype      | 1,384,758 | 1,384,694 |   -64 |
| no-float         | 1,327,502 | 1,327,470 |   -32 |
| no-bigint        | 1,285,878 | 1,285,878 |     0 |

Every delta belongs to `src/vm.o` and matches the binary's to the byte. At `-O0` the added term costs 7 bytes; where the optimizer runs it folds the comparison differently and the function lands smaller.

## Testing

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2794 | 2720 |   74 |   0 |     0 |       0 |
| full-debug  |  3042 | 3031 |   11 |   0 |     0 |       0 |
| bintest     |  3042 | 3022 |   20 |   0 |     0 |       0 |
| cxx_abi     |  3042 | 3022 |   20 |   0 |     0 |       0 |
| byte-string |  2954 | 2880 |   74 |   0 |     0 |       0 |
| ascii-ctype |  3026 | 3004 |   22 |   0 |     0 |       0 |
| no-float    |  2775 | 2678 |   97 |   0 |     0 |       0 |
| no-bigint   |  2991 | 2958 |   33 |   0 |     0 |       0 |

bintest ran in the `bintest` build and passed.

The new assertions pin what a `super` forwards once its scope has closed: the argument, the keyword at its current value, the caller's block, a `**rest`, a post argument, and the same answer from a second call of the same Proc.

A sweep of 116 `super` shapes against CRuby 4.0.6, covering every `kd` layout, block and lambda nesting, envs that have closed, and the argument count boundaries, answers the same on master and on this branch.

## Environment

<details>

|          |                                                                   |
| -------- | ----------------------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                                |
| Kernel   | Linux 7.0.0-31-generic x86_64                                     |
| CPU      | AMD Ryzen 9 5950X 16-Core Processor                               |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

host:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang full-debug:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang bintest:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang cxx_abi (compiled as C++, g++ links):

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang byte-string:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang ascii-ctype:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-float:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-bigint:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `super` calls from deferred scopes so they continue to forward positional, keyword, rest, and block arguments correctly after the original method returns.
  - Corrected handling of keyword arguments when invoking `super`, including default values and repeated calls.
  - Preserved caller-supplied blocks when forwarding through deferred `super` calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->