### PR TITLE
mruby-compiler: reject excessive local variables before narrowing the count

### DIFF
--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -22,6 +22,24 @@ assert('parsing function with void argument') do
   assert_equal 0, status.exitstatus
 end
 
+assert('too many local variables are rejected') do
+  compile = lambda do |count|
+    source = Tempfile.new(['many-locals', '.rb'])
+    count.times { |i| source.puts("local_#{i} = nil") }
+    source.flush
+    Open3.capture2e(*(cmd_list('mrbc') + ['-c', source.path]))
+  end
+
+  result, status = compile.call(254)
+  assert_true status.success?, result
+
+  [255, 65_536].each do |count|
+    result, status = compile.call(count)
+    assert_equal 1, status.exitstatus
+    assert_include result, 'too many local variables'
+  end
+end
+
 assert('embedded document with invalid terminator') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write("=begin\n=endx\n")

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -493,6 +493,9 @@ scope_new(mrc_ccontext *c, mrc_codegen_scope *prev, mrc_constant_id_list *nlv)
     }
   }
   else {
+    if (nlv->size >= UINT8_MAX) {
+      codegen_error(s, "too many local variables");
+    }
     s->lv = nlv;
     s->sp += nlv->size + 1; /* add self */
     s->nlocals = s->nregs = s->sp;


### PR DESCRIPTION
Fixes #7576.

`scope_new()` narrowed the local count before allocating and copying its local-variable table. With 65,536 locals, the count wrapped and the compiler copied 262,144 bytes into the zero-sized allocation; the existing check in `scope_finish()` ran too late.

Reject 255 or more user locals before that arithmetic. This keeps 254 locals valid after the `self` slot is added, and adds generated `mrbc` tests for 254, 255, and 65,536 locals.

Tests:

- `rake test`: mrbtest 2,727 OK, 0 KO, 0 crash, 75 skip; bintest 130 OK, 0 KO, 0 crash, 1 skip
- `prek run --all-files`: pass
- ASan/UBSan `rake test:run:bin`: 130 OK, 0 KO, 0 crash, 1 skip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The compiler now reports a clear error when source code contains too many local variables, instead of proceeding with unsupported input.
* **Tests**
  * Added coverage confirming valid compilation limits and expected failures for sources exceeding the local-variable limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->