### PR TITLE
mruby-enum-ext: pass every yielded value to the `to_h` block

### DIFF
--- a/mrbgems/mruby-enum-ext/mrbgem.rake
+++ b/mrbgems/mruby-enum-ext/mrbgem.rake
@@ -3,4 +3,5 @@ MRuby::Gem::Specification.new('mruby-enum-ext') do |spec|
   spec.author  = 'mruby developers'
   spec.summary = 'Enumerable module extension'
   spec.add_test_dependency 'mruby-fiber', core: 'mruby-fiber'
+  spec.add_test_dependency 'mruby-enumerator', core: 'mruby-enumerator'
 end

--- a/mrbgems/mruby-enum-ext/mrblib/enum.rb
+++ b/mrbgems/mruby-enum-ext/mrblib/enum.rb
@@ -835,8 +835,8 @@ module Enumerable
   def to_h(&blk)
     h = {}
     if blk
-      self.each do |v|
-        v = blk.call(v)
+      self.each do |*v|
+        v = blk.call(*v)
         raise TypeError, "wrong element type #{v.class} (expected Array)" unless Array === v
         raise ArgumentError, "element has wrong array length (expected 2, was #{v.size})" if v.size != 2
         h[v[0]] = v[1]

--- a/mrbgems/mruby-enum-ext/test/enum.rb
+++ b/mrbgems/mruby-enum-ext/test/enum.rb
@@ -188,6 +188,19 @@ assert("Enumerable#to_h") do
   assert_equal({1=>4,3=>8}, c.new.to_h{|k,v|[k,v*2]})
 end
 
+assert("Enumerable#to_h with a multi-value yield") do
+  c = Class.new {
+    include Enumerable
+    def each
+      yield 1, 2
+      yield 3, 4
+    end
+  }
+  assert_equal({2=>1, 4=>3}, c.new.to_h{|k,v|[v,k]})
+  assert_equal({1=>4, 3=>8}, c.new.to_h(&->(k, v) { [k, v*2] }))
+  assert_equal({0=>1, 1=>2}, [1, 2].each_with_index.to_h{|x,i|[i,x]})
+end
+
 assert("Enumerable#filter_map") do
   assert_equal [4, 8, 12, 16, 20], (1..10).filter_map{|i| i * 2 if i%2==0}
 end


### PR DESCRIPTION
## Summary

`Enumerable#to_h` fed its block only the first value of each `yield`, so a source that yields a pair reached the block with the rest dropped. The block now receives every yielded value, the way CRuby's `enum_to_h_ii` hands them over with `rb_yield_values2(argc, argv)`.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-enum-ext/mrblib/enum.rb` | gather the yielded values with `\|*v\|` and splat them into the block |
| `mrbgems/mruby-enum-ext/mrbgem.rake` | take `mruby-enumerator` as a test dependency |
| `mrbgems/mruby-enum-ext/test/enum.rb` | cover a multi-value source and an enumerator |

### The two branches disagreed

`to_h` already had two branches. The blockless one collects the values with `|*v|` and folds them with `__svalue`, which is what makes `[[1, 2]].to_h` and a source yielding `1, 2` answer the same hash. The block branch bound a single `|v|` instead, so everything after the first value never reached the block.

CRuby splits the same way and keeps both halves whole. `enum_to_h` picks between two iterators: `enum_to_h_i` folds the values with `ENUM_WANT_SVALUE()`, and `enum_to_h_ii` hands them all to the block with `rb_yield_values2(argc, argv)`. Splatting the gathered values into `blk.call` is that second contract.

### The test needs an enumerator

The symptom people meet is `each_with_index.to_h`, and reaching it needs `Enumerator`. Inside the gem's own test state the core `to_enum` stub in `mrblib/kernel.rb` raises `NotImplementedError`, so the gem takes `mruby-enumerator` as a test dependency. The hand-written `Enumerable` class in the same test pins the primitive without it.

## Behaviour

```ruby
[1, 2].each_with_index.to_h { |x, i| [i, x] }
# CRuby: {0 => 1, 1 => 2}, mruby: {nil => 2}

[1, 2].each_with_index.to_h(&->(x, i) { [i, x] })
# CRuby: {0 => 1, 1 => 2}, mruby: ArgumentError (given 1, expected 2)
```

A block that names one parameter still sees the first value, so `to_h` over a source that yields a single value each time is unchanged.

## Speed

Gathering the values costs an array per element on the block path. Measured with callgrind, one iteration as `Ir(2N) - Ir(N)` over `N = 100,000`.

```ruby
n = ARGV[0].to_i

class Pairs
  include Enumerable

  def initialize(n)
    @n = n
  end

  def each
    i = 0
    while i < @n
      yield i, i
      i += 1
    end
  end
end

Pairs.new(n).to_h { |k, v| [k, v] }
```

| Case | master | this PR | ratio |
| --- | ---: | ---: | ---: |
| `to_h { }` per element | 3,405.86 | 4,025.38 | 1.18x |
| control, `Array#each` sum | 6,197.45 | 6,197.45 | 1.00x |
| control, `String#+` and `#upcase` | 1,479.48 | 1,479.48 | 1.00x |

The controls are bit identical. The blockless path is untouched.

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,001,334 | 2,001,334 | 0 |
| bintest | 1,400,134 | 1,400,134 | 0 |
| cxx_abi | 1,435,113 | 1,435,113 | 0 |
| byte-string | 1,361,734 | 1,361,734 | 0 |
| ascii-ctype | 1,384,758 | 1,384,758 | 0 |
| no-float | 1,327,502 | 1,327,502 | 0 |
| no-bigint | 1,285,878 | 1,285,878 | 0 |

The change is mrblib only, so its weight would land in the `.rodata` of `mrbgems/mruby-enum-ext/gem_init.o`. That section holds 9,200 bytes on both sides: the bytecode differs but not in length.

## Testing

`rake -m test`, all builds green.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,794 | 2,720 | 74 | 0 | 0 | 0 |
| full-debug | 3,042 | 3,031 | 11 | 0 | 0 | 0 |
| bintest | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| byte-string | 2,954 | 2,880 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,026 | 3,004 | 22 | 0 | 0 | 0 |
| no-float | 2,775 | 2,678 | 97 | 0 | 0 | 0 |
| no-bigint | 2,991 | 2,958 | 33 | 0 | 0 | 0 |

The `bintest` build also runs the command tests: 147 total, 146 OK, 1 skip, no failure.

The new assert pins three things: a source yielding two values reaches a two-parameter block, a lambda of two parameters is a legal block there, and `each_with_index.to_h` answers what CRuby answers.

Out of scope, and still apart from CRuby: the block's answer is checked with `Array === v`, so an object that only responds to `to_ary` is refused here and accepted by CRuby, whose `rb_hash_set_pair` takes the answer through `rb_check_array_type`. `Array#to_h` refuses it the same way.

## Environment

<details>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc 13.3.0, g++ 13.3.0 |
| Binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14) +PRISM |

Compile lines, `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I` and `-o` dropped.

```
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The `cxx_abi` build compiles with `gcc -x c++ -std=gnu++03`; `g++` only links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Enumerable#to_h` block handling so multiple yielded values are passed as separate block arguments rather than as an array.

* **Tests**
  * Added coverage for converting multi-value enumerable results into hashes, including transformed key/value pairs and indexed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->