### PR TITLE
vm.c: deliver the keywords of a method with 15 or more parameters

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1326,11 +1326,29 @@ mrb_funcall_id(mrb_state *mrb, mrb_value self, mrb_sym mid, mrb_int argc, ...)
   return mrb_funcall_argv(mrb, self, mid, argc, argv);
 }
 
+/* The register the caller left the keyword dictionary in.  A frame that has
+   run its `OP_ENTER` moved the dictionary elsewhere; `enter_kwpos()` answers
+   where. */
 static mrb_int
 mrb_ci_kidx(const mrb_callinfo *ci)
 {
   if (!ci->kw) return -1;
   return (ci->n == CALL_MAXARGS) ? 2 : ci->n + 1;
+}
+
+/* The register the frame's own `OP_ENTER` put the keyword dictionary in.
+   `ci->n` names it directly, except for a method that declares 15 or more
+   positional parameters: the field is 4 bits wide, so `vm_op_enter()` can
+   only saturate it there and the layout is read back off the `OP_ENTER`
+   operand instead, the way `mrb_proc_arity()` reads it. */
+static mrb_int
+enter_kwpos(const mrb_callinfo *ci, const mrb_irep *irep)
+{
+  if (mrb_likely(ci->n < CALL_MAXARGS)) return ci->n + 1;
+  mrb_assert(irep->ilen > 0 && irep->iseq[0] == OP_ENTER);
+  uint32_t aspec = PEEK_W(irep->iseq+1);
+  return MRB_ASPEC_REQ(aspec) + MRB_ASPEC_OPT(aspec)
+       + MRB_ASPEC_REST(aspec) + MRB_ASPEC_POST(aspec) + 1;
 }
 
 static inline mrb_int
@@ -2733,8 +2751,12 @@ vm_op_enter(mrb_state *mrb, uint32_t a)
     ci->kw = TRUE;
   }
 
-  /* format arguments for generated code */
-  ci->n = (uint8_t)len;
+  /* format arguments for generated code.  The field is 4 bits wide, so 15 or
+     more positional parameters saturate it rather than wrap around into a
+     count the frame does not have; `enter_kwpos()` reads the layout of such a
+     frame back off this `OP_ENTER`, and `mrb_ci_nregs()` answers the irep's
+     own register count for it. */
+  ci->n = (uint8_t)(len < CALL_MAXARGS ? len : CALL_MAXARGS);
 
   /* clear local (but non-argument) variables */
   if (irep->nlocals-blk_pos-1 > 0) {
@@ -3895,10 +3917,10 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_KARG, BB) {
       mrb_value k = mrb_symbol_value(irep->syms[b]);
-      mrb_int kidx = mrb_ci_kidx(ci);
+      mrb_int kidx = enter_kwpos(ci, irep);
       mrb_value kdict, v;
 
-      if (kidx < 0 || !mrb_hash_p(kdict=regs[kidx]) || !mrb_hash_key_p(mrb, kdict, k)) {
+      if (!mrb_hash_p(kdict=regs[kidx]) || !mrb_hash_key_p(mrb, kdict, k)) {
         RAISE_FORMAT(mrb, E_ARGUMENT_ERROR, "missing keyword: %v", k);
       }
 
@@ -3910,11 +3932,11 @@ RETRY_TRY_BLOCK:
 
     CASE(OP_KEY_P, BB) {
       mrb_value k = mrb_symbol_value(irep->syms[b]);
-      mrb_int kidx = mrb_ci_kidx(ci);
+      mrb_int kidx = enter_kwpos(ci, irep);
       mrb_value kdict;
       mrb_bool key_p = FALSE;
 
-      if (kidx >= 0 && mrb_hash_p(kdict=regs[kidx])) {
+      if (mrb_hash_p(kdict=regs[kidx])) {
         key_p = mrb_hash_key_p(mrb, kdict, k);
         ci = mrb->c->ci;
       }
@@ -3923,10 +3945,10 @@ RETRY_TRY_BLOCK:
     }
 
     CASE(OP_KEYEND, Z) {
-      mrb_int kidx = mrb_ci_kidx(ci);
+      mrb_int kidx = enter_kwpos(ci, irep);
       mrb_value kdict;
 
-      if (kidx >= 0 && mrb_hash_p(kdict=regs[kidx]) && !mrb_hash_empty_p(mrb, kdict)) {
+      if (mrb_hash_p(kdict=regs[kidx]) && !mrb_hash_empty_p(mrb, kdict)) {
         mrb_value key1 = mrb_hash_first_key(mrb, kdict);
         RAISE_FORMAT(mrb, E_ARGUMENT_ERROR, "unknown keyword: %v", key1);
       }

--- a/test/t/syntax.rb
+++ b/test/t/syntax.rb
@@ -1110,6 +1110,54 @@ assert 'keyword arguments' do
   assert_equal([:a, nil, :c], m(a: :a, c: :c))
 end
 
+assert('keyword arguments with fifteen or more positional parameters') do
+  # 15 is the mark for arguments packed into an array in the 4 bits that carry
+  # the positional count, so a method this wide cannot be asked which register
+  # its keyword dictionary was left in
+  a14 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+  a15 = a14 + [15]
+  a16 = a15 + [16]
+
+  def m14(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14, k: 1) [p14, k] end
+  assert_equal([14, 7], m14(*a14, k: 7))
+
+  def m15(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1) [p15, k] end
+  assert_equal([15, 7], m15(*a15, k: 7))
+  assert_equal([15, 1], m15(*a15))
+  assert_raise(ArgumentError) { m15(*a15, z: 9) }
+
+  def m16(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15,p16, k: 1) [p16, k] end
+  assert_equal([16, 7], m16(*a16, k: 7))
+
+  def m15r(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k:) k end
+  assert_equal(7, m15r(*a15, k: 7))
+  assert_raise(ArgumentError) { m15r(*a15) }
+
+  # a declared keyword is taken out of the rest of them
+  def m15k(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1, **o) [k, o] end
+  assert_equal([7, {x: 8}], m15k(*a15, k: 7, x: 8))
+
+  # 14 mandatory parameters and a rest count 15 as well
+  def m14s(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14, *rest, k: 1) [rest, k] end
+  assert_equal([[15], 7], m14s(*a15, k: 7))
+
+  # a lambda and a block are entered the same way
+  l = ->(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1) { [p15, k] }
+  assert_equal([15, 7], l.call(*a15, k: 7))
+  def m15y(*a, **k) yield(*a, **k) end
+  result = m15y(*a15, k: 7) {|p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1| [p15, k] }
+  assert_equal([15, 7], result)
+
+  # and `super` forwards them
+  class KeywordWideParent
+    def m(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1) [p15, k] end
+  end
+  class KeywordWideChild < KeywordWideParent
+    def m(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1) super end
+  end
+  assert_equal([15, 7], KeywordWideChild.new.m(*a15, k: 7))
+end
+
 assert('numbered parameters') do
   assert_equal(15, [1,2,3,4,5].reduce {_1+_2})
   assert_equal(45, Proc.new do _1 + _2 + _3 + _4 + _5 + _6 + _7 + _8 + _9 end.call(*[1, 2, 3, 4, 5, 6, 7, 8, 9]))


### PR DESCRIPTION
## Summary

`vm_op_enter()` records the frame's positional count in `mrb_callinfo.n`, a 4-bit field whose value 15 already means "the arguments are packed in an array". A method that declares 15 or more positional parameters overflows it, so `mrb_ci_kidx()` answers `regs[2]` and `OP_KARG` looks for the keyword dictionary in the second argument. Every named keyword such a method declares silently keeps its default.

## Changes

| File               | What                                                                          |
| ------------------ | ----------------------------------------------------------------------------- |
| `src/vm.c`         | saturate `ci->n` and read a saturated frame's keyword register off `OP_ENTER` |
| `test/t/syntax.rb` | cover keywords on a method with 15 or more positional parameters              |

### What the field can and cannot say

`ci->n` is asked two different questions. Before the callee starts it carries the count the caller passed, where `CALL_MAXARGS` says the arguments arrived in an array; `vm_op_enter()` then overwrites it with `m1+o+r+m2` so that `mrb_ci_kidx()` and `ci_bidx()` can name the keyword and block registers of the frame it just laid out. The second question has a wider range than the field: `ma+oa` and `pa` are each refused at 32 by the compiler, so the count can reach 63.

Writing `(uint8_t)len` into four bits made 15 read as packed and 16 read as 0. `enter_kwpos()` makes the overflow representable instead: `OP_ENTER` saturates at `CALL_MAXARGS`, which after `OP_ENTER` can only mean "15 or more" because a frame that has been laid out never holds packed arguments, and the three opcodes that read the dictionary take the layout back off the `OP_ENTER` operand when they see it. `mrb_proc_arity()` reads the same operand for the same reason.

`ci_bidx()` and `mrb_ci_nregs()` were reading the same overflowed count. Saturating leaves them where they already were for a packed frame, and `mrb_ci_nregs()` answers the irep's own register count for any frame this wide, so the block slot they name is not consulted.

### Behaviour

```ruby
def m(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1) k end
m(*1..15, k: 7)          # CRuby: 7, mruby: 1

def n(p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15, k: 1, **o) [k, o] end
n(*1..15, k: 7, x: 8)    # CRuby: [7, {x: 8}], mruby: [1, {k: 7, x: 8}]
```

An unknown keyword went unreported for the same reason, and a required keyword raised `missing keyword`. `def`, `->`, a block and `super` were all affected; only a bare `**o` escaped, because `vm_op_enter()` writes that register directly and never asks where it is.

## Speed

Instructions per iteration, callgrind `Ir(2N) - Ir(N)` at `N = 100,000`, `build/host`:

```ruby
n = ARGV[0].to_i
def m(a, k: 0) k end
i = 0
s = 0
while i < n
  s += m(1, k: 2)   # kw_default calls `m(1)`, control_plain calls a `def m(a) a end`
  i += 1
end
```

| Case          | master | This PR | Ratio |
| ------------- | -----: | ------: | ----: |
| kw_given      |  2,099 |   2,094 | 1.00x |
| kw_default    |  1,144 |   1,141 | 1.00x |
| control_plain |    612 |     612 | 1.00x |
| control_loop  |    612 |     612 | 1.00x |

The common case reads one fewer field than `mrb_ci_kidx()` did, since a frame that reached `OP_KARG` always has keywords and `ci->kw` need not be tested. The controls are identical to the instruction.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`:

| Build            |    master |   This PR | Delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,003,382 | 2,003,638 |  +256 |
| bintest          | 1,401,990 | 1,402,150 |  +160 |
| cxx_abi          | 1,436,969 | 1,436,905 |   -64 |
| byte-string      | 1,363,350 | 1,363,670 |  +320 |
| ascii-ctype      | 1,386,374 | 1,386,694 |  +320 |
| no-float         | 1,329,246 | 1,329,278 |   +32 |
| no-bigint        | 1,287,622 | 1,287,798 |  +176 |

Every delta belongs to `mrb_vm_exec` in `src/vm.o` and matches the binary's to within padding; no other function changed size. The three opcodes each carry the saturated case now, and how much of it the optimizer keeps out of line differs by build, which is why `cxx_abi` lands smaller.

## Testing

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2803 | 2729 |   74 |   0 |     0 |       0 |
| full-debug  |  3051 | 3040 |   11 |   0 |     0 |       0 |
| bintest     |  3051 | 3031 |   20 |   0 |     0 |       0 |
| cxx_abi     |  3051 | 3031 |   20 |   0 |     0 |       0 |
| byte-string |  2963 | 2889 |   74 |   0 |     0 |       0 |
| ascii-ctype |  3035 | 3013 |   22 |   0 |     0 |       0 |
| no-float    |  2784 | 2687 |   97 |   0 |     0 |       0 |
| no-bigint   |  3000 | 2967 |   33 |   0 |     0 |       0 |

bintest ran in the `bintest` build and passed, 147 total with 1 skip. The same seven builds are green on i686 natively and on armhf under qemu, where `mrb_int` is 32 bits.

The new assertions walk the counts 14, 15 and 16 and the shapes that reach 15 another way: a rest after 14 mandatory parameters, a required keyword, a declared keyword next to `**o`, an unknown keyword, a lambda, a block and a `super`. On master the same block fails three assertions and then raises `missing keyword: k`, which mrbtest counts as a crash.

## Environment

<details>

|          |                                                                   |
| -------- | ----------------------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                                |
| Kernel   | Linux 7.0.0-31-generic x86_64                                     |
| CPU      | AMD Ryzen 9 5950X 16-Core Processor                               |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

host:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang full-debug:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang bintest:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang cxx_abi (compiled as C++, g++ links):

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang byte-string:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang ascii-ctype:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-float:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-bigint:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed keyword argument handling for methods with 15 or more positional parameters.
  - Corrected keyword forwarding across direct calls, splat calls, rest parameters, lambdas, blocks, and `super`.
  - Undeclared keywords now correctly raise `ArgumentError`.

- **Tests**
  - Added coverage for keyword argument handling at the 15-parameter boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->