### PR TITLE
mruby-compiler: unwind from a refused `END` instead of compiling on

### DIFF
--- a/mrbgems/mruby-bin-mruby/bintest/mruby.rb
+++ b/mrbgems/mruby-bin-mruby/bintest/mruby.rb
@@ -21,6 +21,12 @@ assert('regression for #1564') do
   assert_mruby("", /\A-e:1:\d+: syntax error,/, false, %w[-e <<-])
 end
 
+assert('a construct the generator refuses is named on standard error') do
+  # The generator writes its own message; the diagnostic list it also fills is
+  # read by `mrbc`, not here.
+  assert_mruby("", "-e:1: END not supported\n", false, ['-e', 'END { }'])
+end
+
 assert('OP_CALL on a receiver that is not a Proc is refused') do
   # OP_CALL reads ci->stack[0] as an RProc*. No compiled program contains the
   # instruction (the only iseq holding one is call_iseq in src/proc.c, entered

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -7082,7 +7082,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     }
     case PM_POST_EXECUTION_NODE:
     {
-      mrc_diagnostic_list_append(s->c, tree->location.start, "END not supported", MRC_GENERATOR_ERROR);
+      codegen_error(s, "END not supported");
       break;
     }
     case PM_RANGE_NODE:


### PR DESCRIPTION
## Summary

`END` was refused by appending to the diagnostic list without unwinding, so `bin/mruby` exited 1 with nothing on standard error and the scopes standing at that point were never given back. Refusing it through `codegen_error()` puts it on the path every other construct the generator will not compile already takes.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-compiler/src/codegen.c` | refuse `PM_POST_EXECUTION_NODE` through `codegen_error()` |
| `mrbgems/mruby-bin-mruby/bintest/mruby.rb` | a construct the generator refuses is named on standard error |

### What the two ways of refusing do

`codegen_error()` records the message in the diagnostic list, writes it to standard error, gives every scope back and throws out of `codegen()`. Appending to the list on its own does the first of those four.

`END` was the only refusal written the second way. `BEGIN`, `alias $a $b`, a constant path op-assign and every node the generator answers `Not implemented` for all take the first. Nothing but `mrbc` reads the list, so `bin/mruby` had no message to print, and code generation carried on from a `break` that had left no value where the caller expected one.

## Behaviour

```ruby
# END.rb
END { p 1 }
p :main
```

```
$ bin/mruby END.rb          # master: exit 1, nothing said
$ bin/mruby END.rb          # this PR
END.rb:1: END not supported
```

`mrbc` printed the list entry before and now prints the generator's own message as well:

```
$ bin/mrbc -o /dev/null END.rb    # master
END.rb:1:1: generator error, END not supported
$ bin/mrbc -o /dev/null END.rb    # this PR
END.rb:1: END not supported
END.rb:0:0: generator error, END not supported
```

The list entry loses its position, since `codegen_error()` records without one, which is what every other generator error's entry already carries. The line still reaches a reader compiling a file, through the message the generator writes itself, but it is gone from what `eval` raises:

```ruby
begin; eval("END { }"); rescue SyntaxError => e; p e.message; end
# master:  "file (eval) line 1: generator error, END not supported"
# this PR: "file (eval) line 0: generator error, END not supported"

begin; eval("BEGIN { }"); rescue SyntaxError => e; p e.message; end
# both:    "file (eval) line 0: generator error, Not implemented: PM_PRE_EXECUTION_NODE"
```

Out of scope here, and different from CRuby: no generator error records a position, so `mrbc` prints `0:0` and `eval` reports line 0 for every one of them. `codegen()` knows the node it is on, so the line is there to be had.

A `clang-asan` build stops leaking what the abandoned compile held:

```
master    716 byte(s) leaked in 9 allocation(s)
this PR   no leak
```

## Size

`bin/mruby` `.text`, `ci/gcc-clang` with `CC=gcc CXX=g++ LD=gcc`.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,005,334 | 2,005,318 | -16 |
| bintest | 1,402,662 | 1,402,694 | +32 |
| cxx_abi | 1,435,257 | 1,435,337 | +80 |
| byte-string | 1,364,006 | 1,364,038 | +32 |
| ascii-ctype | 1,387,030 | 1,387,062 | +32 |
| no-float | 1,329,758 | 1,329,742 | -16 |
| no-bigint | 1,286,614 | 1,286,646 | +32 |

The whole delta is `mrbgems/mruby-compiler/src/codegen.o`, whose `.text` moves by the same amount in every build: a four-argument call to `mrc_diagnostic_list_append()` becomes a two-argument call to `codegen_error()`, and gcc weighs the surrounding block differently.

## Testing

`rake -m test`, all builds on this branch.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,830 | 2,756 | 74 | 0 | 0 | 0 |
| full-debug | 3,078 | 3,067 | 11 | 0 | 0 | 0 |
| bintest | 3,078 | 3,058 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,078 | 3,058 | 20 | 0 | 0 | 0 |
| byte-string | 2,990 | 2,916 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,062 | 3,040 | 22 | 0 | 0 | 0 |
| no-float | 2,811 | 2,714 | 97 | 0 | 0 | 0 |
| no-bigint | 3,027 | 2,994 | 33 | 0 | 0 | 0 |

bintest is green where it runs: 135 on host and 152 on the `bintest` build, one skip each, no KO and no Crash. Master has no such assertion.

The new assertion is what the driver says rather than what it exits with, which is where the whole difference sat: master already exited 1. With the compiler change taken back out and the assertion left in, it reads

```
Fail: a construct the generator refuses is named on standard error (mrbgems: mruby-bin-mruby)
 - Assertion[1]
    Fail: assert_mruby (mrbgems: mruby-bin-mruby)
     - Assertion[1-2] standard error.
        Expected "-e:1: END not supported\n" to be === "".
```

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines from `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` arguments elided. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03` and uses `g++` only to link.

```
host         gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK ../../src/string.c

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK ../../src/string.c

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message shown when unsupported `END` blocks are used.
  * The command now reports the diagnostic on standard error and exits unsuccessfully, with no standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->