### PR TITLE
mruby-compiler: give every generator error a position

### DIFF
--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -49,6 +49,18 @@ assert('too many local variables are rejected') do
   #   mrbc -c many-locals.rb
 end
 
+assert('a scope refused for its local variables is named with its position') do
+  source = Tempfile.new(['many-locals', '.rb'])
+  source.puts("x = 1")
+  source.puts("def big")
+  255.times { |i| source.puts("  local_#{i} = nil") }
+  source.puts("end")
+  source.flush
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', source.path]))
+  assert_equal 1, status.exitstatus
+  assert_include result, "#{source.path}:2: too many local variables"
+end
+
 assert('embedded document with invalid terminator') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write("=begin\n=endx\n")

--- a/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
+++ b/mrbgems/mruby-bin-mrbc/bintest/mrbc.rb
@@ -61,6 +61,19 @@ assert('a scope refused for its local variables is named with its position') do
   assert_include result, "#{source.path}:2: too many local variables"
 end
 
+assert('a generator error carries its position into the diagnostic list') do
+  # The list is what `mrbc` prints and what `eval` builds its SyntaxError from.
+  # Every entry in it used to read 0:0, since the generator recorded no
+  # position; the parser's entries have always carried one.
+  source = Tempfile.new(['end-block', '.rb'])
+  source.puts("x = 1")
+  source.puts("END { }")
+  source.flush
+  result, status = Open3.capture2e(*(cmd_list('mrbc') + ['-c', source.path]))
+  assert_equal 1, status.exitstatus
+  assert_include result, "#{source.path}:2:1: generator error, END not supported"
+end
+
 assert('embedded document with invalid terminator') do
   a, out = Tempfile.new('a.rb'), Tempfile.new('out.mrb')
   a.write("=begin\n=endx\n")

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -135,6 +135,7 @@ typedef struct scope {
   struct loopinfo *loop;
   const char *filename;
   uint16_t lineno;
+  const uint8_t *loc;           /* start of the node being compiled */
 
   mrc_code *iseq;
   uint16_t *lines;
@@ -167,7 +168,7 @@ codegen_error(mrc_codegen_scope *s, const char *message)
   if (!s) return;
   s->c->capture_errors = TRUE;
 
-  mrc_diagnostic_list_append(s->c, 0, message, MRC_GENERATOR_ERROR);
+  mrc_diagnostic_list_append(s->c, s->loc, message, MRC_GENERATOR_ERROR);
 
 #ifndef MRC_NO_STDIO
   if (!s->c->quiet_errors) {
@@ -470,6 +471,7 @@ scope_new(mrc_ccontext *c, mrc_codegen_scope *prev, mrc_constant_id_list *nlv)
      here is still named on standard error */
   s->filename = prev->filename;
   s->lineno = prev->lineno;
+  s->loc = prev->loc;
 
   scope_add_irep(s);
 
@@ -4961,6 +4963,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
   int nt = nint(tree);
 
   s->lineno = node_lineno(s->c, tree);
+  s->loc = tree->location.start;
 
   switch (nt) {
     case PM_PROGRAM_NODE: {

--- a/mrbgems/mruby-compiler/src/codegen.c
+++ b/mrbgems/mruby-compiler/src/codegen.c
@@ -466,6 +466,10 @@ scope_new(mrc_ccontext *c, mrc_codegen_scope *prev, mrc_constant_id_list *nlv)
   s->prev = prev;
   s->ainfo = 0;
   s->mscope = 0;
+  /* inherited before the first check that can fail, so that a scope refused
+     here is still named on standard error */
+  s->filename = prev->filename;
+  s->lineno = prev->lineno;
 
   scope_add_irep(s);
 
@@ -513,11 +517,9 @@ scope_new(mrc_ccontext *c, mrc_codegen_scope *prev, mrc_constant_id_list *nlv)
 
   int ai = mrc_gc_arena_save(c);
   s->ai = ai;
-  s->filename = prev->filename;
   if (s->filename) {
     s->lines = (uint16_t *)mrc_malloc(c, sizeof(uint16_t)*s->icapa);
   }
-  s->lineno = prev->lineno;
 
   /* degug info */
   s->debug_start_pos = 0;

--- a/mrbgems/mruby-eval/test/eval.rb
+++ b/mrbgems/mruby-eval/test/eval.rb
@@ -54,6 +54,19 @@ assert 'eval syntax error' do
   end
 end
 
+assert 'eval names the line a generator error is on' do
+  # eval reads the diagnostic list, and the generator's entries in it used to
+  # carry no position at all, so every one of them read as line 0.
+  assert_raise_with_message(SyntaxError,
+                            "file (eval) line 2: generator error, END not supported") do
+    eval("p 1\nEND { }")
+  end
+  assert_raise_with_message(SyntaxError,
+                            "file (eval) line 3: generator error, END not supported") do
+    eval("p 1\np 2\nEND { }")
+  end
+end
+
 assert 'eval deeply nested input does not crash the parser' do
   # The recursive-descent parser must hit its nesting cap and report an error
   # rather than overflowing the C stack on pathologically nested source.


### PR DESCRIPTION
## Summary

Two of the generator's refusals reached standard error with nothing naming where, and every generator error's entry in the diagnostic list carried no position at all, so `mrbc` printed `0:0` against the first input file's name and `eval` reported line 0. Both are a position the compiler already holds: the first wants it copied a few lines earlier, the second wants it passed one argument further.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-compiler/src/codegen.c` | inherit the position before the checks that can refuse a scope, and record it on the diagnostic list |
| `mrbgems/mruby-bin-mrbc/bintest/mrbc.rb` | a refused scope is named with its position, and a generator error's list entry carries one |
| `mrbgems/mruby-eval/test/eval.rb` | `eval` names the line a generator error is on |

### The window between a scope and its position

`scope_new()` starts from a zeroed scope, calls `scope_add_irep()`, checks the local variable count, allocates the scope's arrays, and only then copies `filename` and `lineno` from the enclosing scope. Two refusals live inside that window: `too many nested blocks/methods` for the 65,536th block or method of one scope, and `too many local variables` for a scope with 255 of them.

`codegen_error()` writes `<file>:<line>: <message>` when the scope has both fields and the bare message when it does not, so those two were the only generator errors that said what was wrong without saying where. `bin/mruby` writes nothing but that line, and had none to give.

The line inherited is the one `codegen()` last set on the enclosing scope, which is the node whose scope is being opened: the `def`, `class`, `module` or block, and the first line of a file for the file's own scope.

A source long enough to hold 65,536 blocks also runs past what the 16-bit `lineno` holds, so that refusal names a wrapped line unless the blocks are packed onto few lines. The limit is the field's and is older than this window.

### What the diagnostic list was told

`codegen_error()` appended to the list with a null location. The list derives the file, the line and the column from one pointer into the source, the way it does for a parser error, so a null one left every generator error's entry reading `0:0` with no file. `mrbc` prints the list and had to fall back to the name of the first input file; `eval` builds its `SyntaxError` from it and reported line 0 for every construct the generator will not compile; `mirb` marks the column it is given, which was the start of the line.

The scope already follows the node being compiled, for the line it writes to standard error and for the debug info it records. Keeping that node's start beside them costs the scope one pointer for the length of the compile, and is what the list wants.

## Behaviour

```ruby
# many-locals.rb
x = 1
def big
  local_0 = nil
  # 255 assignments in all
end
```

```
$ bin/mruby many-locals.rb     # master
too many local variables
$ bin/mruby many-locals.rb     # this PR
many-locals.rb:2: too many local variables
```

`mrbc` prints the generator's message and then the list entry, and both change:

```
$ bin/mrbc -c many-locals.rb     # master
too many local variables
many-locals.rb:0:0: generator error, too many local variables
$ bin/mrbc -c many-locals.rb     # this PR
many-locals.rb:2: too many local variables
many-locals.rb:2:1: generator error, too many local variables
```

The other refusal in the window reads the same way, here with the blocks packed onto one line so the count stays inside what `lineno` holds:

```
$ ruby -e 'print "z = 0\n", "proc { }; " * 65_536, "\n"' > many-blocks.rb
$ bin/mruby many-blocks.rb     # master
too many nested blocks/methods
$ bin/mruby many-blocks.rb     # this PR
many-blocks.rb:2: too many nested blocks/methods
```

The entry names the file the error is in rather than the first one on the command line. Here `a.rb` holds `p 1`, and `b.rb` holds `p 2` and an `END` block:

```
$ bin/mrbc -c a.rb b.rb     # master
b.rb:2: END not supported
a.rb:0:0: generator error, END not supported
$ bin/mrbc -c a.rb b.rb     # this PR
b.rb:2: END not supported
b.rb:2:1: generator error, END not supported
```

`eval` reads the list, so every generator error it raises now names its line:

```ruby
begin; eval("p 1\nEND { }"); rescue SyntaxError => e; p e.message; end
# master:  "file (eval) line 0: generator error, END not supported"
# this PR: "file (eval) line 2: generator error, END not supported"

begin; eval("p 1\nBEGIN { }"); rescue SyntaxError => e; p e.message; end
# master:  "file (eval) line 0: generator error, Not implemented: PM_PRE_EXECUTION_NODE"
# this PR: "file (eval) line 2: generator error, Not implemented: PM_PRE_EXECUTION_NODE"
```

`mirb` reads it too, and marks the column:

```
1> END { }          # master
line 0:0: generator error, END not supported
  END { }
  ^
1> END { }          # this PR
line 1:1: generator error, END not supported
  END { }
   ^
```

Every message the generator refuses with now arrives with a position. A sweep of the reachable ones, `END`, `BEGIN`, `too many local variables`, `too many formal arguments`, `too many nested blocks/methods`, `symbol name too long`, `string literal too long` and `dynamic symbol is not supported by alias/undef`, prints `<file>:<line>:<column>` for each.

## Size

`bin/mruby` `.text`, `ci/gcc-clang` with `CC=gcc CXX=g++ LD=gcc`.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,005,318 | 2,005,382 | +64 |
| bintest | 1,402,694 | 1,402,742 | +48 |
| cxx_abi | 1,435,337 | 1,435,385 | +48 |
| byte-string | 1,364,038 | 1,364,086 | +48 |
| ascii-ctype | 1,387,062 | 1,387,110 | +48 |
| no-float | 1,329,742 | 1,329,774 | +32 |
| no-bigint | 1,286,646 | 1,286,694 | +48 |

The whole delta is `mrbgems/mruby-compiler/src/codegen.o`. At `-O0`, where the functions read one to one, it falls to `codegen()` +22, `scope_new()` +19, `codegen_error()` +15, `scope_add_irep()` +9 and `scope_finish()` +3: the store of the node's start, the argument it becomes, and the wider displacements of the scope fields the new pointer moves along. No symbol appears or disappears in any build.

The first commit on its own is -16 in every optimized build. Where the copy used to sit, gcc had cloned the tail of `scope_new()` onto both arms of the `nlv` branch, so the load and store of `lineno` were emitted twice; above the branch they are emitted once.

## Testing

`rake -m test`, all builds on this branch.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,831 | 2,757 | 74 | 0 | 0 | 0 |
| full-debug | 3,079 | 3,068 | 11 | 0 | 0 | 0 |
| bintest | 3,079 | 3,059 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,079 | 3,059 | 20 | 0 | 0 | 0 |
| byte-string | 2,991 | 2,917 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,063 | 3,041 | 22 | 0 | 0 | 0 |
| no-float | 2,812 | 2,715 | 97 | 0 | 0 | 0 |
| no-bigint | 3,028 | 2,995 | 33 | 0 | 0 | 0 |

bintest is green where it runs: 136 on host and 153 on the `bintest` build, one skip each, no KO and no Crash.

The bintest assertion next to the one master already has for the local variable limit asks for the position rather than the message, which is the whole of the difference there. With the first commit's change taken back out it reads

```
Fail: a scope refused for its local variables is named with its position (mrbgems: mruby-bin-mrbc)
 - Assertion[2]
    Expected "too many local variables\n/tmp/many-locals.rb:0:0: generator error, too many local variables\n" to include "/tmp/many-locals.rb:2: too many local variables".
```

and with the second commit's taken out, the two assertions on the list read

```
Fail: a generator error carries its position into the diagnostic list (mrbgems: mruby-bin-mrbc)
    Expected "...:0:0: generator error, END not supported\n" to include "...:2:1: generator error, END not supported".
Fail: eval names the line a generator error is on (mrbgems: mruby-eval)
    Expected: "file (eval) line 2: generator error, END not supported"
      Actual: "file (eval) line 0: generator error, END not supported"
```

The blocks refusal is not asserted: one such source is 65,536 blocks and its line number wraps, which would pin the field's width rather than this window.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.4 LTS |
| Kernel | Linux 7.0.0-31-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines from `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` arguments elided. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03` and uses `g++` only to link.

```
host         gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK ../../src/string.c

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK ../../src/string.c

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compiler diagnostics now report the correct source location when errors occur in nested scopes or when local-variable limits are exceeded.
  - Improved `mrbc` and `eval` syntax error messages to include accurate filenames and line numbers for unsupported `END` blocks.

- **Tests**
  - Added regression coverage to verify source positions and line numbers are preserved in compiler and evaluation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->