### PR TITLE
mruby-compiler: refuse a `super` or a `yield` that overflows its operand

### DIFF
--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1606,13 +1606,18 @@ gen_blkmove(mrc_codegen_scope *s, const struct mscope *m)
   gen_mscope_lvar(s, m, m1+r+m2+kd+1);
 }
 
-/* The operand `OP_ARGARY` and `OP_BLKPUSH` reach the method scope by.  Only
-   four bits are left for the level once `ainfo` has taken the rest, so a
-   `super` or a `yield` further down than that cannot name the frame it means
-   and has to be refused rather than sent to another one. */
+/* The operand `OP_ARGARY` and `OP_BLKPUSH` reach the method scope by.  It has
+   sixteen bits for both the layout of the arguments to forward and the level
+   the method scope is at, four of them the level, and neither the mandatory
+   and optional parameters counted together nor the level is bounded anywhere
+   else.  A `super` or a `yield` that outgrows either is refused rather than
+   sent to a frame it did not mean. */
 static uint16_t
 mscope_operand(mrc_codegen_scope *s, const struct mscope *m)
 {
+  if (m->ainfo > 0xfff) {
+    codegen_error(s, "too many formal arguments");
+  }
   if (m->lv > 0xf) {
     codegen_error(s, "too many nested blocks/methods");
   }

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -1606,6 +1606,19 @@ gen_blkmove(mrc_codegen_scope *s, const struct mscope *m)
   gen_mscope_lvar(s, m, m1+r+m2+kd+1);
 }
 
+/* The operand `OP_ARGARY` and `OP_BLKPUSH` reach the method scope by.  Only
+   four bits are left for the level once `ainfo` has taken the rest, so a
+   `super` or a `yield` further down than that cannot name the frame it means
+   and has to be refused rather than sent to another one. */
+static uint16_t
+mscope_operand(mrc_codegen_scope *s, const struct mscope *m)
+{
+  if (m->lv > 0xf) {
+    codegen_error(s, "too many nested blocks/methods");
+  }
+  return (uint16_t)((m->ainfo<<4)|m->lv);
+}
+
 static mrc_sym nsym(mrc_parser_state *p, const uint8_t *start, size_t length);
 
 /* The name of the method's local in register `reg`, as a symbol of this
@@ -6612,7 +6625,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       if (m.ainfo > 0) {
         mrc_bool blk_lost = FALSE;
 
-        genop_2S(s, OP_ARGARY, cursp(), (m.ainfo<<4)|(m.lv & 0xf));
+        genop_2S(s, OP_ARGARY, cursp(), mscope_operand(s, &m));
         push(); push(); push();   /* ARGARY pushes 3 values at most */
         pop(); pop(); pop();
         /* keyword arguments */
@@ -6700,7 +6713,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       }
       push(); pop(); /* space for a block */
       pop_n(st+1);
-      genop_2S(s, OP_BLKPUSH, cursp(), (m.ainfo<<4)|(m.lv & 0xf));
+      genop_2S(s, OP_BLKPUSH, cursp(), mscope_operand(s, &m));
       if (nk == 0 && n < 15) {
         /* fast path: direct block call without method dispatch */
         genop_2(s, OP_BLKCALL, cursp(), n);

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -848,3 +848,28 @@ assert 'eval a `super` and a `yield` at the width of the forwarding level' do
   assert_equal :ok, eval(yielder.call(15))
   assert_raise(SyntaxError) { eval(yielder.call(16)) }
 end
+
+assert 'eval a `super` and a `yield` at the width of the forwarded layout' do
+  # The rest of that operand holds `ainfo`, the layout of the arguments being
+  # forwarded, whose mandatory and optional parameters share a field of six
+  # bits that only twelve bits of room are left for.  The compiler allows 31
+  # of each, so 32 counted together is where the layout runs into the level.
+  params = lambda do |ma, oa|
+    ((1..ma).map { |i| "a#{i}" } + (1..oa).map { |i| "b#{i} = #{i}" }).join(', ')
+  end
+
+  zsuper = lambda do |ma, oa|
+    "class EvalWideParent; def m(#{params.call(ma, oa)}) a1 end end\n" \
+    "class EvalWideChild < EvalWideParent; def m(#{params.call(ma, oa)}) super end end\n" \
+    "EvalWideChild.new.m(#{(1..ma).to_a.join(', ')})"
+  end
+  assert_equal 1, eval(zsuper.call(16, 15))
+  assert_raise(SyntaxError) { eval(zsuper.call(16, 16)) }
+
+  yielder = lambda do |ma, oa|
+    "def eval_wide_yielder(#{params.call(ma, oa)}) yield a1 end\n" \
+    "eval_wide_yielder(#{(1..ma).to_a.join(', ')}) { |v| v }"
+  end
+  assert_equal 1, eval(yielder.call(16, 15))
+  assert_raise(SyntaxError) { eval(yielder.call(16, 16)) }
+end

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -825,3 +825,26 @@ assert('eval of a nesting Prism would recurse through') do
   assert_equal 2, eval("[1].map { |v| eval('[[[2]]]')[0][0][0] }[0]")
   assert_equal [1, 2], eval("q = [1, 2]; q => [a, b]; [a, b]")
 end
+
+assert 'eval a `super` and a `yield` at the width of the forwarding level' do
+  # `OP_ARGARY` and `OP_BLKPUSH` carry the level between the asker and its
+  # method scope in four bits of their operand, so fifteen nested blocks is
+  # the deepest either can still name the frame it forwards from.  Deeper
+  # than that the level wrapped and the pair read another frame's registers.
+  zsuper = lambda do |depth|
+    "class EvalLevelParent; def m(a) [a, :parent] end end\n" \
+    "class EvalLevelChild < EvalLevelParent; def m(a)\n" +
+    "[1].each { " * depth + "$eval_level = super" + " }" * depth +
+    "\n$eval_level\nend end\nEvalLevelChild.new.m(1)"
+  end
+  assert_equal [1, :parent], eval(zsuper.call(15))
+  assert_raise(SyntaxError) { eval(zsuper.call(16)) }
+
+  yielder = lambda do |depth|
+    "def eval_level_yielder\n" +
+    "[1].each { " * depth + "$eval_level = yield" + " }" * depth +
+    "\n$eval_level\nend\neval_level_yielder { :ok }"
+  end
+  assert_equal :ok, eval(yielder.call(15))
+  assert_raise(SyntaxError) { eval(yielder.call(16)) }
+end

--- a/test/t/codegen.rb
+++ b/test/t/codegen.rb
@@ -449,3 +449,33 @@ assert('a rescue modifier in a loop body leaves the registers balanced') do
       end
   assert_equal 30, v
 end
+
+assert('super and yield at fifteen nested blocks') do
+  # `OP_ARGARY` and `OP_BLKPUSH` reach the method scope through a level of
+  # four bits, so fifteen is the deepest nesting either can still name the
+  # frame it forwards from.
+  class CodegenLevelParent
+    def m(a) [a, :parent] end
+  end
+  class CodegenLevelChild < CodegenLevelParent
+    def m(a)
+      [1].each { [1].each { [1].each { [1].each { [1].each {
+      [1].each { [1].each { [1].each { [1].each { [1].each {
+      [1].each { [1].each { [1].each { [1].each { [1].each {
+        $codegen_level = super
+      } } } } } } } } } } } } } } }
+      $codegen_level
+    end
+  end
+  assert_equal [1, :parent], CodegenLevelChild.new.m(1)
+
+  def codegen_level_yield
+    [1].each { [1].each { [1].each { [1].each { [1].each {
+    [1].each { [1].each { [1].each { [1].each { [1].each {
+    [1].each { [1].each { [1].each { [1].each { [1].each {
+      $codegen_level = yield
+    } } } } } } } } } } } } } } }
+    $codegen_level
+  end
+  assert_equal :ok, codegen_level_yield { :ok }
+end


### PR DESCRIPTION
## Summary

`OP_ARGARY` and `OP_BLKPUSH` reach the method scope a `super` or a `yield` forwards from through one 16-bit operand that holds two things: the argument layout of that method, and the level between it and the asker. The code generator packed both without checking either. Sixteen nested blocks wrap the level to zero, and 32 mandatory and optional parameters counted together push the layout into the level's bits, so in both cases the pair reads a frame nobody asked for.

## Changes

| File                                   | What                                                           |
| -------------------------------------- | -------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c` | refuse a level, and a layout, the operand cannot carry         |
| `test/t/codegen.rb`                    | cover a `super` and a `yield` at the deepest nesting that fits |
| `mrbgems/mruby-eval/test/eval.rb`      | cover both widths, one level and one parameter past what fits  |

Two commits: the level first, then the layout, which is the same operand and the same helper but a shape a program reaches without nesting anything.

### The level

`ainfo` takes twelve of the sixteen bits, which leaves four for the level, and the generator wrote `m.lv & 0xf`. At a nesting of sixteen the mask answers 0, which names the asker's own frame, so a bare `super` forwarded the innermost block's registers as the method's arguments and `yield` looked for the block among them. `mscope_operand()` refuses that with the message `scope_add_irep()` already uses for a nesting the compiler cannot carry.

The block a `super` forwards travels a different road when the method takes no arguments: `gen_blkmove()` reads it with `OP_GETUPVAR`, whose level is eight bits, and Prism stops at `PRISM_DEPTH_MAXIMUM` first, so that path needs no bound of its own.

### The layout

`ainfo` spends six of its bits on the mandatory and optional parameters counted together, and `lambda_body()` bounds them at 31 each rather than 31 together. Thirty-two of them set the twelfth bit, which the shift by four carries out of the operand: what comes back is a different layout, and `OP_ARGARY` forwards a register count of its own reading. It takes no block to reach, so `def m(a1..a16, b1 = 1, ..., b16 = 1) super end` is enough. The same helper refuses it with `too many formal arguments`, the message the parameter counts already answer with when one of them alone is too wide.

Refusing it here rather than at the `OP_ENTER` that records the layout leaves a method that wide compiling as long as nothing forwards it, which is what it does today.

### Behaviour

```ruby
# a bare `super` inside sixteen nested `[1].each { }` in `def m(a, b)`
sub.new.m(1, 2)      # CRuby: [1, 2], mruby: TypeError
# the same with a block parameter in each block
sub.new.m(1, 2)      # CRuby: [1, 2], mruby: [1, nil]
# `yield` at that depth
y16 { :ok }          # CRuby: :ok, mruby: TypeError
# a bare `super` in a method with 16 mandatory and 16 optional parameters
sub.new.m(1)         # CRuby: 1, mruby: TypeError
```

Each now fails to compile, with `too many nested blocks/methods` for the first three and `too many formal arguments` for the fourth. The level was reported next to a bounds check on the same operand in #7569.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang`:

| Build            |    master |   This PR | Delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,003,382 | 2,003,494 |  +112 |
| bintest          | 1,401,990 | 1,402,070 |   +80 |
| cxx_abi          | 1,436,969 | 1,437,033 |   +64 |
| byte-string      | 1,363,350 | 1,363,430 |   +80 |
| ascii-ctype      | 1,386,374 | 1,386,454 |   +80 |
| no-float         | 1,329,246 | 1,329,342 |   +96 |
| no-bigint        | 1,287,622 | 1,287,702 |   +80 |

Every delta belongs to `mrbgems/mruby-compiler/src/codegen.o` and matches the binary's to the byte, apart from padding at `-O0`. Two comparisons and two calls to `codegen_error()` is what it buys.

## Testing

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2805 | 2731 |   74 |   0 |     0 |       0 |
| full-debug  |  3053 | 3042 |   11 |   0 |     0 |       0 |
| bintest     |  3053 | 3033 |   20 |   0 |     0 |       0 |
| cxx_abi     |  3053 | 3033 |   20 |   0 |     0 |       0 |
| byte-string |  2965 | 2891 |   74 |   0 |     0 |       0 |
| ascii-ctype |  3037 | 3015 |   22 |   0 |     0 |       0 |
| no-float    |  2786 | 2689 |   97 |   0 |     0 |       0 |
| no-bigint   |  3002 | 2969 |   33 |   0 |     0 |       0 |

bintest ran in the `bintest` build and passed, 147 total with 1 skip. The same seven builds are green on i686 natively and on armhf under qemu.

The assertion in `test/t/codegen.rb` answers the same on master, so it is coverage of the deepest nesting that still compiles rather than a regression test. The two in `mrbgems/mruby-eval/test/eval.rb` are the regression tests, since only `eval` can hold source the compiler is meant to refuse. On master the level pair reports that no `SyntaxError` was raised for the `super` and that `yield` raised `LocalJumpError`; the layout pair reports `TypeError` from both.

## Environment

<details>

|          |                                                                   |
| -------- | ----------------------------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                                                |
| Kernel   | Linux 7.0.0-31-generic x86_64                                     |
| CPU      | AMD Ryzen 9 5950X 16-Core Processor                               |
| Compiler | gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0                       |
| binutils | GNU ld (GNU Binutils) 2.47.20260726                               |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

host:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang full-debug:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang bintest:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

ci/gcc-clang cxx_abi (compiled as C++, g++ links):

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang byte-string:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang ascii-ctype:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-float:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ci/gcc-clang no-bigint:

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build dir>=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for deeply nested `super` and `yield` forwarding.
  * Invalid nesting depths and oversized forwarded argument layouts now raise `SyntaxError` instead of being silently truncated.

* **Tests**
  * Added coverage for supported boundary limits and error conditions involving nested blocks and forwarded parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->