### PR TITLE
build: stop reporting a plot that gnuplot did not write

### DIFF
--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -45,6 +45,10 @@ def plot
       p.puts "e"
     end
   end
+  # A gnuplot that never ran leaves the same trace as one that plotted: what
+  # the shell writes goes to the terminal rather than here, and the status is
+  # the only thing that tells the two apart.
+  raise "gnuplot exited #{$?.exitstatus}" unless $?.success?
 
   puts "Benchmark results output to #{plot_file}"
 end


### PR DESCRIPTION
## Summary

With no gnuplot installed, `rake benchmark` printed the path it meant to write and exited 0, so a run that plotted nothing read as a run that had plotted.

## Changes

| File                   | What                              |
| ---------------------- | --------------------------------- |
| `tasks/benchmark.rake` | raise when gnuplot exits non-zero |

### Where the failure went

`plot` hands the data to gnuplot through `IO.popen(cmd, 'w')`. The block form waits for the child and leaves its status in `$?`, and nothing read it. A gnuplot that is not there is the shell exiting 127, which is indistinguishable at that point from a gnuplot that plotted: the shell writes its own message straight to the terminal rather than back through the pipe, so the task went on to announce the file it had not written.

The raise names the status and nothing else. Whatever gnuplot itself says about a failure is already on the terminal by then, and the alternative of putting `cmd` in the message adds the whole generated plot script, some four hundred characters, to every failure.

`benchmark: parse bm_app_lc_fizzbuzz.rb again and stop recording failed runs` (#7583) also touches this file. It changes the task that records a timing, twenty lines away from `plot`, and the two merge without a conflict in either order.

## Testing

| Build         | Total | OK   | Skip | KO  | Crash | Warning |
| ------------- | ----- | ---- | ---- | --- | ----- | ------- |
| `host`        | 2824  | 2750 | 74   | 0   | 0     | 0       |
| `full-debug`  | 3072  | 3061 | 11   | 0   | 0     | 0       |
| `bintest`     | 3072  | 3052 | 20   | 0   | 0     | 0       |
| `cxx_abi`     | 3072  | 3052 | 20   | 0   | 0     | 0       |
| `byte-string` | 2984  | 2910 | 74   | 0   | 0     | 0       |
| `ascii-ctype` | 3056  | 3034 | 22   | 0   | 0     | 0       |
| `no-float`    | 2805  | 2708 | 97   | 0   | 0     | 0       |
| `no-bigint`   | 3021  | 2988 | 33   | 0   | 0     | 0       |

`bintest` also ran the command binary tests: 148 total, 147 OK, 1 skip, 0 KO, 0 crash, 0 warning.

`rake benchmark` was run under three gnuplot conditions. Under gnuplot 6.0 it exits 0 and writes the plot, 22,777 bytes with a bar for each of the seven benchmarks. Under a gnuplot that exits 127, which is what the shell returns for a program it cannot find, the run stops with `gnuplot exited 127` and writes no file. Under a gnuplot that exits 1 after writing a diagnostic, the diagnostic appears and the run stops with `gnuplot exited 1`.

## Environment

<details>

|          |                                |
| -------- | ------------------------------ |
| OS       | Ubuntu 24.04.4 LTS             |
| Kernel   | Linux 7.0.0-31-generic         |
| CPU      | AMD Ryzen 9 5950X              |
| Compiler | gcc 13.3.0                     |
| Binutils | GNU ld 2.47.20260726           |
| gnuplot  | 6.0 patchlevel 0               |
| CRuby    | ruby 4.0.6 (2026-07-14) +PRISM |

`host`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK src/string.c
```

`full-debug` (-O0)

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

`bintest`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK src/string.c
```

`cxx_abi` (compiled as C++ by `gcc -x c++ -std=gnu++03`; g++ only links)

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

`byte-string`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

`ascii-ctype`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

`no-float`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

`no-bigint`

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved benchmark plotting error handling by reporting when the plotting process fails, including its exit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->