### PR TITLE
hash.c: see the matched entry vacated by an eql? callback

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -457,6 +457,31 @@ obj_eql(mrb_state *mrb, mrb_value a, mrb_value b, struct RHash *h)
   }
 }
 
+/*
+ * The comparison every keyed lookup makes against the entry it is standing on.
+ * A key that is not a String, Symbol, Integer or Float answers `eql?` itself,
+ * and that call can delete this very entry and insert another: a delete and an
+ * insert that put the size back move no pointer and no capacity, so
+ * H_CHECK_MODIFIED (which watches those and the size) does not report it, and
+ * the entry the search matched has been vacated all the same. Reading its
+ * value or deleting it a second time then works from an entry the table no
+ * longer holds, and once its value has been collected, from freed memory
+ * (CWE-416). So the entry is read again once the comparison says yes, and a
+ * match is answered only while it still holds the key that was compared; a
+ * reallocation that would leave `entry` dangling has already been reported by
+ * the comparison above (it moves the pointer H_CHECK_MODIFIED watches).
+ */
+static mrb_bool
+entry_key_eql(mrb_state *mrb, struct RHash *h, hash_entry *entry, mrb_value key)
+{
+  mrb_value stored = entry->key;
+  if (!obj_eql(mrb, key, stored, h)) return FALSE;
+  if (!mrb_obj_eq(mrb, entry->key, stored)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "hash modified");
+  }
+  return TRUE;
+}
+
 static inline mrb_bool
 entry_deleted_p(const hash_entry* entry)
 {
@@ -559,7 +584,7 @@ ea_get_by_key(mrb_state *mrb, hash_entry *ea, uint32_t ea_capa, uint32_t size,
               mrb_value key, struct RHash *h)
 {
   EA_EACH(ea, ea_capa, size, entry) {
-    if (obj_eql(mrb, key, entry->key, h)) return entry;
+    if (entry_key_eql(mrb, h, entry, key)) return entry;
   }
   return NULL;
 }
@@ -616,7 +641,7 @@ static mrb_bool
 ar_get(mrb_state *mrb, struct RHash *h, mrb_value key, mrb_value *valp)
 {
   EA_EACH(ar_ea(h), ar_ea_capa(h), ar_size(h), entry) {
-    if (!obj_eql(mrb, key, entry->key, h)) continue;
+    if (!entry_key_eql(mrb, h, entry, key)) continue;
     *valp = entry->val;
     return TRUE;
   }
@@ -810,7 +835,7 @@ ib_it_find_by_key(mrb_state *mrb, index_buckets_iter *it, mrb_value key)
     ib_it_next(it);
     if (ib_it_empty_p(it)) return FALSE;
     if (!ib_it_deleted_p(it) &&
-        obj_eql(mrb, key, ib_it_entry(it)->key, it->h)) {
+        entry_key_eql(mrb, it->h, ib_it_entry(it), key)) {
       return TRUE;
     }
   }
@@ -1006,7 +1031,7 @@ ht_set(mrb_state *mrb, struct RHash *h, mrb_value key, mrb_value val)
   mrb_assert(ht_size(h) < ib_bit_to_capa(ib_bit(h)));
   IB_CYCLE_BY_KEY(mrb, h, key, it) {
     if (ib_it_active_p(it)) {
-      if (!obj_eql(mrb, key, ib_it_entry(it)->key, h)) continue;
+      if (!entry_key_eql(mrb, h, ib_it_entry(it), key)) continue;
       ib_it_entry(it)->val = val;
     }
     else if (ib_it_deleted_p(it)) {

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -1035,6 +1035,47 @@ assert('Hash lookup with entries deleted by an eql? callback') do
   assert_equal(2, q.rehash.size)
 end
 
+assert('Hash lookup with the matched entry vacated by an eql? callback') do
+  # A companion to the case above, with the callback returning true. It deletes
+  # the very entry the search matched and inserts another, which puts the count
+  # back: the guard watches the count and the pointers and so sees nothing, and
+  # the slot the search is standing on has been vacated all the same. Answering
+  # from it hands #[] the value of an entry the collector no longer keeps and
+  # lets #delete take it a second time, dropping the count below the entries the
+  # table still holds. Each operation has to report the change, not answer from
+  # the vacated slot.
+  swapper = Class.new do
+    def initialize(h) @h, @fired = h, false end
+    def eql?(other)
+      unless @fired
+        @fired = true
+        @h.delete(other)
+        @h[:added] = :added_value
+      end
+      true
+    end
+    def hash; 42 end
+  end
+  # The indexed (HT) shape, and the AR shape with a leading hole: word boxing
+  # reads an AR hash's first slot as the pointer the guard watches, so only a
+  # hole ahead of that slot exposes the AR path the way HT is already exposed.
+  ht = lambda { h = {}; 20.times { |i| h[i] = i }; h }
+  ar = lambda { h = {}; 12.times { |i| h[i] = i }; h.delete(0); h }
+
+  [ht, ar].each do |build|
+    [ lambda { |h, k| h.delete(k) },
+      lambda { |h, k| h[k] },
+      lambda { |h, k| h[k] = :stored },
+      lambda { |h, k| h.key?(k) } ].each do |op|
+      h = build.call
+      assert_raise(RuntimeError) { op.call(h, swapper.new(h)) }
+      # What the table can find and what it iterates stay the same entries.
+      h.keys.each { |k| assert_true(h.key?(k)) }
+      assert_equal(h.key?(:added), h.keys.include?(:added))
+    end
+  end
+end
+
 assert('Hash#assoc, Hash#rassoc') do
   h = {foo: 0, bar: 1, baz: 2}
   assert_equal([:bar, 1], h.assoc(:bar))


### PR DESCRIPTION
## Summary

A key whose `eql?` runs Ruby can delete the entry a lookup just matched and insert another; the pair puts the size back and reallocates nothing, so the reentry guard sees no change and the lookup answers from a slot it no longer holds. `Hash#[]` then returns the value of an entry the collector has freed, and `Hash#delete` deletes it a second time and drops the size below the entries the table still holds. The entry is read again once the comparison matches, and answered for only while the slot still holds the key that was compared.

## Changes

| File | What |
| --- | --- |
| `src/hash.c` | Re-read the matched entry before a keyed lookup answers for it, reporting a modification if the slot was vacated. |
| `test/t/hash.rb` | A regression case: an `eql?` that deletes and re-inserts, over the array and indexed shapes and `#[]` / `#[]=` / `#delete` / `#key?`. |

### Why the guard does not catch it

`H_CHECK_MODIFIED` watches the flags, the table, the entry array and its capacity, and the size. A delete touches only the size and one slot's key; an insert that follows with room to spare reallocates nothing. So a delete and an insert together leave every field the guard watches where it was, and the guard reports nothing, while the slot the search matched has been vacated and another filled.

Answering from that slot hands `Hash#[]` the value of an entry the collector no longer keeps — once collected, a read of freed memory (CWE-416) — and lets `Hash#delete` delete it a second time and call `ht_dec_size` for it, so the size falls below the number of entries the table still holds: one key is then found by `#[]` and missing from `#keys`. Both are reachable from Ruby and both predate this change, since the pair leaves the guard nothing to compare.

### The fix

`entry_key_eql` reads the slot again once the comparison matches, and answers only while it still holds the key that was compared (`mrb_obj_eq` against the key read before the comparison ran). A reallocation that would leave the entry dangling has already been reported by the comparison itself, because it moves the pointer the guard watches, so the re-read only ever touches live memory. A key compared by the table itself — a String, Symbol, Integer or Float — runs no Ruby and cannot vacate the slot; it goes through the same helper and the extra read is a pointer comparison.

Where a search that was interfered with lands is still left unspecified, the way CRuby leaves a hash mutated from `hash` or `eql?` unspecified. What this promises is that the walk stays inside live memory, that it returns, and that afterwards what the table can find and what it iterates are the same entries.

## Behaviour

A `#[]`, `#[]=`, `#delete` or `#key?` whose key vacates the matched entry from inside `eql?` now raises `RuntimeError` ("hash modified"), as the dangerous mutations a comparison callback can already make do, instead of answering from the vacated slot.

## Speed

Per-operation instruction reads (callgrind `Ir(2N) − Ir(N)`, N = 100,000; the host wall clock swings up to 5x, so a sub-2% change is read from Ir). The lookup body is

```ruby
n = ARGV[0].to_i
h = {}; 1024.times { |i| h[i] = i }
i = 0; s = 0
while i < n; s += h[i & 1023]; i += 1; end
```

with the key type and the table size varied, `#[]=` building a fresh 1024-entry hash, and `#delete` taken as build-and-delete minus build-only.

| Operation | master | this PR | ratio |
| --- | --- | --- | --- |
| `#[]` hit, Integer, 1024 | 986.3 | 1003.3 | 1.017 |
| `#[]` miss, Integer, 1024 | 1289.3 | 1290.7 | 1.001 |
| `#[]` hit, String, 1024 | 1161.3 | 1178.7 | 1.015 |
| `#[]` hit, Ruby `hash`/`eql?`, 1024 | 3345.1 | 3363.1 | 1.005 |
| `#[]` hit, Integer, 8 | 990.5 | 1001.5 | 1.011 |
| `#[]=` building 1024 (per insert) | 953.0 | 949.2 | 0.996 |
| `#delete`, 1024 (per delete) | 1140.0 | 1159.0 | 1.017 |

The re-read runs only where a comparison matched, so a miss and a build are unchanged; a hit pays one pointer comparison.

## Size

`.text` of `bin/mruby`, `size -A`, `CC=gcc CXX=g++ LD=gcc`.

| Build | master | this PR | delta |
| --- | --- | --- | --- |
| full-debug (-O0) | 2,004,838 | 2,004,998 | +160 |
| bintest | 1,402,662 | 1,403,158 | +496 |
| cxx_abi | 1,435,385 | 1,435,833 | +448 |
| byte-string | 1,363,318 | 1,363,814 | +496 |
| ascii-ctype | 1,387,030 | 1,387,526 | +496 |
| no-float | 1,329,694 | 1,328,670 | −1,024 |
| no-bigint | 1,286,614 | 1,287,110 | +496 |

The change is confined to `hash.o`: the new `entry_key_eql` and the four comparisons that call it. Factoring the comparison into a function lets gcc leave it out of line, which under no-float rebalances inlining (`ar_set` −457, `ar_rehash` −437 bytes) below the helper it adds, for a net −1,024 there.

## Testing

| Build | Total | OK | Skip | KO | Crash | Warning |
| --- | --- | --- | --- | --- | --- | --- |
| full-debug | 3090 | 3079 | 11 | 0 | 0 | 0 |
| bintest | 3090 | 3070 | 20 | 0 | 0 | 0 |
| cxx_abi | 3090 | 3070 | 20 | 0 | 0 | 0 |
| byte-string | 2998 | 2924 | 74 | 0 | 0 | 0 |
| ascii-ctype | 3074 | 3052 | 22 | 0 | 0 | 0 |
| no-float | 2823 | 2726 | 97 | 0 | 0 | 0 |
| no-bigint | 3039 | 3006 | 33 | 0 | 0 | 0 |

`bintest` reports 111 tests, 0 failures. The new case runs `#delete`, `#[]`, `#[]=` and `#key?` against the array and indexed shapes with a key that deletes and re-inserts from `eql?`; it fails without the fix (the operation does not raise, and a value read after `GC.start` comes back as a freed string) and passes with it.

## Environment

<details>

| | |
| --- | --- |
| OS | Ubuntu 24.04.5 LTS |
| Kernel | Linux 7.0.0-31-generic (x86_64) |
| CPU | AMD Ryzen 9 5950X |
| Compiler | gcc / g++ 13.3.0 |
| binutils | GNU ld / size 2.47 |
| CRuby | ruby 4.0.6 |

Compile flags per build (`-O`, distinguishing defines; `-MMD -c -I -o` dropped):

- full-debug: `-g3 -O0 -DMRB_GC_STRESS -DMRB_DEBUG -DMRB_USE_DEBUG_HOOK`
- bintest: `-O3 -DMRB_GC_FIXED_ARENA -DMRB_USE_DEBUG_HOOK`
- cxx_abi: `-x c++ -std=gnu++03 -O3 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI`
- byte-string: `-O3` (no `HAVE_MRUBY_ENCODING_GEM`, no `MRB_UTF8_STRING`)
- ascii-ctype: `-O3 -DMRB_USE_ASCII_CTYPE`
- no-float: `-O3 -DMRB_NO_FLOAT`
- no-bigint: `-O3` (no `MRB_USE_BIGINT`)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hash lookups now detect when a custom equality callback deletes and replaces the entry being matched.
  - `Hash#delete`, `Hash#[]`, `Hash#[]=`, and `Hash#key?` now raise a `RuntimeError` instead of reading or modifying an invalid entry.
  - Hash keys remain consistent after this type of mutation, across supported hash storage formats.

- **Tests**
  - Added regression coverage for mutation during equality checks and the resulting error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->