### PR TITLE
mruby-io: leave the growing file end of stream test to real Windows

### DIFF
--- a/mrbgems/mruby-io/test/io.rb
+++ b/mrbgems/mruby-io/test/io.rb
@@ -101,9 +101,8 @@ assert('IO#eof?', '15.2.20.5.6') do
   io.close
 end
 
-assert('IO#eof? is answered again after the end') do
-  # Bytes put back after the end are there to be read, and so are bytes that
-  # reach a file after a reader has seen the end of it.
+assert('IO#eof? is answered again after a put-back byte') do
+  # Bytes put back after the end are there to be read.
   io = IO.open(IO.sysopen($mrbtest_io_rfname))
   begin
     io.read
@@ -115,6 +114,12 @@ assert('IO#eof? is answered again after the end') do
   ensure
     io.close
   end
+end
+
+assert('IO#eof? is answered again after the file grows') do
+  # Bytes that reach a file after a reader has seen the end of it are there
+  # to be read.
+  skip "wine reads no further than where this handle saw the end" if MRubyIOTestUtil.wine?
 
   dir = MRubyIOTestUtil.mkdtemp("mruby-io-test.XXXXXX")
   path = "#{dir}/growing"

--- a/mrbgems/mruby-io/test/mruby_io_test.c
+++ b/mrbgems/mruby-io/test/mruby_io_test.c
@@ -225,6 +225,20 @@ mrb_io_win_p(mrb_state *mrb, mrb_value klass)
 #endif
 }
 
+/* Wine is close enough to Windows to run the whole suite but not close enough
+   in every corner, and it is what the cross-mingw-winetest build tests with.
+   The version function is exported by its ntdll and by no other. */
+static mrb_value
+mrb_io_wine_p(mrb_state *mrb, mrb_value klass)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+  HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+  return mrb_bool_value(ntdll && GetProcAddress(ntdll, "wine_get_version") != NULL);
+#else
+  return mrb_false_value();
+#endif
+}
+
 #if defined(_WIN32)
 #define MAXPATHLEN 1024
 #define getcwd _getcwd
@@ -266,6 +280,7 @@ mrb_mruby_io_gem_test(mrb_state* mrb)
   mrb_define_class_method(mrb, io_test, "mkdtemp", mrb_io_test_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "rmdir", mrb_io_test_rmdir, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, io_test, "win?", mrb_io_win_p, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, io_test, "wine?", mrb_io_wine_p, MRB_ARGS_NONE());
 
   mrb_define_const(mrb, io_test, "MRB_USE_IO_PREAD_PWRITE", mrb_bool_value(MRB_USE_IO_PREAD_PWRITE_ENABLED));
 


### PR DESCRIPTION
## Summary

`cross-mingw-winetest` reports one KO: wine will not read past where a handle has already seen the end of a file, so `IO#eof?` cannot answer again once another descriptor has appended. This leaves that half of the test to real Windows and keeps the rest running under wine.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-io/test/mruby_io_test.c` | `MRubyIOTestUtil.wine?`, true when `ntdll` exports `wine_get_version` |
| `mrbgems/mruby-io/test/io.rb` | split `IO#eof? is answered again after the end` in two and skip the growing file half under wine |

### What wine does

The failing assertions are the last four, the ones that grow the file through a second descriptor and ask the first one again. Under wine the reader stays at the end it already found:

```
Fail: IO#eof? is answered again after the end (mrbgems: mruby-io)
 - Assertion[8]
    Expected true to be false.
 - Assertion[9]
    Expected: "two\n"
      Actual: nil
```

This sits below the C runtime rather than in `mruby-io`. With the file grown to 8 bytes through another descriptor, `GetFileSizeEx` on the reading handle answers 8 and its position is 4, yet `ReadFile` on that handle succeeds with 0 bytes:

```c
fd = _open(path, _O_RDONLY|_O_BINARY);          /* file holds "one\n" */
_read(fd, b, sizeof(b));                        /* 4 */
_read(fd, b, sizeof(b));                        /* 0 */
/* another descriptor appends "two\n" and closes */
GetFileSizeEx(_get_osfhandle(fd), &sz);         /* 8 */
SetFilePointerEx(_get_osfhandle(fd), zero, &pos, FILE_CURRENT);  /* 4 */
ReadFile(_get_osfhandle(fd), b, sizeof(b), &got, NULL);          /* TRUE, got = 0 */
```

`_O_BINARY` and `_O_TEXT` behave alike, and a `SetFilePointer` to that same position makes the appended bytes readable again, so it is the handle's idea of where the file ends that is stale.

### Why the test is split

`skip` raises out of the whole `assert` block (`test/assert.rb:402`), so skipping inside the existing test would give up the put back half as well. That half passes under wine, so it moves into an assertion of its own and keeps running.

### Detecting wine

`wine_get_version` is exported by wine's `ntdll` and by no other, which makes it the usual way to ask. On real Windows `GetProcAddress` answers `NULL` and the test runs as before; Cygwin is excluded the same way `win?` excludes it.

## Testing

`rake -m test`, all builds on this branch.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,829 | 2,755 | 74 | 0 | 0 | 0 |
| full-debug | 3,077 | 3,066 | 11 | 0 | 0 | 0 |
| bintest | 3,077 | 3,057 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,077 | 3,057 | 20 | 0 | 0 | 0 |
| byte-string | 2,989 | 2,915 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,061 | 3,039 | 22 | 0 | 0 | 0 |
| no-float | 2,810 | 2,713 | 97 | 0 | 0 | 0 |
| no-bigint | 3,026 | 2,993 | 33 | 0 | 0 | 0 |
| cross-mingw-winetest | 3,059 | 3,008 | 51 | 0 | 0 | 0 |

bintest is green everywhere it runs: 131 on host, 148 on the `bintest` build, 101 under wine, no KO and no Crash in any of them.

On master the same wine build answers 3,058 / 3,007 / 50 with 1 KO. The put back assertions were the ones still worth running there, and they are what the first of the two tests now holds on its own; the second names wine in its skip message rather than naming Windows, so a native Windows run still has to answer it.

Nothing outside `bin/mrbtest` is built from the changed files, so there is no size to compare.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| Cross compiler | x86_64-w64-mingw32-gcc-posix (GCC) 13-posix |
| binutils | GNU ld 2.47.20260726 (host), 2.41.90.20240122 (mingw) |
| Wine | wine-11.0 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines from `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` arguments elided. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03` and uses `g++` only to link.

```
host         gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK ../../src/string.c

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK ../../src/string.c

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

cross-mingw-winetest
             x86_64-w64-mingw32-gcc-posix -static -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Split `IO#eof?` coverage into separate tests for put-back bytes and file growth.
  - Added a platform guard to skip the file-growth test under Wine.
  - Added a helper to detect Wine environments for platform-specific test handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->