### PR TITLE
mruby-compiler: guard with MRC_NO_STDIO only what stdio owns

### DIFF
--- a/mrbgems/mruby-compiler/include/mrc_ccontext.h
+++ b/mrbgems/mruby-compiler/include/mrc_ccontext.h
@@ -54,12 +54,15 @@ typedef struct mrc_ccontext {
   // For PICOIRB
   uint16_t scope_sp;
 
-#ifndef MRC_NO_STDIO
-  mrc_pool *pool; // for codedump
-
+  /* Where in the joined source each of the files given to this context
+     begins, so that a position can be told which file it came from. The
+     codegen and the diagnostics both read it, whether or not stdio is in. */
   mrc_filename_table *filename_table;
   uint16_t filename_table_length;
   uint16_t current_filename_index;
+
+#ifndef MRC_NO_STDIO
+  mrc_pool *pool; // for codedump
 #endif
 
   /* The arena everything Prism allocates for this context is taken from, and

--- a/mrbgems/mruby-compiler/include/mrc_dump.h
+++ b/mrbgems/mruby-compiler/include/mrc_dump.h
@@ -9,10 +9,11 @@ MRC_BEGIN_DECL
 #define MRC_DUMP_DEBUG_INFO 1
 #define MRC_DUMP_STATIC 2
 
+int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
+
 #ifndef MRC_NO_STDIO
 int mrc_dump_irep_cfunc(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, FILE *fp, const char *initname);
 int mrc_dump_irep_binary(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, FILE* fp);
-int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
 #endif
 
 /* dump/load error code

--- a/mrbgems/mruby-compiler/src/codedump.c
+++ b/mrbgems/mruby-compiler/src/codedump.c
@@ -9,6 +9,8 @@
 #include "../include/mrc_irep_pool_type.h"
 #include <inttypes.h>
 
+#ifndef MRC_NO_STDIO
+
 const char *
 mrc_sym_dump(mrc_ccontext *c, mrc_sym sym)
 {
@@ -44,7 +46,6 @@ mrc_irep_catch_handler_table(const mrc_irep *irep)
   }
 }
 
-#ifndef MRC_NO_STDIO
 /* An anonymous local (a rest or block placeholder) is a pool entry with an
    empty name here, where mruby leaves the symbol unset, so the name has to be
    looked at rather than just the symbol. */

--- a/mrbgems/mruby-compiler/src/compile.c
+++ b/mrbgems/mruby-compiler/src/compile.c
@@ -244,6 +244,61 @@ mrc_pm_parser_init(mrc_parser_state *p, uint8_t **source, size_t size, mrc_ccont
   }
 }
 
+static mrc_node *
+mrc_pm_parse(mrc_ccontext *cc)
+{
+  mrc_node *node = pm_parse(cc->p);
+
+#if defined(PICORB_VM_MRUBYC)
+  // Workaround: save top-level locals for PicoRuby(mruby/c) IRB
+  pm_program_node_t *program = (pm_program_node_t *)node;
+  uint32_t nlocals = program->locals.size;
+  pm_options_t *options = (pm_options_t *)mrc_malloc(cc, sizeof(pm_options_t));
+  memset(options, 0, sizeof(pm_options_t));
+  pm_string_t *encoding = &options->encoding;
+  pm_string_constant_init(encoding, "UTF-8", 5);
+  pm_options_scopes_init(options, 1);
+  pm_options_scope_t *options_scope = &options->scopes[0];
+  pm_options_scope_init(options_scope, nlocals);
+  pm_constant_id_t id;
+  pm_constant_t *local;
+  pm_string_t *scope_local;
+  char *allocated;
+  for (int i = 0; i < nlocals; i++) {
+    scope_local = &options_scope->locals[i];
+    id = program->locals.ids[i];
+    local = pm_constant_pool_id_to_constant(&cc->p->constant_pool, id);
+    allocated = (char *)mrc_malloc(cc, local->length);
+    memcpy(allocated, local->start, local->length);
+    pm_string_constant_init(scope_local, (const char *)allocated, local->length);
+  }
+  if (cc->options && cc->options->scopes) {
+    for (int i = 0; i < cc->options->scopes[0].locals_count; i++) {
+      mrc_free(cc, (void *)cc->options->scopes[0].locals[i].source);
+    }
+    mrc_free(cc, cc->options);
+  }
+  cc->options = options;
+#endif
+
+  return node;
+}
+
+/* Give back the tree.  Where the arena is in use nothing is done here: the
+   parser is still holding what it allocated from the same arena, and the
+   whole of it is given back at mrc_ccontext_free() instead.  Where the arena
+   is not in use, which is a build with its own allocator, the tree is walked
+   as prism walks it. */
+static void
+mrc_prism_release_tree(mrc_ccontext *c, mrc_node *root)
+{
+#if defined(MRC_TARGET_MRUBY) && defined(MRC_PRISM_ARENA)
+  (void)c; (void)root;
+#else
+  if (root) pm_node_destroy(c->p, root);
+#endif
+}
+
 #ifndef MRC_NO_STDIO
 
 #define INITIAL_BUF_SIZE 1024
@@ -390,47 +445,6 @@ read_input_files(mrc_ccontext *c, const char **filenames, uint8_t **source, mrc_
 }
 
 static mrc_node *
-mrc_pm_parse(mrc_ccontext *cc)
-{
-  mrc_node *node = pm_parse(cc->p);
-
-#if defined(PICORB_VM_MRUBYC)
-  // Workaround: save top-level locals for PicoRuby(mruby/c) IRB
-  pm_program_node_t *program = (pm_program_node_t *)node;
-  uint32_t nlocals = program->locals.size;
-  pm_options_t *options = (pm_options_t *)mrc_malloc(cc, sizeof(pm_options_t));
-  memset(options, 0, sizeof(pm_options_t));
-  pm_string_t *encoding = &options->encoding;
-  pm_string_constant_init(encoding, "UTF-8", 5);
-  pm_options_scopes_init(options, 1);
-  pm_options_scope_t *options_scope = &options->scopes[0];
-  pm_options_scope_init(options_scope, nlocals);
-  pm_constant_id_t id;
-  pm_constant_t *local;
-  pm_string_t *scope_local;
-  char *allocated;
-  for (int i = 0; i < nlocals; i++) {
-    scope_local = &options_scope->locals[i];
-    id = program->locals.ids[i];
-    local = pm_constant_pool_id_to_constant(&cc->p->constant_pool, id);
-    allocated = (char *)mrc_malloc(cc, local->length);
-    memcpy(allocated, local->start, local->length);
-    pm_string_constant_init(scope_local, (const char *)allocated, local->length);
-  }
-  if (cc->options && cc->options->scopes) {
-    for (int i = 0; i < cc->options->scopes[0].locals_count; i++) {
-      mrc_free(cc, (void *)cc->options->scopes[0].locals[i].source);
-    }
-    mrc_free(cc, cc->options);
-  }
-  cc->options = options;
-#endif
-
-  return node;
-}
-
-
-static mrc_node *
 mrc_parse_file_cxt(mrc_ccontext *c, const char **filenames, uint8_t **source)
 {
   size_t filecount = 0;
@@ -451,21 +465,6 @@ mrc_parse_file_cxt(mrc_ccontext *c, const char **filenames, uint8_t **source)
   }
   mrc_pm_parser_init(c->p, source, length, c);
   return mrc_pm_parse(c);
-}
-
-/* Give back the tree.  Where the arena is in use nothing is done here: the
-   parser is still holding what it allocated from the same arena, and the
-   whole of it is given back at mrc_ccontext_free() instead.  Where the arena
-   is not in use, which is a build with its own allocator, the tree is walked
-   as prism walks it. */
-static void
-mrc_prism_release_tree(mrc_ccontext *c, mrc_node *root)
-{
-#if defined(MRC_TARGET_MRUBY) && defined(MRC_PRISM_ARENA)
-  (void)c; (void)root;
-#else
-  if (root) pm_node_destroy(c->p, root);
-#endif
 }
 
 MRC_API mrc_irep *

--- a/mrbgems/mruby-compiler/src/diagnostic.c
+++ b/mrbgems/mruby-compiler/src/diagnostic.c
@@ -64,7 +64,6 @@ mrc_diagnostic_list_append(mrc_ccontext *c, const uint8_t * location_start, cons
   mrc_diagnostic_list *list = (mrc_diagnostic_list *)mrc_calloc(c, 1, sizeof(mrc_diagnostic_list));
   const uint8_t *file_start = c->p->start;
   list->filename = NULL;
-#ifndef MRC_NO_STDIO
   if (c->filename_table && 0 < c->filename_table_length && location_start) {
     uint32_t offset = (uint32_t)(location_start - c->p->start);
     int file_idx = 0;
@@ -75,7 +74,6 @@ mrc_diagnostic_list_append(mrc_ccontext *c, const uint8_t * location_start, cons
     list->filename = c->filename_table[file_idx].filename;
     file_start = c->p->start + c->filename_table[file_idx].start;
   }
-#endif
   line_and_column_by_start_and_offset(file_start, location_start, &list->line, &list->column);
   char buf[256];
   const char *diagnostic_code_str = mrc_diagnostic_code_to_string(code);

--- a/mrbgems/mruby-compiler/src/mruby_compat.c
+++ b/mrbgems/mruby-compiler/src/mruby_compat.c
@@ -15,14 +15,10 @@
 #include "../include/mrc_ccontext.h"
 #include "../include/mrc_compile.h"
 #include "../include/mrc_diagnostic.h"
+#include "../include/mrc_dump.h"
 #include "../include/mrc_irep.h"
 #include "../include/mrc_parser_util.h"
 #include "../include/mrc_pool.h"
-
-#define MRC_COMPAT_DUMP_OK 0
-#define MRC_COMPAT_DUMP_DEBUG_INFO 1
-
-int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t **bin, size_t *bin_size);
 
 static void
 copy_context_to_mrc(mrc_ccontext *dst, const mrb_ccontext *src)
@@ -462,12 +458,12 @@ mrb_generate_code(mrb_state *mrb, struct mrb_parser_state *p)
   /* Always carry debug info across the dump/reload that turns the mrc_irep
      into an mrb_irep: without it runtime backtraces lose the file name and
      line number, and mruby reports those even when compiled without -g. */
-  uint8_t flags = MRC_COMPAT_DUMP_DEBUG_INFO;
+  uint8_t flags = MRC_DUMP_DEBUG_INFO;
 
   if (!p || !p->tree || p->nerr) return NULL;
   mc = (mrc_ccontext*)p->ylval;
   irep = (mrc_irep*)p->tree;
-  if (mrc_dump_irep(mc, irep, flags, &bin, &bin_size) != MRC_COMPAT_DUMP_OK) {
+  if (mrc_dump_irep(mc, irep, flags, &bin, &bin_size) != MRC_DUMP_OK) {
     report_roundtrip_error(mc, "irep dump error");
     return NULL;
   }


### PR DESCRIPTION
## Summary

A build that defines `MRC_NO_STDIO` does not compile: `mrc_ccontext` keeps `filename_table` inside the `#ifndef MRC_NO_STDIO` block while the codegen, the diagnostics and the string entry points all read it unconditionally. This moves out of that block everything that is not stdio's, leaving in only what needs a stream: the code dumper, and the dump entry points that write to a `FILE`.

## Changes

| File                                            | What                                                                                                                                 |
| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
| `mrbgems/mruby-compiler/include/mrc_ccontext.h` | `filename_table`, `filename_table_length` and `current_filename_index` move out of the `#ifndef MRC_NO_STDIO` block; `pool` stays in |
| `mrbgems/mruby-compiler/src/compile.c`          | `mrc_pm_parse()` and `mrc_prism_release_tree()` move above the block that starts at `append_from_stdin()`                            |
| `mrbgems/mruby-compiler/src/codedump.c`         | `mrc_sym_dump()` and `mrc_irep_catch_handler_table()` move inside the block                                                          |
| `mrbgems/mruby-compiler/src/diagnostic.c`       | the guard around the filename lookup goes, now that the table is always declared                                                     |
| `mrbgems/mruby-compiler/include/mrc_dump.h`     | `mrc_dump_irep()`, which takes no `FILE`, is declared outside the block                                                              |
| `mrbgems/mruby-compiler/src/mruby_compat.c`     | includes `mrc_dump.h` instead of writing that prototype and two of the header's constants out again                                  |

### What the guard was drawn around

The filename table says where in the joined source each input file begins, so that a position can be told which file it came from. `mrc_parse_file_cxt()` fills it from the files it reads, and `mrc_parse_string_cxt()` fills it with a single entry for the string. It is read by `partial_hook()`, by `mrc_parser_get_filename()`, `generate_code()`, `node_lineno()` and `codegen()` in `codegen.c`, by `mrc_diagnostic_list_append()`, and freed by `mrc_ccontext_free()`, none of which are guarded. Under `MRC_NO_STDIO` every one of those refers to a field that is not declared.

The compiler cannot report a file name without the table, so the fields move out rather than the readers moving in. `compile.c` had two more members of the block that stdio does not own: `mrc_pm_parse()` is what `mrc_parse_string_cxt()` calls to parse, and `mrc_prism_release_tree()` is what `mrc_load_string_cxt()` calls to give the tree back.

What is left inside is `pool`, which the code dumper opens in `mrc_codedump_all_file()` and allocates symbol names from. Its only reader is `mrc_sym_dump()`, which nothing outside the dump calls, so that function and the `mrc_irep_catch_handler_table()` helper next to it move inside the block instead.

### The same line in `mrc_dump.h`

`mrc_dump_irep()` writes an irep to a buffer the caller frees, and takes no `FILE`. Its definition is outside the block, but its declaration was inside it, so a no-stdio target could not reach the only dump entry point open to it through the header. `mruby_compat.c` shows what that costs: it writes the prototype out again by hand, next to its own `MRC_COMPAT_DUMP_OK` and `MRC_COMPAT_DUMP_DEBUG_INFO` spellings of two constants the header already gives. The declaration moves out and that file includes the header.

### Why it was not noticed

Nothing in the tree defines `MRC_NO_STDIO`. `build_config/minimal.rb` defines `MRB_NO_STDIO`, which the gem does not translate into it, and `mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c` refuses the define with an `#error`, so no build in the repository reaches the guarded code. The define is there for targets that embed the compiler without stdio.

Nothing observable changes for a build that can be made today. With `MRC_NO_STDIO` undefined the preprocessor sees exactly what it saw before, and the one field the diagnostics gain under it, `list->filename`, is read only by `mrbc.c`, which refuses the define outright.

## Size

`bin/mruby` `.text`, gcc 13.3.0, `MRUBY_CONFIG=ci/gcc-clang`:

| Build            |    master |   This PR | Delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,005,318 | 2,005,318 |     0 |
| bintest          | 1,402,694 | 1,402,694 |     0 |
| cxx_abi          | 1,435,337 | 1,435,337 |     0 |
| byte-string      | 1,364,038 | 1,364,038 |     0 |
| ascii-ctype      | 1,387,062 | 1,387,062 |     0 |
| no-float         | 1,329,742 | 1,329,742 |     0 |
| no-bigint        | 1,286,646 | 1,286,646 |     0 |

Every object is unchanged, `compile.o` and `mruby_compat.o` included: the code moves within its translation unit, and the `mrc_ccontext` fields that move are read through the same offsets by the same code.

## Testing

| Build       | Total |   OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ---: | ---: | --: | ----: | ------: |
| host        |  2830 | 2756 |   74 |   0 |     0 |       0 |
| full-debug  |  3078 | 3067 |   11 |   0 |     0 |       0 |
| bintest     |  3078 | 3058 |   20 |   0 |     0 |       0 |
| cxx_abi     |  3078 | 3058 |   20 |   0 |     0 |       0 |
| byte-string |  2990 | 2916 |   74 |   0 |     0 |       0 |
| ascii-ctype |  3062 | 3040 |   22 |   0 |     0 |       0 |
| no-float    |  2811 | 2714 |   97 |   0 |     0 |       0 |
| no-bigint   |  3027 | 2994 |   33 |   0 |     0 |       0 |

`bintest` runs 135 tests on the host build (1 skip) and 152 on the `bintest` build (1 skip), all passing.

Nothing in the tree exercises `MRC_NO_STDIO`, so the guarded build was checked by hand with a config that embeds the compiler and defines it:

```ruby
MRuby::CrossBuild.new('nostdio') do |conf|
  conf.toolchain :gcc
  conf.cc.defines << 'MRB_NO_STDIO'
  conf.cc.defines << 'MRC_NO_STDIO'
  conf.gem core: 'mruby-compiler'
end
```

On master it stops at the first guarded reader:

```
mrbgems/mruby-compiler/src/codedump.c:27:38: error: 'mrc_ccontext' has no member named 'pool'
mrbgems/mruby-compiler/src/ccontext.c:195:8: error: 'mrc_ccontext' has no member named 'filename_table'
mrbgems/mruby-compiler/src/compile.c:105:8: error: 'mrc_ccontext' has no member named 'current_filename_index'
```

With this PR it builds with no error and no warning.

## Environment

<details>

|          |                                        |
| -------- | -------------------------------------- |
| OS       | Ubuntu 24.04.4 LTS                     |
| Kernel   | Linux 7.0.0-31-generic x86_64          |
| CPU      | AMD Ryzen 9 5950X 16-Core              |
| Compiler | gcc 13.3.0, g++ 13.3.0                 |
| binutils | GNU ld 2.47.20260726                   |
| CRuby    | ruby 4.0.6 (2026-07-14) [x86_64-linux] |

Compile lines, taken with `touch src/string.c; rake --verbose` and stripped of `-MMD -c`, `-I` and `-o`:

host (`rake`)

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK
```

full-debug

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

bintest

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK
```

cxx_abi (compiled as C++ by gcc, g++ links)

```
gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

byte-string

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

ascii-ctype

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

no-float

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

no-bigint

```
gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler behavior when standard I/O support is disabled.
  * Diagnostic output now consistently includes filename and line/column information.
  * Ensured intermediate representation dumping is consistently available across supported configurations.

* **Refactor**
  * Consolidated compiler dump definitions and streamlined internal compilation organization without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->