### PR TITLE
mruby-compiler: close a file's debug range only in a scope with an irep

### DIFF
--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -13,6 +13,36 @@ assert('Compiling multiple files without new line in last line. #2361') do
   assert_equal 0, status.exitstatus
 end
 
+assert('the first of several input files may hold no statements') do
+  # codegen() walks from one input file to the next when the node it is handed
+  # starts past the end of the file it is on, and closes the debug range of the
+  # file it leaves against the scope's irep. The scope generate_code() starts in
+  # has none: it only carries the program node down to the top-level scope. A
+  # first file that parses to no statement puts that program node in the second
+  # file, so the walk ran in the scope without an irep and read through it.
+  Dir.mktmpdir do |dir|
+    second = File.join(dir, 'second.rb')
+    File.write(second, "p 1\nraise 'boom'\n")
+
+    # Every file that holds no statement at all arrives the same way.
+    ['', "\n", "# comment\n", "=begin\n=end\n"].each do |source|
+      first = File.join(dir, 'first.rb')
+      out = File.join(dir, 'out.mrb')
+      File.write(first, source)
+
+      result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-g', '-o', out, first, second]))
+      assert_equal 0, status.exitstatus, source.inspect
+      assert_equal '', result.chomp
+
+      # The walk still has to land on the second file: that is what names the
+      # line the backtrace blames.
+      ran, = Open3.capture2e(*(cmd_list('mruby') + ['-b', out]))
+      assert_include ran, "1\n", source.inspect
+      assert_include ran, "#{second}:2: boom (RuntimeError)", source.inspect
+    end
+  end
+end
+
 assert('parsing function with void argument') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write('f ()')

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -4948,8 +4948,13 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
 
   if (s->filename_index+1 < s->c->filename_table_length) {
     if (s->c->filename_table[s->filename_index+1].start <= token_pos) {
-      mrc_debug_info_append_file(s->c, s->irep->debug_info,
-                                s->filename, s->lines, s->debug_start_pos, s->pc);
+      /* The scope generate_code() starts in emits nothing and has no irep to
+         attribute a range to. It still has to move to the file the node is
+         in, which is the file it hands to the top-level scope below it. */
+      if (s->irep) {
+        mrc_debug_info_append_file(s->c, s->irep->debug_info,
+                                  s->filename, s->lines, s->debug_start_pos, s->pc);
+      }
       s->debug_start_pos = s->pc;
       s->filename_index++;
       s->filename = (const char *)s->c->filename_table[s->filename_index].filename;


### PR DESCRIPTION
## Summary

`mrbc` took SIGSEGV whenever the first of several input files parsed to no statement at all. The walk that moves the compiler from one input file to the next ran in a scope that has no irep, and read through it.

## Changes

| File                                     | What                                                                  |
| ---------------------------------------- | --------------------------------------------------------------------- |
| `mrbgems/mruby-compiler/src/codegen.c`   | Close a file's debug range only in a scope that has an irep           |
| `mrbgems/mruby-bin-mrbc/bintest/mrbc.rb` | Compile and run a pair of files whose first one holds no statement    |

### Where the null pointer comes from

`generate_code()` opens the scope it hands the program node to with `scope_new(c, NULL, NULL)`, and that call returns before `scope_add_irep()`: the scope carries the program node down to the top-level scope, which is the one that emits code. Its `irep` is null for the whole of its life.

`codegen()` compares the start of every node it is given against the file table, and when the node has moved past the end of the current file it closes that file's debug range against `s->irep->debug_info`. On a single input file, or when the first file holds a statement, the program node still lies in the first file and the comparison is false, so the scope without an irep never reached the dereference. A first file that parses to no statement puts the program node itself in the second file, and the very first `codegen()` call took the walk.

The guard sits on that read alone. What is left of the walk is the scope moving to the file its node is in, and this scope is the one that hands its file to the top-level scope below it. Skipping the whole walk instead would open the top-level scope on the first file, which it corrects on its own first node; the range it would close in between is empty, and `mrc_debug_info_append_file()` already returns without recording an empty one, so the debug info is the same either way. Guarding the read alone is what keeps the name the scope carries right for whatever comes to read it.

## Behaviour

`mrbc` compiles what it used to crash on. `mrc_load_file_cxt()` is the only entry point that takes more than one filename and `mrbc` is its only caller, so nothing else could reach this.

```console
$ printf '# a comment\n' > a.rb; printf 'p 1\n' > b.rb
$ mrbc -o out.mrb a.rb b.rb
Segmentation fault (core dumped)     # master
                                     # this PR: compiles, and out.mrb prints 1
```

Every shape of a statement-less file arrives the same way: an empty file, a lone newline, a comment, an embedded document. The file has to be the first one and something after it has to carry a statement. A statement-less file in the middle compiles on master, and so does a run where every file is statement-less.

## Size

`.text` of `bin/mruby`, `ci/gcc-clang` with `CC=gcc CXX=g++ LD=gcc`.

| Build            |    master |   This PR |   Δ |
| ---------------- | --------: | --------: | --: |
| full-debug (-O0) | 2,005,318 | 2,005,334 | +16 |
| bintest          | 1,402,694 | 1,402,710 | +16 |
| cxx_abi          | 1,435,337 | 1,435,353 | +16 |
| byte-string      | 1,364,038 | 1,364,054 | +16 |
| ascii-ctype      | 1,387,062 | 1,387,078 | +16 |
| no-float         | 1,329,742 | 1,329,726 | -16 |
| no-bigint        | 1,286,646 | 1,286,662 | +16 |

All of it is `codegen()` in `codegen.o`, the only symbol whose size changes in any build, and none appears or disappears. The function itself moves by a handful of bytes, +5 in `bintest`, +13 in `cxx_abi` and -12 in `no-float`; the binary figure is that rounded out by alignment.

## Testing

| Build       | Total |    OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ----: | ---: | --: | ----: | ------: |
| host        | 2,830 | 2,756 |   74 |   0 |     0 |       0 |
| full-debug  | 3,078 | 3,067 |   11 |   0 |     0 |       0 |
| bintest     | 3,078 | 3,058 |   20 |   0 |     0 |       0 |
| cxx_abi     | 3,078 | 3,058 |   20 |   0 |     0 |       0 |
| byte-string | 2,990 | 2,916 |   74 |   0 |     0 |       0 |
| ascii-ctype | 3,062 | 3,040 |   22 |   0 |     0 |       0 |
| no-float    | 2,811 | 2,714 |   97 |   0 |     0 |       0 |
| no-bigint   | 3,027 | 2,994 |   33 |   0 |     0 |       0 |

bintest ran in the two builds that enable it: 136 tests in `host` and 153 in `bintest`, one skip each and no KO.

The new bintest compiles two files for each of the four statement-less shapes and runs the result, so it fails on master by crashing `mrbc`. It then reads the backtrace of a `raise` in the second file: the walk still has to arrive at that file for the trace to name it, which is what the fix has to leave working.

## Environment

<details>

| Item     | Version                                       |
| -------- | --------------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                            |
| Kernel   | 7.0.0-31-generic                              |
| CPU      | AMD Ryzen 9 5950X 16-Core Processor           |
| Compiler | gcc 13.3.0, g++ 13.3.0                        |
| binutils | GNU ld 2.47.20260726                          |
| CRuby    | 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM |

Compile lines, from `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I` and `-o` dropped and the build directory written as `<build>`:

```
host
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK

full-debug
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

bintest
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK

cxx_abi
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
(g++ links only)

byte-string
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

ascii-ctype
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-float
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER

no-bigint
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -ffile-prefix-map="../..=.." -ffile-prefix-map="<build>=build" -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bytecode compilation for empty or comment-only files followed by files containing code.
  * Corrected source-file information in runtime backtraces, ensuring line references point to the appropriate input file.

* **Tests**
  * Added coverage for compiling empty, whitespace-only, comment-only, and delimiter-only source files before executable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->