### PR TITLE
mruby-hash-ext: give `Hash#to_h` its block form

### DIFF
--- a/mrbgems/mruby-hash-ext/mrblib/hash.rb
+++ b/mrbgems/mruby-hash-ext/mrblib/hash.rb
@@ -208,13 +208,26 @@ class Hash
 
   ##
   #  call-seq:
-  #     hsh.to_h     -> hsh or new_hash
+  #     hsh.to_h                 -> hsh
+  #     hsh.to_h {|k, v| ... }   -> new_hash
   #
-  #  Returns `self`. If called on a subclass of Hash, converts
-  #  the receiver to a Hash object.
+  #  Returns `self`. If a block is given, it is called with each
+  #  key and value, and it should return a `[key, value]` pair to
+  #  construct a new hash.
   #
-  def to_h
-    self
+  #     {a: 1}.to_h{|k, v| [v, k]}
+  #       # => {1 => :a}
+  #
+  def to_h(&blk)
+    return self unless blk
+    h = {}
+    self.each do |k, v|
+      pair = blk.call(k, v)
+      raise TypeError, "wrong element type #{pair.class} (expected Array)" unless Array === pair
+      raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" if pair.size != 2
+      h[pair[0]] = pair[1]
+    end
+    h
   end
 
   ##

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -199,6 +199,15 @@ assert("Hash#to_h") do
   assert_equal h, h.to_h
 end
 
+assert("Hash#to_h with a block") do
+  h = { "a" => 100, "b" => 200 }
+  assert_equal({ 100 => "a", 200 => "b" }, h.to_h { |k, v| [v, k] })
+  assert_equal({ "a" => 1, "b" => 1 }, h.to_h(&->(k, v) { [k, 1] }))
+  assert_equal :stopped, h.to_h { |k, v| break :stopped }
+  assert_raise(TypeError)     { h.to_h { |k, v| k } }
+  assert_raise(ArgumentError) { h.to_h { |k, v| [k, v, 1] } }
+end
+
 assert('Hash#<') do
   h1 = {a:1, b:2}
   h2 = {a:1, b:2, c:3}


### PR DESCRIPTION
## Summary

`Hash#to_h` took no block, so the block CRuby uses to rewrite each pair was dropped without a word. It now calls the block with the key and the value and builds a new hash from the pairs it answers.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-hash-ext/mrblib/hash.rb` | take a block, call it with each key and value, check the pair it answers |
| `mrbgems/mruby-hash-ext/test/hash.rb` | cover the block form |

### Two arguments, not one pair

CRuby's `to_h_i` yields with `rb_yield_values(2, key, value)`, so a block of one parameter sees the key and a lambda of two parameters is legal. Calling `blk.call(k, v)` gives both. The answer goes through `rb_hash_set_pair`, which refuses anything that is not a two element array; mruby's `Enumerable#to_h` already states those two refusals, and the wording here follows it.

### Without a block nothing moves

`to_h` still answers `self`. CRuby converts a subclass there, through `hash_dup` with `rb_cHash` and the receiver's default proc flag, so the new hash keeps its default. Carrying a default over is a separate piece of work; this PR leaves it alone rather than answering a hash that has lost one.

## Behaviour

```ruby
{k: 2}.to_h { |k, v| [v, k] }
# CRuby: {2 => :k}, mruby: {k: 2}

{k: 2}.to_h { |k, v| k }
# CRuby: TypeError, mruby: {k: 2}
```

## Speed

The method now takes a block parameter and tests it. Measured with callgrind, one iteration as `Ir(2N) - Ir(N)` over `N = 100,000`.

```ruby
n = ARGV[0].to_i
h = { a: 1, b: 2, c: 3 }
i = 0
while i < n
  h.to_h
  i += 1
end
```

| Case | master | this PR | ratio |
| --- | ---: | ---: | ---: |
| `to_h` without a block | 521.00 | 589.00 | 1.13x |
| control, `Array#each` sum | 6,197.45 | 6,197.45 | 1.00x |
| control, `String#+` and `#upcase` | 1,479.48 | 1,479.48 | 1.00x |

68 instructions per call, for reading the block slot and the branch on it. The controls are bit identical.

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,001,334 | 2,001,366 | +32 |
| bintest | 1,400,134 | 1,400,134 | 0 |
| cxx_abi | 1,435,113 | 1,435,113 | 0 |
| byte-string | 1,361,734 | 1,361,734 | 0 |
| ascii-ctype | 1,384,758 | 1,384,758 | 0 |
| no-float | 1,327,502 | 1,327,502 | 0 |
| no-bigint | 1,285,878 | 1,285,878 | 0 |

The change is mrblib only, so the bytecode lands in the `.rodata` of `mrbgems/mruby-hash-ext/gem_init.o`, which grows from 3,124 to 3,348 bytes. `.text` moves only in `full-debug`, where the gem init function is compiled at `-O0`.

## Testing

`rake -m test`, all builds green.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,794 | 2,720 | 74 | 0 | 0 | 0 |
| full-debug | 3,042 | 3,031 | 11 | 0 | 0 | 0 |
| bintest | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| byte-string | 2,954 | 2,880 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,026 | 3,004 | 22 | 0 | 0 | 0 |
| no-float | 2,775 | 2,678 | 97 | 0 | 0 | 0 |
| no-bigint | 2,991 | 2,958 | 33 | 0 | 0 | 0 |

The `bintest` build also runs the command tests: 147 total, 146 OK, 1 skip, no failure.

The new assert pins the rewritten hash, a lambda of two parameters as the block, `break` out of it, and the two refusals. The existing `Hash#to_h` assert keeps the blockless answer.

Out of scope, and still apart from CRuby: `Class.new(Hash)` instances answer themselves rather than a plain `Hash`, and the block's answer is checked with `Array === pair`, so an object that only responds to `to_ary` is refused here and accepted by CRuby, whose `rb_hash_set_pair` takes the answer through `rb_check_array_type`. `Array#to_h` and `Enumerable#to_h` refuse it the same way.

## Environment

<details>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc 13.3.0, g++ 13.3.0 |
| Binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14) +PRISM |

Compile lines, `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I` and `-o` dropped.

```
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The `cxx_abi` build compiles with `gcc -x c++ -std=gnu++03`; `g++` only links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `Hash#to_h` accepts an optional block for transforming key-value pairs into a new hash.
  * Without a block, `to_h` returns the original hash.
  * Block arguments and `break` return values are handled as expected.
  * Invalid block results raise `TypeError` or `ArgumentError` when they are not two-element arrays.
  * Documentation now accurately describes behavior for hash subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->