### PR TITLE
mruby-string-ext: keep the receiver's class through `String#-@` and `#+@`

### DIFF
--- a/mrbgems/mruby-string-ext/src/string.c
+++ b/mrbgems/mruby-string-ext/src/string.c
@@ -1628,19 +1628,31 @@ str_lines(mrb_state *mrb, mrb_value self)
   return result;
 }
 
+/* `mrb_str_dup()` keeping the receiver's class but not its singleton class,
+   and without calling `initialize_copy`, as the unary operators copy in CRuby.
+   The copy is fresh, so storing the class needs no write barrier. */
+static mrb_value
+str_copy_with_class(mrb_state *mrb, mrb_value str)
+{
+  mrb_value copy = mrb_str_dup(mrb, str);
+
+  mrb_obj_ptr(copy)->c = mrb_obj_class(mrb, str);
+  return copy;
+}
+
 /*
  * call-seq:
  *   +string -> new_string or self
  *
  * Returns `self` if `self` is not frozen.
  *
- * Otherwise returns `self.dup`, which is not frozen.
+ * Otherwise returns an unfrozen copy of `self`, of the same class.
  */
 static mrb_value
 str_uplus(mrb_state *mrb, mrb_value str)
 {
   if (mrb_frozen_p(mrb_obj_ptr(str))) {
-    return mrb_str_dup(mrb, str);
+    return str_copy_with_class(mrb, str);
   }
   else {
     return str;
@@ -1651,8 +1663,9 @@ str_uplus(mrb_state *mrb, mrb_value str)
  * call-seq:
  *   -string -> frozen_string
  *
- * Returns a frozen, possibly pre-existing copy of the string.
+ * Returns `self` if `self` is already frozen.
  *
+ * Otherwise returns a frozen copy of `self`, of the same class.
  */
 static mrb_value
 str_uminus(mrb_state *mrb, mrb_value str)
@@ -1660,7 +1673,7 @@ str_uminus(mrb_state *mrb, mrb_value str)
   if (mrb_frozen_p(mrb_obj_ptr(str))) {
     return str;
   }
-  return mrb_obj_freeze(mrb, mrb_str_dup(mrb, str));
+  return mrb_obj_freeze(mrb, str_copy_with_class(mrb, str));
 }
 
 /* Internal helper for String#ascii_only? - checks if string contains only ASCII characters */

--- a/mrbgems/mruby-string-ext/test/string.rb
+++ b/mrbgems/mruby-string-ext/test/string.rb
@@ -1636,6 +1636,58 @@ assert('String#-@') do
   assert_true(a.frozen?)
 end
 
+assert('String#+@ and String#-@ keep the class of the receiver') do
+  cls = Class.new(String)
+
+  s = cls.new("abc")
+  assert_same(s, +s)
+  m = -s
+  assert_equal(cls, m.class)
+  assert_true(m.frozen?)
+  assert_equal("abc", m)
+  assert_not_same(s, m)
+
+  f = cls.new("abc").freeze
+  assert_same(f, -f)
+  u = +f
+  assert_equal(cls, u.class)
+  assert_false(u.frozen?)
+  assert_equal("abc", u)
+  assert_not_same(f, u)
+
+  # Too long to embed, so the copy shares the receiver's buffer.
+  long = "x" * 1000
+  s = cls.new(long)
+  assert_equal(cls, (-s).class)
+  assert_equal(long, -s)
+
+  f = cls.new(long).freeze
+  assert_equal(cls, (+f).class)
+  assert_equal(long, +f)
+end
+
+assert('String#+@ and String#-@ copy without the singleton class') do
+  # The copy is made in C, so a redefined `initialize_copy` stays unused.
+  cls = Class.new(String) do
+    def initialize_copy(other)
+      raise "initialize_copy called"
+    end
+  end
+
+  s = cls.new("abc")
+  def s.tagged?
+    true
+  end
+  assert_false((-s).respond_to?(:tagged?))
+
+  f = cls.new("abc")
+  def f.tagged?
+    true
+  end
+  f.freeze
+  assert_false((+f).respond_to?(:tagged?))
+end
+
 assert('String#scrub default replacement (U+FFFD)') do
   # scrub has UTF-8 semantics; on builds without MRB_UTF8_STRING it
   # degrades to a no-op (verified separately below).


### PR DESCRIPTION
## Summary

`String#-@` and `String#+@` copied a `String` subclass instance into a plain `String`, where CRuby keeps the receiver's class. They now copy with the class put back.

## Changes

| File | What |
| --- | --- |
| `mrbgems/mruby-string-ext/src/string.c` | `-@` and `+@` copy through a helper that sets the receiver's class on the copy |
| `mrbgems/mruby-string-ext/test/string.rb` | the class, frozenness and identity of both operators on a subclass instance, and what the copy leaves behind |

### Where the class is put back

Both operators copied through `mrb_str_dup()`, which allocates with `mrb->string_class`. CRuby's `str_uplus()` and `str_uminus()` copy through `rb_str_dup()`, which allocates with `rb_obj_class(str)` and calls no Ruby method.

`mrb_str_dup()` stays as it is, since it is a C API called from many places in the tree that expect a `String` back. `mrb_obj_dup()` keeps the class but calls a redefined `initialize_copy`, which CRuby does not do here. So the helper copies with `mrb_str_dup()` and sets `mrb_obj_class()` of the receiver on the copy, the way `mrb_hash_dup()` sets the class of its copy. The copy is freshly allocated, so the store needs no write barrier.

These two are the only `String` methods where mruby and CRuby disagree about the class of the result on a subclass instance. `*`, `+`, `succ`, `upcase`, `sub`, `gsub`, `[]`, `center`, `chomp`, `strip`, `reverse`, `b`, `to_s` and `to_str` answer `String` in CRuby as well, and `dup`, `clone` and `freeze` already keep the class here.

## Behaviour

```ruby
class S < String; end

(-S.new("abc")).class          # master: String, this PR: S, CRuby: S
(+S.new("abc").freeze).class   # master: String, this PR: S, CRuby: S
```

With `class S < String`, every row now matches CRuby 4.0.6:

| Expression | Class | `frozen?` | Identity |
| --- | --- | --- | --- |
| `-S.new("abc")` | `S` | `true` | new object |
| `-S.new("abc").freeze` | `S` | `true` | `self` (unchanged) |
| `+S.new("abc")` | `S` | `false` | `self` (unchanged) |
| `+S.new("abc").freeze` | `S` | `false` | new object |

As in CRuby, the copy does not carry the receiver's singleton class, and a redefined `initialize_copy` is not called.

Out of scope, and unchanged by this PR: CRuby deduplicates `-@` through its fstring table, which mruby does not have, so the identity of the result differs for a frozen `String`:

```ruby
g = "Y" + "bc"
h = -g
i = ("Y" + "bc").freeze
(-i).equal?(i)   # CRuby: false, mruby: true
(-i).equal?(h)   # CRuby: true, mruby: false
```

## Size

`bin/mruby` `.text`, `ci/gcc-clang` with `CC=gcc CXX=g++ LD=gcc`.

| Build | master | this PR | delta |
| --- | ---: | ---: | ---: |
| full-debug (-O0) | 2,004,758 | 2,004,838 | +80 |
| bintest | 1,402,582 | 1,402,662 | +80 |
| cxx_abi | 1,435,305 | 1,435,385 | +80 |
| byte-string | 1,363,238 | 1,363,318 | +80 |
| ascii-ctype | 1,386,950 | 1,387,030 | +80 |
| no-float | 1,329,614 | 1,329,694 | +80 |
| no-bigint | 1,286,534 | 1,286,614 | +80 |

The whole delta is `mrbgems/mruby-string-ext/src/string.o`: the new `str_copy_with_class()` at `-O0`, and in the optimized builds the same code inlined into `str_uminus()` (+36) and `str_uplus()` (+48).

## Testing

`rake -m test`, all builds on this branch.

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| host | 2,837 | 2,763 | 74 | 0 | 0 | 0 |
| full-debug | 3,089 | 3,078 | 11 | 0 | 0 | 0 |
| bintest | 3,089 | 3,069 | 20 | 0 | 0 | 0 |
| cxx_abi | 3,089 | 3,069 | 20 | 0 | 0 | 0 |
| byte-string | 2,997 | 2,923 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3,073 | 3,051 | 22 | 0 | 0 | 0 |
| no-float | 2,822 | 2,725 | 97 | 0 | 0 | 0 |
| no-bigint | 3,038 | 3,005 | 33 | 0 | 0 | 0 |

bintest is green where it runs: 138 on host and 155 on the `bintest` build, one skip each, no KO and no Crash.

The first new assertion covers the four rows of the table above for an embedded receiver, and the class of the copy for a receiver too long to embed, whose copy shares the receiver's buffer. The second covers the singleton class and `initialize_copy`. With the C change taken back out, the first reads

```
Fail: String#+@ and String#-@ keep the class of the receiver (mrbgems: mruby-string-ext)
 - Assertion[2]
    Expected: #<Class:0x5f7088028fc0>
      Actual: String
 - Assertion[7]
    Expected: #<Class:0x5f7088028fc0>
      Actual: String
```

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.5 LTS |
| Kernel | Linux 7.0.0-31-generic |
| CPU | AMD Ryzen 9 5950X (16 cores, 32 threads) |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1) |
| binutils | GNU ld 2.47.20260726 |
| CRuby | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines from `touch src/string.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` arguments elided. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03` and uses `g++` only to link.

```
host         gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK ../../src/string.c

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK ../../src/string.c

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/string.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unary plus and minus on strings so results preserve the receiver’s subclass.
  * Corrected frozen and unfrozen string behavior: operations now return the appropriate original object or a correctly frozen/thawed copy.
  * Ensured behavior is consistent for both short and long strings.
  * Copies no longer inherit singleton-specific behavior or trigger custom copy initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->