### PR TITLE
vm.c: resolve a define_method body's special variables where it was written

### DIFF
--- a/mrbgems/mruby-regexp/test/backref_scope.rb
+++ b/mrbgems/mruby-regexp/test/backref_scope.rb
@@ -262,6 +262,218 @@ assert("$~ - a match made in a block survives the method's escape") do
   assert_equal "wb", backref_scope_block_writes.call
 end
 
+def backref_scope_dm_read
+  "outer" =~ /(ou)ter/
+  k = Class.new { define_method(:reader) { [$~ && $~[0], $&, $1] } }
+  [k.new.reader, $~ && $~[0]]
+end
+
+assert("$~ - a define_method body reads the scope it was written in") do
+  # `define_method` marks the block it installs a scope so that a `def` in
+  # it lands on the right class, but the block keeps the env it was made
+  # with: what it reads is the scope it was written in, the way its locals
+  # are, and the way CRuby's leaves its ep alone.
+  assert_equal [["outer", "outer", "ou"], "outer"], backref_scope_dm_read
+end
+
+def backref_scope_dm_write
+  "outer" =~ /outer/
+  k = Class.new { define_method(:writer) { "inner" =~ /(in)ner/ } }
+  k.new.writer
+  [$~ && $~[0], $1]
+end
+
+assert("$~ - a define_method body publishes into the scope it was written in") do
+  assert_equal ["inner", "in"], backref_scope_dm_write
+end
+
+def backref_scope_dm_mk
+  "written" =~ /written/
+  Class.new { define_method(:writer) { "inner" =~ /inner/ } }
+end
+
+def backref_scope_dm_caller
+  k = backref_scope_dm_mk
+  "caller" =~ /caller/
+  k.new.writer
+  $~ && $~[0]
+end
+
+assert("$~ - a define_method body leaves the scope that calls it alone") do
+  # the body publishes into the scope it was written in, which has
+  # returned: the write lands in the slot that scope's env carries, where
+  # the caller cannot see it
+  assert_equal "caller", backref_scope_dm_caller
+end
+
+def backref_scope_dm_nil
+  "outer" =~ /outer/
+  k = Class.new { define_method(:clearer) { $~ = nil } }
+  k.new.clearer
+  $~
+end
+
+assert("$~ - an assignment inside a define_method body clears the same scope") do
+  assert_nil backref_scope_dm_nil
+end
+
+def backref_scope_dm_nested
+  "outer" =~ /(ou)ter/
+  inner = Class.new do
+    define_method(:outer_body) do
+      Class.new { define_method(:inner_body) { [$&, $1] } }.new.inner_body
+    end
+  end
+  inner.new.outer_body
+end
+
+assert("$~ - a define_method body nested in another reaches the method scope") do
+  # the walk of svar_scope_env() crosses the outer body the way it crosses
+  # a block, so both bodies answer the one scope they were written in
+  assert_equal ["outer", "ou"], backref_scope_dm_nested
+end
+
+def backref_scope_dm_block
+  "outer" =~ /(ou)ter/
+  k = Class.new { define_method(:reader) { [1].map { [$&, $1] }.first } }
+  k.new.reader
+end
+
+assert("$~ - a block inside a define_method body reaches the same scope") do
+  assert_equal ["outer", "ou"], backref_scope_dm_block
+end
+
+def backref_scope_dm_def
+  "outer" =~ /(ou)ter/
+  k = Class.new { define_method(:reader) { self.class.written_by_def } }
+  k.singleton_class.class_eval { def written_by_def; [$&, $1]; end }
+  k.new.reader
+end
+
+assert("$~ - a def written inside a define_method body owns its scope") do
+  assert_equal [nil, nil], backref_scope_dm_def
+end
+
+def backref_scope_dm_pair
+  "outer" =~ /(ou)ter/
+  Class.new do
+    define_method(:reader) { $~ && $~[0] }
+    define_method(:writer) { "inner" =~ /inner/ }
+  end
+end
+
+assert("$~ - two define_method bodies of one dead scope share its slot") do
+  # the scope has returned, so both resolve into the slot its env carries
+  o = backref_scope_dm_pair.new
+  assert_equal "outer", o.reader
+  o.writer
+  assert_equal "inner", o.reader
+end
+
+def backref_scope_dm_twice
+  "outer" =~ /outer/
+  k = Class.new { define_method(:writer) { |s| s =~ /#{s}/; $~ && $~[0] } }
+  o = k.new
+  [o.writer("p"), o.writer("q"), $~ && $~[0]]
+end
+
+assert("$~ - two calls of one define_method body share the same slot") do
+  assert_equal ["p", "q", "q"], backref_scope_dm_twice
+end
+
+def backref_scope_dm_last_match
+  "outer" =~ /(ou)ter/
+  k = Class.new { define_method(:reader) { Regexp.last_match && Regexp.last_match(1) } }
+  k.new.reader
+end
+
+assert("Regexp.last_match reads the scope a define_method body was written in") do
+  assert_equal "ou", backref_scope_dm_last_match
+end
+
+def backref_scope_dm_singleton
+  "outer" =~ /(ou)ter/
+  o = Object.new
+  o.define_singleton_method(:reader) { [$&, $1] }
+  o.reader
+end
+
+assert("$~ - a define_singleton_method body reads the same scope") do
+  skip unless Object.new.respond_to?(:define_singleton_method)
+  assert_equal ["outer", "ou"], backref_scope_dm_singleton
+end
+
+def backref_scope_dm_lambda
+  "outer" =~ /(ou)ter/
+  body = -> { [$&, $1] }
+  k = Class.new { define_method(:reader, body) }
+  k.new.reader
+end
+
+assert("$~ - a lambda installed as a method reads where it was written") do
+  assert_equal ["outer", "ou"], backref_scope_dm_lambda
+end
+
+def backref_scope_dm_fiber
+  "outer" =~ /(ou)ter/
+  k = Class.new { define_method(:reader) { [$&, $1] } }
+  [Fiber.new { k.new.reader }.resume, k.new.reader]
+end
+
+assert("$~ - a define_method body called in a fiber reads the fiber's slot") do
+  # resolution lands on the scope the fiber's own root block was defined
+  # in, which is handed the fiber's root slot instead, the way it is for
+  # any other block; outside the fiber the same body reads the scope again
+  skip unless Object.const_defined?(:Fiber)
+  assert_equal [[nil, nil], ["outer", "ou"]], backref_scope_dm_fiber
+end
+
+assert("$~ - a define_method body written at the top level reads that scope") do
+  "top-level" =~ /(top)-level/
+  k = Class.new { define_method(:reader) { [$&, $1] } }
+  assert_equal ["top-level", "top"], k.new.reader
+  assert_equal "top-level", $~ && $~[0]
+end
+
+def backref_scope_dm_locals
+  "outer" =~ /outer/
+  held = :held
+  k = Class.new { define_method(:reader) { [held, $&] } }
+  k.new.reader
+end
+
+assert("$~ - a define_method body keeps reading its scope's locals") do
+  # the same condition answers both walks (MRB_PROC_LVAR_BOUNDARY_P in
+  # mruby/proc.h and svar_own_scope_p in vm.c), so pin the locals here too
+  assert_equal [:held, "outer"], backref_scope_dm_locals
+end
+
+"class-body-outer" =~ /outer/
+class BackrefScopeClassBody
+  AT_ENTRY = $~ && $~[0]
+  "class-body" =~ /(class)-body/
+  READ = [$&, $1]
+  define_method(:reader) { [$&, $1] }
+end
+BACKREF_SCOPE_AFTER_CLASS_BODY = $~ && $~[0]
+
+assert("$~ - a class body owns its scope") do
+  # the body captured no env, so it is a scope in its own right: it starts
+  # with nothing behind the name and its match stays inside
+  assert_nil BackrefScopeClassBody::AT_ENTRY
+  assert_equal ["class-body", "class"], BackrefScopeClassBody::READ
+  assert_equal "outer", BACKREF_SCOPE_AFTER_CLASS_BODY
+end
+
+assert("$~ - a define_method body written in a class body reads that body") do
+  # the ordinary spelling of the whole thing: the scope the block was
+  # written in is the class body, and the caller of the method it became
+  # keeps its own match
+  "outer" =~ /outer/
+  assert_equal ["class-body", "class"], BackrefScopeClassBody.new.reader
+  assert_equal "outer", $~ && $~[0]
+end
+
 assert("$~ - accepts a MatchData and nil, refuses the rest") do
   m = /a/.match("a")
   $~ = m
@@ -785,6 +997,20 @@ end
 
 assert("svar - an escaped proc reads both keys of its dead scope") do
   assert_equal ["captured", "captured"], svar_container_escape.call
+end
+
+def svar_container_dm
+  __svar_lastline_set("outer")
+  "outer" =~ /outer/
+  k = Class.new { define_method(:g) { [__svar_lastline, $~ && $~[0], __svar_container?] } }
+  [k.new.g, __svar_lastline]
+end
+
+assert("svar - a define_method body reaches both keys of its defining scope") do
+  # owner resolution is what the body crosses, not anything `$~` has of its
+  # own, so the second key follows; `__svar_container?` reports on the body's
+  # own frame, which owns no container because it is not the owner
+  assert_equal [["outer", "outer", false], "outer"], svar_container_dm
 end
 
 def svar_container_immediates

--- a/src/vm.c
+++ b/src/vm.c
@@ -391,6 +391,20 @@ mrb_vm_ci_env_clear(mrb_state *mrb, mrb_callinfo *ci)
   mrb_ci_svar_set(mrb, mrb->c, ci, NULL);
 }
 
+/* A proc that is a scope of its own: one the VM made for a `def` body or a
+ * class body, which captured no env. `mrb_define_method_raw()` marks a
+ * block installed by `define_method` a scope too, but that block keeps the
+ * env it was made in, and its special variables belong to the scope it was
+ * written in, the way its locals do (MRB_PROC_LVAR_BOUNDARY_P() in
+ * mruby/proc.h, the same condition read for the other walk). CRuby resolves
+ * the same way: the block's ep is unchanged by the install, so its svar is
+ * still its lep's. */
+static mrb_bool
+svar_own_scope_p(const struct RProc *p)
+{
+  return MRB_PROC_SCOPE_P(p) && !MRB_PROC_ENV_P(p);
+}
+
 /* The local scope of a block or lambda: following p->upper toward the
  * scope proc, MRB_PROC_ENV() of each step is the env of the frame the
  * proc was defined in, instance by instance, so the env in hand when the
@@ -406,7 +420,7 @@ svar_scope_env(const struct RProc *p)
   if (!e) return NULL;
   for (;;) {
     const struct RProc *up = p->upper;
-    if (!up || MRB_PROC_CFUNC_P(up) || MRB_PROC_SCOPE_P(up)) return e;
+    if (!up || MRB_PROC_CFUNC_P(up) || svar_own_scope_p(up)) return e;
     struct REnv *upenv = MRB_PROC_ENV(up);
     if (!upenv) return e;
     p = up;
@@ -491,8 +505,8 @@ svar_slot_ensure(mrb_state *mrb, struct REnv *e)
 
 /* The owner of the frame-scoped special variables, resolved the way CRuby
  * resolves its svar: walking down from the top, a C frame has no slot of
- * its own, a scope frame owns its own slot, a frame with no
- * scope of its own is as transparent as a C frame (see
+ * its own, a scope frame owns its own slot (see `svar_own_scope_p()`), a
+ * frame with no scope of its own is as transparent as a C frame (see
  * `svar_scopeless_frame_p()`), and a block or lambda frame resolves to the
  * scope it was defined in, wherever that scope now is: a live frame on
  * this or on another context's stack, or the env the scope left behind. A
@@ -539,7 +553,7 @@ svar_owner_from(struct mrb_context *c, mrb_callinfo *top, mrb_callinfo **cip, st
     const struct RProc *p = ci->proc;
 
     if (p && !MRB_PROC_CFUNC_P(p)) {
-      if (MRB_PROC_SCOPE_P(p)) {
+      if (svar_own_scope_p(p)) {
         *cip = ci;
         *ocp = wc;
         return;

--- a/src/vm.c
+++ b/src/vm.c
@@ -431,8 +431,10 @@ svar_scopeless_frame_p(const mrb_callinfo *ci)
 {
   const struct RProc *p = ci->proc;
 
+  /* `svar_scope_env()` answers NULL for exactly the procs that captured
+     nothing, so the walk it makes is not one this question needs. */
   return p && !MRB_PROC_CFUNC_P(p) &&
-         !MRB_PROC_SCOPE_P(p) && svar_scope_env(p) == NULL;
+         !MRB_PROC_SCOPE_P(p) && !MRB_PROC_ENV_P(p);
 }
 
 /* An escaped scope's slot (MRB_ENV_SVAR_SLOT in internal.h):


### PR DESCRIPTION
## Summary

A block installed as a method by `define_method` read and wrote special variables in a scope nothing else reaches, so `$~` and the names derived from it answered `nil` inside the body and a match made there was lost. It now resolves to the scope the block was written in, as CRuby does and as the block's local variables already did.

## Changes

| File                                         | What                                                                                                                                                                                       |
| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `src/vm.c`                                   | `svar_scopeless_frame_p()` asks for the captured env instead of walking for it; `svar_own_scope_p()`, the test for a proc that is a scope of its own, and its two uses in owner resolution |
| `mrbgems/mruby-regexp/test/backref_scope.rb` | 15 assertions for the bodies that resolve to the scope they were written in and the bodies that stay scopes of their own                                                                   |

### What the flag meant

`mrb_define_method_raw()` marks every proc it installs `MRB_PROC_SCOPE`, so that a `def` written in the body lands on the right class. A block given to `define_method` gets the flag too, but it keeps the env it was made in, which is why the walk looking for local variables stops one step later (`MRB_PROC_LVAR_BOUNDARY_P()` in `include/mruby/proc.h`, whose comment names this case). Owner resolution read the flag on its own and took such a frame for a scope, so the body neither reached the scope around it nor left anything there.

`svar_scope_env()` needs the same test. Without it a body written inside another body stops at the outer body's env instead of crossing it, which is the one shape the owner walk alone does not answer.

### The walk `svar_scopeless_frame_p()` did not need

The first commit is the reason the second one costs nothing. `svar_scope_env()` starts at `MRB_PROC_ENV()` and every exit past that returns an env, so it answers `NULL` for exactly the procs that captured nothing, which is all `svar_scopeless_frame_p()` read it for. Asked as one flag, the walk leaves the copies `cipop()` has inlined along every return path of `mrb_vm_exec()`.

### The shapes

Every way a proc reaches `mrb_define_method_raw()` was checked against CRuby: `define_method` with a block and with a lambda, `define_singleton_method`, and `alias_method`, `module_function`, `include` and `prepend` of what those installed. So was every scope a body can be written in: a method, a block, a class, module or `class << self` body, a string and a block `class_eval`, an `instance_eval` block, the top level, and a fiber, live, suspended and finished. The procs the VM makes for a `def` body and for a class body capture no env, so they stay scopes of their own; a `def`, a class body, a module body, a `class << self` body and a `def self.name` all answer as before.

The first commit rests on `MRB_PROC_ENV_P()` implying a non-`NULL` env, which is what `MRB_PROC_TARGET_CLASS()` already reads it as: the five places that raise the flag (`src/proc.c`, `src/class.c`, `mrbgems/mruby-eval`, `mrbgems/mruby-binding`) each store an env in the same breath.

Out of scope, and still different from CRuby: `define_method` accepts only a `Proc`, so `define_method(:name, method(:other))` raises a `TypeError` where CRuby installs the method.

## Behaviour

```ruby
def m
  "outer" =~ /(ou)ter/
  k = Class.new { define_method(:reader) { [$&, $1] } }
  [k.new.reader, $~ && $~[0]]
end
m  # CRuby: [["outer", "ou"], "outer"], mruby before: [[nil, nil], "outer"]
```

```ruby
def m
  "outer" =~ /outer/
  k = Class.new { define_method(:writer) { "inner" =~ /(in)ner/ } }
  k.new.writer
  [$~ && $~[0], $1]
end
m  # CRuby: ["inner", "in"], mruby before: ["outer", nil]
```

## Size

`.text` of `bin/mruby`, `size -A`, gcc 13.3.0.

| Build            |    master |   this PR |  delta |
| ---------------- | --------: | --------: | -----: |
| full-debug (-O0) | 2,003,382 | 2,003,446 |    +64 |
| bintest          | 1,401,990 | 1,400,742 | -1,248 |
| cxx_abi          | 1,436,969 | 1,434,953 | -2,016 |
| byte-string      | 1,363,350 | 1,362,166 | -1,184 |
| ascii-ctype      | 1,386,374 | 1,385,190 | -1,184 |
| no-float         | 1,329,246 | 1,328,430 |   -816 |
| no-bigint        | 1,287,622 | 1,286,534 | -1,088 |

All of it is `src/vm.o`, whose `.text` in the bintest build goes 98,545 to 96,449 with the first commit and 96,449 to 97,297 with the second; where nothing is inlined the two commits are the added condition alone.

## Testing

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2820 | 2746 |   74 |   0 |     0 |       0 |
| full-debug  |  3068 | 3057 |   11 |   0 |     0 |       0 |
| bintest     |  3068 | 3048 |   20 |   0 |     0 |       0 |
| cxx_abi     |  3068 | 3048 |   20 |   0 |     0 |       0 |
| byte-string |  2980 | 2906 |   74 |   0 |     0 |       0 |
| ascii-ctype |  3052 | 3030 |   22 |   0 |     0 |       0 |
| no-float    |  2801 | 2704 |   97 |   0 |     0 |       0 |
| no-bigint   |  3017 | 2984 |   33 |   0 |     0 |       0 |

The bintest build's command tests are green too: 147 assertions, 146 OK, 1 skip.

The 18 new assertions pin what a body reads and publishes, an assignment of `$~` inside one, a body nested in another, a block inside a body and a `def` inside a body, two bodies of a scope that has returned sharing its slot, two calls of one body sharing it, `Regexp.last_match` read from a body, `define_singleton_method` and a lambda installed as a method, a body written in a class body and one written at the top level, a body called on a fiber, that a body still reads its scope's locals, that the second key of the container follows the same owner while the body's own frame carries none, and that a class body and a `def` are still scopes of their own. Fifteen of them fail on the first commit alone; the three that pass either way are the ones that pin what does not change.

## Environment

<details>

| Item     | Value                                                             |
| -------- | ----------------------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                                |
| Kernel   | Linux 7.0.0-31-generic x86_64                                     |
| CPU      | AMD Ryzen 9 5950X, 16 cores                                       |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines, measured with `touch src/vm.c; rake --verbose`, with `-MMD -c`, `-I`, `-ffile-prefix-map` and `-o` dropped.

host (`build_config/default.rb`)

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

full-debug

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

bintest

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

cxx_abi (compiled by `gcc -x c++`, linked by `g++`)

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

byte-string

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ascii-ctype

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

no-float

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

no-bigint

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected special-variable scoping for methods created dynamically, including nested blocks, lambdas, fibers, closures, and class bodies.
  * Ensured reads and writes to match-related special variables resolve to the appropriate surrounding scope.
  * Improved behavior when dynamically defined methods access variables captured from their defining context.

* **Tests**
  * Added comprehensive coverage for dynamic method and singleton method scope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->