### PR TITLE
mruby-struct: give `Struct#to_h` its block form

### DIFF
--- a/mrbgems/mruby-struct/mrblib/struct.rb
+++ b/mrbgems/mruby-struct/mrblib/struct.rb
@@ -46,6 +46,32 @@ class Struct
   end
 
   ##
+  #  call-seq:
+  #    struct.to_h                -> hash
+  #    struct.to_h {|k, v| ... }  -> hash
+  #
+  #  Create a hash from member names and struct values. If a block is
+  #  given, it is called with each member name and value, and it should
+  #  return a `[key, value]` pair to construct the hash.
+  #
+  #     Customer = Struct.new(:name, :zip)
+  #     Customer.new("Joe", 12345).to_h{|k, v| [k.to_s, v]}
+  #       # => {"name" => "Joe", "zip" => 12345}
+  #
+  def to_h(&blk)
+    h = __to_h
+    return h unless blk
+    ret = {}
+    h.each {|k, v|
+      pair = blk.call(k, v)
+      raise TypeError, "wrong element type #{pair.class} (expected Array)" unless Array === pair
+      raise ArgumentError, "element has wrong array length (expected 2, was #{pair.size})" if pair.size != 2
+      ret[pair[0]] = pair[1]
+    }
+    ret
+  end
+
+  ##
   # 15.2.18.4.11(x)
   #
   alias to_s inspect

--- a/mrbgems/mruby-struct/src/struct.c
+++ b/mrbgems/mruby-struct/src/struct.c
@@ -956,7 +956,7 @@ static const mrb_mt_entry struct_rom_entries[] = {
   MRB_MT_ENTRY(mrb_struct_len,        MRB_SYM(length),       MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_struct_to_a,       MRB_SYM(to_a),         MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_struct_to_a,       MRB_SYM(values),       MRB_ARGS_NONE()),
-  MRB_MT_ENTRY(mrb_struct_to_h,       MRB_SYM(to_h),         MRB_ARGS_NONE()),
+  MRB_MT_ENTRY(mrb_struct_to_h,       MRB_SYM(__to_h),       MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_struct_to_a,       MRB_SYM(deconstruct),  MRB_ARGS_NONE()),
   MRB_MT_ENTRY(mrb_struct_deconstruct_keys, MRB_SYM(deconstruct_keys), MRB_ARGS_REQ(1)),
   MRB_MT_ENTRY(mrb_struct_values_at,  MRB_SYM(values_at), MRB_ARGS_ANY()),

--- a/mrbgems/mruby-struct/test/struct.rb
+++ b/mrbgems/mruby-struct/test/struct.rb
@@ -194,6 +194,15 @@ assert('Struct#to_h') do
   assert_equal({:white => 'ruuko', :red => 'yuzuki', :green => 'hitoe'}) { s.to_h }
 end
 
+assert('Struct#to_h with a block') do
+  s = Struct.new(:white, :red).new('ruuko', 'yuzuki')
+  assert_equal({'white' => 'ruuko', 'red' => 'yuzuki'}, s.to_h { |k, v| [k.to_s, v] })
+  assert_equal({:white => 'ruuko', :red => 'yuzuki'}, s.to_h(&->(k, v) { [k, v] }))
+  assert_equal :stopped, s.to_h { |k, v| break :stopped }
+  assert_raise(TypeError)     { s.to_h { |k, v| k } }
+  assert_raise(ArgumentError) { s.to_h { |k, v| [k, v, 1] } }
+end
+
 assert('Struct#values_at') do
   a = Struct.new(:blue, :purple).new('aki', 'io')
   assert_equal ['aki'], a.values_at(0)


### PR DESCRIPTION
## Summary

`Struct#to_h` was registered with `MRB_ARGS_NONE()`, so the block CRuby uses to rewrite each member reached nothing. The C function keeps the blockless path under `__to_h` and a wrapper in mrblib calls the block.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-struct/src/struct.c` | register `mrb_struct_to_h` as `__to_h` |
| `mrbgems/mruby-struct/mrblib/struct.rb` | `to_h` wrapper that calls the block and checks the pair it answers |
| `mrbgems/mruby-struct/test/struct.rb` | cover the block form |

### The block belongs on the Ruby side

A method that takes a block is expressed in Ruby here, with the C function kept as a fast path under a `__` name. `Array#max` has the same shape: `ary_max` is registered as `__max` and `mrblib/array.rb` decides between the block and the fast path. The wrapper follows it, so the blockless call still builds the hash in C.

`mrb_struct_to_h` is also what `deconstruct_keys(nil)` answers with. That call reaches the C function directly and is untouched by the rename.

### Two arguments, and a pair back

CRuby's `rb_struct_to_h` walks the members once with a `rb_block_given_p()` branch inside the loop, yielding `rb_yield_values(2, k, v)` and putting the answer through `rb_hash_set_pair`, which refuses anything that is not a two element array. The wrapper calls `blk.call(k, v)` and states the two refusals in the words `Enumerable#to_h` already uses.

## Behaviour

```ruby
Struct.new(:x).new(1).to_h { |k, v| [k.to_s, v] }
# CRuby: {"x" => 1}, mruby: {x: 1}

Struct.new(:x).new(1).to_h { |k, v| k }
# CRuby: TypeError, mruby: {x: 1}
```

## Speed

The blockless call now passes through one Ruby frame. Measured with callgrind, one iteration as `Ir(2N) - Ir(N)` over `N = 100,000`.

```ruby
n = ARGV[0].to_i
s = Struct.new(:x, :y, :z).new(1, 2, 3)
i = 0
while i < n
  s.to_h
  i += 1
end
```

| Case | master | this PR | ratio |
| --- | ---: | ---: | ---: |
| `to_h` without a block | 2,011.18 | 2,419.39 | 1.20x |
| control, `Array#each` sum | 6,197.45 | 6,198.45 | 1.00x |
| control, `String#+` and `#upcase` | 1,479.48 | 1,480.96 | 1.00x |

408 instructions per call, for the wrapper frame and the send to `__to_h`. `Array#max` pays the same kind of frame for the same reason. The controls touch no `Struct`; they move by one and by one and a half instructions because `__to_h` is a new presym, which renumbers the symbols after it.

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,001,334 | 2,001,398 | +64 |
| bintest | 1,400,134 | 1,400,134 | 0 |
| cxx_abi | 1,435,113 | 1,435,113 | 0 |
| byte-string | 1,361,734 | 1,361,734 | 0 |
| ascii-ctype | 1,384,758 | 1,384,758 | 0 |
| no-float | 1,327,502 | 1,327,502 | 0 |
| no-bigint | 1,285,878 | 1,285,878 | 0 |

`src/struct.o` is byte for byte the same size: the method table entry only changed which symbol it names. The wrapper's bytecode lands in the `.rodata` of `mrbgems/mruby-struct/gem_init.o`, which grows from 656 to 912 bytes. `.text` moves only in `full-debug`, where the gem init function is compiled at `-O0`.

## Testing

`rake -m test`, all builds green.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,794 | 2,720 | 74 | 0 | 0 | 0 |
| full-debug | 3,042 | 3,031 | 11 | 0 | 0 | 0 |
| bintest | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,042 | 3,022 | 20 | 0 | 0 | 0 |
| byte-string | 2,954 | 2,880 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,026 | 3,004 | 22 | 0 | 0 | 0 |
| no-float | 2,775 | 2,678 | 97 | 0 | 0 | 0 |
| no-bigint | 2,991 | 2,958 | 33 | 0 | 0 | 0 |

The `bintest` build also runs the command tests: 147 total, 146 OK, 1 skip, no failure.

The new assert pins the rewritten hash, a lambda of two parameters as the block, `break` out of it, and the two refusals. The existing asserts keep the blockless answer and the `deconstruct_keys(nil)` equality, which is what watches the rename.

Out of scope, and still apart from CRuby: the block's answer is checked with `Array === pair`, so an object that only responds to `to_ary` is refused here and accepted by CRuby, whose `rb_hash_set_pair` takes the answer through `rb_check_array_type`. `Array#to_h` and `Enumerable#to_h` refuse it the same way.

## Environment

<details>

| Item | Value |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic x86_64 |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc 13.3.0, g++ 13.3.0 |
| Binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14) +PRISM |

Compile lines, `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I` and `-o` dropped.

```
full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

The `cxx_abi` build compiles with `gcc -x c++ -std=gnu++03`; `g++` only links it.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `Struct#to_h` to convert struct members into a hash.
  - Supports transforming each key/value pair with a block, including lambda usage and early exit.

- **Bug Fixes**
  - Added validation and clear errors when block results are not two-element pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->