### PR TITLE
build: add a zig toolchain

### DIFF
--- a/build_config/zig.rb
+++ b/build_config/zig.rb
@@ -1,0 +1,54 @@
+# Build with `zig cc`, which compiles for any target zig knows without a
+# sysroot to install first.
+#
+#   ZIG_TARGET       the triple to compile for; `zig targets` lists them. The
+#                    target is the host when it is unset.
+#   ZIG_TEST_RUNNER  the program `rake test` runs the binaries with. A target
+#                    that does not run on this host needs one.
+#
+#   ZIG_TARGET=aarch64-linux-musl ZIG_TEST_RUNNER=qemu-aarch64-static \
+#     MRUBY_CONFIG=build_config/zig.rb rake test
+
+zig_target = ENV['ZIG_TARGET']
+zig_runner = ENV['ZIG_TEST_RUNNER']
+
+# `RUBY_PLATFORM` and zig name the same machine differently, so the host is
+# read down to the arch and the os as zig spells them.
+host_arch, host_os = RUBY_PLATFORM.split('-', 2)
+host_arch = {'arm64' => 'aarch64', 'x64' => 'x86_64', 'amd64' => 'x86_64'}
+              .fetch(host_arch, host_arch.sub(/\Ai[3-6]86\z/, 'x86'))
+host_os = case host_os
+          when /\Adarwin/ then 'macos'
+          when /\A(?:mingw|mswin|cygwin)/ then 'windows'
+          else host_os.split('-').first
+          end
+zig_host = "#{host_arch}-#{host_os}"
+zig_machine = zig_target ? zig_target.split('-')[0, 2].join('-') : zig_host
+
+if zig_machine != zig_host && zig_runner.nil?
+  abort "build_config/zig.rb: #{zig_machine} binaries do not run on #{zig_host}; " \
+        "name the program that runs them in ZIG_TEST_RUNNER (qemu-aarch64-static, wine, ...)"
+end
+
+(zig_target ? MRuby::CrossBuild : MRuby::Build).new('zig') do |conf|
+  conf.toolchain :zig, target: zig_target
+
+  if zig_target
+    # A cross build detects no port, and the gems that sit on the HAL leave
+    # every `mrb_hal_*` symbol undefined without one.
+    conf.ports(zig_machine.end_with?('-windows') ? :win : :posix)
+
+    if zig_machine.end_with?('-windows')
+      # What `for_windows?` reads to give `mruby-io` and friends their
+      # libraries, and the suffix the binaries are named with.
+      conf.host_target = "#{zig_machine.start_with?('x86-') ? 'i686' : 'x86_64'}-w64-mingw32"
+      conf.exts.executable = '.exe'
+    end
+  end
+
+  conf.gembox 'full-core'
+
+  conf.enable_test
+  conf.enable_bintest
+  conf.test_runner.command = zig_runner if zig_runner
+end

--- a/doc/guides/compile.md
+++ b/doc/guides/compile.md
@@ -76,6 +76,18 @@ GCC toolchain.
 conf.toolchain :clang
 ```
 
+#### Zig
+
+Toolchain configuration for `zig cc`. Based on the clang toolchain, with `zig`
+on the `PATH` or in `ZIG`.
+
+```ruby
+conf.toolchain :zig, target: 'aarch64-linux-musl'
+```
+
+The `target:` parameter names the triple to compile for; without it the target
+is the host.
+
 #### Visual Studio
 
 Toolchain configuration for Visual Studio on Windows. If you use the

--- a/tasks/toolchains/zig.rake
+++ b/tasks/toolchains/zig.rake
@@ -1,0 +1,20 @@
+MRuby::Toolchain.new(:zig) do |conf, params|
+  toolchain :clang
+
+  zig = ENV['ZIG'] || 'zig'
+  target = params[:target]
+
+  conf.cc.command = "#{zig} cc"
+  conf.cxx.command = "#{zig} c++"
+  conf.linker.command = "#{zig} cc"
+  conf.archiver.command = "#{zig} ar"
+
+  if target
+    flags = %W(-target #{target})
+    [conf.cc, conf.cxx, conf.linker].each{|tool| tool.flags << flags}
+  end
+
+  # `zig ar` is llvm-ar, which defaults to the Darwin format on macOS hosts,
+  # where it overflows on long member paths.
+  conf.archiver.archive_options = '--format=gnu rcs%{deterministic} "%{outfile}" %{objs}'
+end


### PR DESCRIPTION
## Summary

A `zig` toolchain, so that `zig cc` builds mruby for the host and cross compiles
for any target zig knows without a sysroot to install first.

## Changes

| File                        | What                                                                                                       |
| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
| `tasks/toolchains/zig.rake` | The toolchain: `zig cc`, `zig c++` and `zig ar` over the clang toolchain, with an optional `target:` triple |
| `build_config/zig.rb`       | A build for `ZIG_TARGET`, tested with `ZIG_TEST_RUNNER`                                                    |
| `doc/guides/compile.md`     | Its section in the guide                                                                                   |

### The commands

`zig cc` is a clang driver, so the clang toolchain covers everything else:
`-MMD`, the `-Wp,-v` header search, `-ffile-prefix-map` and
`-ffile-compilation-dir` answer as clang does. The commands are two words each,
which `MRuby::Command#command_line` and `MRuby::SizeReport.find_tool` already
carry, since a compiler behind `ccache` reads the same way. `conf.cxx` is
spelled out because the `g\Kcc|$` substitution the GCC toolchain derives it with
makes `zig cc++` of `zig cc`.

`zig ar` is llvm-ar, which writes a Darwin-format archive on a macOS host and
overflows there on long member paths, so it is asked for the GNU format, the
same way `tasks/toolchains/wasi.rake` asks it of the same program.

### The target

`target:` names the triple `zig cc -target` takes. Left out, zig compiles for
the host, so the one toolchain serves `MRuby::Build` and `MRuby::CrossBuild`
alike.

### The build config

`build_config/zig.rb` reads the target from `ZIG_TARGET` and the program its
binaries run under from `ZIG_TEST_RUNNER`, so the one config covers the targets
zig knows. With neither set it builds for this host and `rake test` runs the
tests here. A target that does not run here and names no runner is refused
before the build starts:

```
$ ZIG_TARGET=aarch64-linux-musl MRUBY_CONFIG=build_config/zig.rb rake test
build_config/zig.rb: aarch64-linux binaries do not run on x86_64-linux; name the program that runs them in ZIG_TEST_RUNNER (qemu-aarch64-static, wine, ...)
```

A cross build names its own `conf.ports` and, for a Windows target, the
`host_target` that `for_windows?` reads, both of which the config takes from the
triple.

## Testing

| Build                                                                        | Total | OK   | Skip | KO  | Crash | Warning |
| ---------------------------------------------------------------------------- | ----- | ---- | ---- | --- | ----- | ------- |
| zig, host                                                                    | 3050  | 3030 | 20   | 0   | 0     | 0       |
| zig, host, `enable_cxx_abi`                                                  | 3050  | 3030 | 20   | 0   | 0     | 0       |
| zig, `ZIG_TARGET=aarch64-linux-musl`, `ZIG_TEST_RUNNER=qemu-aarch64-static`  | 3050  | 3030 | 20   | 0   | 0     | 0       |

The rows are `build_config/zig.rb`, the middle one with `enable_cxx_abi` added.
`enable_bintest` is green in both, the cross build under
`qemu-aarch64-static` as well: 103 total, 102 OK, 1 skip, 0 KO, 0 crash, 0
warning each.

The aarch64 `bin/mruby` is a static ELF and answers `"aarch64-linux"` for
`MRUBY_PLATFORM`. A clean build of the three prints no compiler warning.

## Environment

<details>

| Item   | Value                                                  |
| ------ | ------------------------------------------------------ |
| OS     | Ubuntu 24.04.4 LTS                                     |
| Kernel | Linux 7.0.0-31-generic x86_64                          |
| CPU    | AMD Ryzen 9 5950X, 16 cores                            |
| zig    | 0.16.0                                                 |
| gcc    | 13.3.0, for the generated `mrbc` build of a cross build |
| qemu   | qemu-aarch64 8.2.2 (Debian 1:8.2.2+ds-0ubuntu1.18)     |
| CRuby  | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM     |

Compile and link lines, from `touch src/string.c; rake --verbose`:

```
# host
zig cc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -ffile-prefix-map="../..=.." -ffile-compilation-dir="build" ... -o "zig/src/string.o" "../../src/string.c"
zig cc -o ".../zig/bin/mruby" ".../mruby.o" ".../lib/libmruby.a" -lm

# host, enable_cxx_abi
zig cc -MMD -c -g -O3 -Wall -Wundef -Wwrite-strings -Wzero-length-array -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-compilation-dir="build" -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI ... -o "zig-cxx/src/string.o" "../../src/string.c"

# ZIG_TARGET=aarch64-linux-musl
zig cc -MMD -c -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -Wzero-length-array -target aarch64-linux-musl -ffile-prefix-map="../..=.." -ffile-compilation-dir="build" ... -o "zig/src/string.o" "../../src/string.c"
zig cc -target aarch64-linux-musl -o ".../zig/bin/mruby" ".../mruby.o" ".../lib/libmruby.a" -lm
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zig toolchain support for building MRuby projects.
  * Added optional cross-compilation targets, including Windows and POSIX environments.
  * Added support for specifying a custom test runner when cross-target tests cannot run directly.
  * Added compile guide documentation covering Zig configuration and target selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->