### PR TITLE
hw-adc: reject out-of-range pins before narrowing

### DIFF
--- a/mrbgems/hw-adc/src/adc.c
+++ b/mrbgems/hw-adc/src/adc.c
@@ -9,6 +9,9 @@ mrb_adc_m_init(mrb_state *mrb, mrb_value self)
 {
   mrb_int pin;
   mrb_get_args(mrb, "i", &pin);
+  if (pin < 0 || pin > UINT8_MAX) {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid ADC pin");
+  }
   int input = mrb_adc_init((uint8_t)pin);
   if (input < 0) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid ADC pin");


### PR DESCRIPTION
## What is the purpose of the change?

`ADC#__init` reads the Ruby pin argument as an `mrb_int`, but currently converts it to `uint8_t` before the platform HAL validates it. Values outside the byte range are therefore reduced modulo 256. For example, both `282` and `-230` become `26`.

This matters because GPIO 26 is a valid ADC pin on the RP2040 and some ESP32 targets. An invalid Ruby pin can consequently initialize a different physical ADC pin instead of raising the documented `ArgumentError`.

This change validates the integer before the narrowing conversion. Values from 0 through `UINT8_MAX` keep the existing behavior and are still checked by the selected platform's exact ADC pin allowlist.

**What does this change do?**

- Reject negative pins before calling the HAL.
- Reject pins greater than `UINT8_MAX` before calling the HAL.
- Use the existing `ArgumentError` type and `invalid ADC pin` message.
- Preserve platform-specific validation for all byte-range values.

## Testing

A focused host-side harness linked the exact common binding against a stub ADC HAL.

- Pins `26` and `27` continued to reach the HAL and initialize successfully.
- On the unpatched code, `282` and `-230` both reached the HAL as pin `26`.
- With this change, both aliasing inputs raised `ArgumentError` before any HAL call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ADC initialization now rejects negative or oversized pin values with an immediate `ArgumentError`, preventing invalid pin configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->