### PR TITLE
mruby-compiler: store the right value in each multiple assignment target

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -2725,18 +2725,22 @@ gen_massignment(mrc_codegen_scope *s, mrc_node *tree, int rhs, int val)
   }
   if (has_rest || 0 < post) {
     gen_move(s, cursp(), rhs, val);
+    int sp = cursp();
+    /* OP_APOST fills sp..sp+post, and the targets keep being read from there
+       while they are assigned: a call or index target assigns through a send
+       built from cursp() up, so those registers have to be reserved first */
     push_n(post+1);
-    pop_n(post+1);
-    genop_3(s, OP_APOST, cursp(), n, post);
+    genop_3(s, OP_APOST, sp, n, post);
     if (has_rest) { /* rest */
       pm_node_t *rest_expr = ((pm_splat_node_t *)cast->rest)->expression;
       if (rest_expr) {
-        gen_assignment(s, rest_expr, NULL, cursp(), NOVAL);
+        gen_assignment(s, rest_expr, NULL, sp, NOVAL);
       }
     }
     for (int i = 0; i < post; i++) {
-      gen_assignment(s, cast->rights.nodes[i], NULL, cursp()+i+1, NOVAL);
+      gen_assignment(s, cast->rights.nodes[i], NULL, sp+i+1, NOVAL);
     }
+    pop_n(post+1);
     if (val) {
       gen_move(s, cursp(), rhs, 0);
     }
@@ -4937,8 +4941,11 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
               n++;
             }
             else {
-              genop_1(s, OP_LOADNIL, rhs+n);
-              gen_assignment(s, cast->lefts.nodes[i], NULL, rhs+n, NOVAL);
+              int sp = cursp();
+              genop_1(s, OP_LOADNIL, sp);
+              push();
+              gen_assignment(s, cast->lefts.nodes[i], NULL, sp, NOVAL);
+              pop();
             }
           }
         }
@@ -4958,7 +4965,13 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
             genop_3(s, OP_ARRAY2, cursp(), rhs+n, rn);
           }
           if (((pm_splat_node_t *)cast->rest)->expression) {
-            gen_assignment(s, ((pm_splat_node_t *)cast->rest)->expression, NULL, cursp(), NOVAL);
+            int sp = cursp();
+            /* the array is above the values but not reserved; a target that is
+               a call or an index assigns through a send whose receiver is built
+               at cursp() and would overwrite it */
+            push();
+            gen_assignment(s, ((pm_splat_node_t *)cast->rest)->expression, NULL, sp, NOVAL);
+            pop();
           }
           n += rn;
         }
@@ -4980,8 +4993,11 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
               n++;
             }
             else {
-              genop_1(s, OP_LOADNIL, cursp());
-              gen_assignment(s, cast->rights.nodes[i], NULL, cursp(), NOVAL);
+              int sp = cursp();
+              genop_1(s, OP_LOADNIL, sp);
+              push();
+              gen_assignment(s, cast->rights.nodes[i], NULL, sp, NOVAL);
+              pop();
               n++;
             }
           }

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4977,6 +4977,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
           for (size_t i = 0; i < post; i++) {
             if (n < len) {
               gen_assignment(s, cast->rights.nodes[i], NULL, rhs+n, NOVAL);
+              n++;
             }
             else {
               genop_1(s, OP_LOADNIL, cursp());

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -336,6 +336,47 @@ assert('multiple assignment to an attribute counts its registers') do
   assert_equal [11, 12], [i, h[0]]
 end
 
+assert('a multiple assignment target assigning through a send keeps its value') do
+  # The rest array, the values behind a rest, and the `nil` a target past the
+  # end of the values takes all sit at the top of the frame without being
+  # reserved, and a target that is an attribute or an index assigns by
+  # sending, which builds its receiver from there up. The receiver landed on
+  # the value being assigned, so each such target stored the receiver.
+  klass = Class.new do
+    attr_accessor :v, :w, :x
+  end
+  o = klass.new
+
+  *o.v, o.w = 1, 2, 3
+  assert_equal [[1, 2], 3], [o.v, o.w]
+
+  h = {}
+  h[:a], *h[:b], h[:c] = 1, 2, 3, 4
+  assert_equal({:a => 1, :b => [2, 3], :c => 4}, h)
+
+  # a target the values do not reach takes nil through the same send, in
+  # front of a rest and behind one
+  o = klass.new
+  o.v, o.w, o.x = 1, 2
+  assert_equal [1, 2, nil], [o.v, o.w, o.x]
+  h = {}
+  h[:a], h[:b] = [1]
+  assert_equal({:a => 1, :b => nil}, h)
+  o = klass.new
+  *o.v, o.w, o.x = 1
+  assert_equal [[], 1, nil], [o.v, o.w, o.x]
+
+  # the same targets with an rhs whose length the compiler cannot count
+  rhs = [1, 2, 3]
+  o = klass.new
+  *o.v, o.w = *rhs
+  assert_equal [[1, 2], 3], [o.v, o.w]
+
+  h = {}
+  h[:a], *h[:b], h[:c] = *[1, 2, 3, 4]
+  assert_equal({:a => 1, :b => [2, 3], :c => 4}, h)
+end
+
 assert('a discarded interpolation leaves the register pointer where it was') do
   # A string literal whose value is thrown away is compiled for the side
   # effects of its interpolations alone. Each part was popped though nothing

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -614,6 +614,16 @@ assert('multiple assignment (rest+post)') do
   assert_equal 2, b
   assert_equal [], c
   assert_equal 3, d
+
+  # each post target takes the next value left after the rest, and nil once
+  # they run out; the counter that walks them stood still, so every post
+  # target after the first took the value of the one before it
+  e, f, *g, h, i = 1, 2, 3
+  assert_equal [1, 2, [], 3, nil], [e, f, g, h, i]
+  e, f, *g, h, i = 1, 2, 3, 4
+  assert_equal [1, 2, [], 3, 4], [e, f, g, h, i]
+  e, f, *g, h, i = 1, 2, 3, 4, 5
+  assert_equal [1, 2, [3], 4, 5], [e, f, g, h, i]
 end
 
 assert('multiple assignment (nosplat array rhs)') do


### PR DESCRIPTION
## Summary

A multiple assignment stored the wrong value in a target whenever the values ran out before the targets did, or the target was an attribute or an index rather than a local. Two commits: the counter that walks the values, and the registers the values sit in.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-compiler/src/codegen.c` | advance the post counter of a counted right-hand side; reserve the registers a target assigns from |
| `test/t/syntax.rb` | the value each post target takes |
| `test/t/codegen.rb` | attribute and index targets keep the value assigned to them |

### The counter over a counted right-hand side

When the compiler can count the values, `PM_MULTI_WRITE_NODE` assigns them from their registers directly. The loop over the post targets read `rhs+n` without advancing `n`, so the second post target read the register of the first, and `n` never reached `len`, where a target past the end takes `nil` instead.

### The registers a target assigns from

`OP_APOST`, the `OP_ARRAY` a counted right-hand side builds for a rest, and the `OP_LOADNIL` a target past the end of the values takes all write to the top of the frame without reserving the registers. A target that is an attribute or an index assigns by sending, and `gen_assignment()` builds the receiver of that send at `cursp()`, which is the register holding the very value it is about to store. The send then assigned the receiver to itself.

The pre targets already reserved their register through `push()`, and every target that is a local, an instance variable, a global or a constant assigns with a single instruction and never needed one, which is why only attributes and indices behind a rest or past the end of the values were affected.

## Behaviour

```ruby
a, b, *c, d, e = 1, 2, 3   # CRuby: [1, 2, [], 3, nil], mruby: [1, 2, [], 3, 3]

o = C.new
*o.x, o.y = 1, 2, 3        # CRuby: o.x == [1, 2], mruby: o.x.equal?(o)

h = {}
h[:a], h[:b] = [1]         # CRuby: {a: 1, b: nil}, mruby: h[:b].equal?(h)
```

## Size

`.text` of `bin/mruby`, gcc 13.3.0.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,001,334 | 2,001,478 | +144 |
| bintest | 1,400,134 | 1,400,310 | +176 |
| cxx_abi | 1,435,113 | 1,435,225 | +112 |
| byte-string | 1,361,734 | 1,361,910 | +176 |
| ascii-ctype | 1,384,758 | 1,384,934 | +176 |
| no-float | 1,327,502 | 1,327,534 | +32 |
| no-bigint | 1,285,878 | 1,286,054 | +176 |

All of it is `codegen.o`, which carries the same delta as the binary in every build.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,794 | 2,720 | 74 | 0 | 0 | 0 |
| full-debug | 3,042 | 3,031 | 11 | 0 | 0 | 0 |
| bintest | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| byte-string | 2,954 | 2,880 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,026 | 3,004 | 22 | 0 | 0 | 0 |
| no-float | 2,775 | 2,678 | 97 | 0 | 0 | 0 |
| no-bigint | 2,991 | 2,958 | 33 | 0 | 0 | 0 |

`rake test:bin` on the bintest build answers 147 with 146 OK and 1 skip.

The test in `test/t/syntax.rb` extends `multiple assignment (rest+post)` with the three lengths that separate a post target reading the value before it from one reading its own. The test in `test/t/codegen.rb` covers three registers a target can assign from: the rest array, the `nil` of a target past the end of the values, and the `OP_APOST` slots of a right-hand side the compiler cannot count. Each gets an attribute target and an index target, next to the existing test for the registers a pre target's send reads.

Beyond the suite, a generated sweep of 2,024 shapes (0 to 2 pre targets, no rest or an anonymous or a named one, 0 to 2 post targets, targets all local or all attribute or all index or mixed, eleven right-hand sides, and the value of the assignment as its own case) and a second of 807 (nested targets, instance variables, globals, constants, multi-argument and 14-argument indices, blocks, `for`, and receiver and value evaluation order) answer as CRuby 4.0.6 does. On master 61 of the first sweep disagree, all of them attribute or index targets.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc 13.3.0, g++ 13.3.0 |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, `-MMD -c -I -o` dropped:

```
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG ...
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_USE_DEBUG_HOOK ...
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI ...
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings ...
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE ...
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT ...
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings ...
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed multiple-assignment behavior involving attribute and index targets, preserving assigned values correctly.
  - Corrected rest-and-post assignments so values are distributed to each target in the proper order.
  - Ensured targets without corresponding values receive `nil`.
- **Tests**
  - Added coverage for multiple-assignment scenarios with rest targets, setter expressions, index targets, and variable-length right-hand expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->