### PR TITLE
hash.c: check the entry again and keep its pair alive across a callback

### DIFF
--- a/mrbgems/mruby-hash-ext/src/hash_ext.c
+++ b/mrbgems/mruby-hash-ext/src/hash_ext.c
@@ -58,14 +58,20 @@ hash_slice(mrb_state *mrb, mrb_value hash)
   mrb_get_args(mrb, "*", &argv, &argc);
   mrb_value result = mrb_hash_new_capa(mrb, argc);
   if (argc == 0) return result; /* empty hash */
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < argc; i++) {
     mrb_value key = argv[i];
     mrb_value val;
 
     val = mrb_hash_fetch(mrb, hash, key, mrb_undef_value());
     if (!mrb_undef_p(val)) {
+      /* On the arena for the set: it asks the key for its hash code, and Ruby
+         there can delete the pair out of `hash`, after which the value is held
+         by this frame alone, which the GC does not scan. */
+      mrb_gc_protect(mrb, val);
       mrb_hash_set(mrb, result, key, val);
     }
+    mrb_gc_arena_restore(mrb, ai);
   }
   return result;
 }
@@ -93,9 +99,16 @@ static int
 slice_bang_i(mrb_state *mrb, mrb_value key, mrb_value val, void *data)
 {
   struct slice_bang_i_arg *args = (struct slice_bang_i_arg *)data;
+  int ai = mrb_gc_arena_save(mrb);
+  /* On the arena for the lookup: it asks the key for its hash code and its
+     eql?, and Ruby there can delete this pair from the hash being walked. The
+     push then allocates, so the key has to stay reachable until the array
+     holds it, and this frame is all that holds it in between. */
+  mrb_gc_protect(mrb, key);
   if (!mrb_hash_key_p(mrb, args->keep_keys, key)) {
     mrb_ary_push(mrb, args->keys_to_remove, key);
   }
+  mrb_gc_arena_restore(mrb, ai);
   return 0; /* Continue iteration */
 }
 
@@ -129,10 +142,15 @@ hash_slice_bang(mrb_state *mrb, mrb_value self)
 
   mrb_int len = RARRAY_LEN(args.keys_to_remove);
   mrb_value removed_hash = mrb_hash_new_capa(mrb, len);
+  int ai = mrb_gc_arena_save(mrb);
   for (mrb_int i = 0; i < len; i++) {
     mrb_value key = mrb_ary_ref(mrb, args.keys_to_remove, i);
     mrb_value val = mrb_hash_delete_key(mrb, self, key);
+    /* the delete has taken the pair out of `self`, so this frame is what holds
+       the value while the set asks the key for its hash code */
+    mrb_gc_protect(mrb, val);
     mrb_hash_set(mrb, removed_hash, key, val);
+    mrb_gc_arena_restore(mrb, ai);
   }
 
   return removed_hash;
@@ -294,11 +312,18 @@ static int
 hash_key_i(mrb_state *mrb, mrb_value key, mrb_value val, void *data)
 {
   struct key_search *search = (struct key_search*)data;
+  int ai = mrb_gc_arena_save(mrb);
+  /* On the arena for the comparison: the `==` below runs Ruby, and it can
+     delete this pair from the hash being walked, after which the key is held
+     by this frame alone, which the GC does not scan. A match leaves it on the
+     arena, since what carries it from here is the answer in C. */
+  mrb_gc_protect(mrb, key);
   if (mrb_equal(mrb, val, search->target)) {
     search->result = key;
     search->found = TRUE;
     return 1; /* Stop iteration */
   }
+  mrb_gc_arena_restore(mrb, ai);
   return 0; /* Continue iteration */
 }
 

--- a/mrbgems/mruby-hash-ext/test/hash.rb
+++ b/mrbgems/mruby-hash-ext/test/hash.rb
@@ -193,6 +193,116 @@ assert("Hash#key") do
   assert_equal 'nil', h.key(nil)
 end
 
+assert("Hash#key keeps the key it answers with across the comparison") do
+  # The scan hands the value to `==`, and the Ruby there can delete the pair it
+  # is standing on. The key the scan would answer with is then held by the scan
+  # in C, which the collector does not scan, so the collection the same Ruby
+  # sets off takes it.
+  thief = Class.new do
+    def initialize(h, k) @h, @k = h, k end
+    def ==(other)
+      if @h
+        h, k, @h, @k = @h, @k, nil, nil
+        h.delete(k)
+        h[:added] = :added_value
+        GC.start
+      end
+      true
+    end
+    # Built here and not in the assertion so that returning drops the stored
+    # key from the arena: what holds it from then on is the entry alone. An
+    # unfrozen String key is stored as a frozen copy, which is the object the
+    # entry holds and the delete below takes away.
+    def self.armed_hash
+      h = {}
+      20.times { |i| h[i] = i }
+      k = "the key only that entry holds"
+      h[k] = new(h, k)
+      h
+    end
+  end
+
+  assert_equal("the key only that entry holds", thief.armed_hash.key(:target))
+end
+
+assert("Hash#slice keeps the value it carries across the set") do
+  # Reading the pair out asks the key for its hash code, and storing it in the
+  # result asks a second time. The Ruby answering that second ask can delete
+  # the pair out of the receiver, and what holds the value then is the C local
+  # carrying it, which the collector does not scan.
+  thief = Class.new do
+    attr_reader :fired
+    def initialize(h) @h, @asks = h, 0 end
+    def arm(n) @fire_at, @asks, @fired = n, 0, false end
+    def hash
+      @asks += 1
+      if @asks == @fire_at
+        @fired = true
+        h, @h = @h, nil
+        h.delete(self)
+        h[:added] = :added_value
+        GC.start
+      end
+      42
+    end
+    def eql?(other) equal?(other) end
+    def self.armed_hash
+      h = {}
+      20.times { |i| h[i] = i }
+      k = new(h)
+      h[k] = "the value only that entry holds"
+      [h, k]
+    end
+  end
+
+  h, k = thief.armed_hash
+  # A result asks for a hash code only once it has an index of its own, which
+  # is what the keys ahead of this one are for. The second ask is the set, so
+  # having fired says the value below is answered from the path being covered.
+  keys = (0...17).to_a
+  keys.push(k)
+  k.arm(2)
+  sliced = h.slice(*keys)
+  assert_true(k.fired)
+  assert_equal("the value only that entry holds", sliced[k])
+end
+
+assert("Hash#slice! keeps the value it removed across the set") do
+  # The delete takes the pair out of the receiver, and the set that files it
+  # under the same key asks that key for its hash code. Anything the Ruby
+  # answering that allocates can collect the value on the way, since what
+  # holds it between the two calls is the C local carrying it.
+  collector = Class.new do
+    attr_reader :asks
+    def initialize; @asks = 0 end
+    def arm; @asks = 0 end
+    def hash
+      @asks += 1
+      GC.start
+      7
+    end
+    def eql?(other) equal?(other) end
+    def self.armed_hash
+      h = {}
+      20.times { |i| h[i] = i }
+      k = new
+      h[k] = "the value only that entry holds"
+      k.arm
+      [h, k]
+    end
+  end
+
+  h, k = collector.armed_hash
+  removed = h.slice!(0)
+  # Two asks and no more: the delete and the set into the result. The scan for
+  # the keys to keep asks nothing, since one key to keep is a hash in list
+  # shape, which compares with `eql?` alone. A result too small to be indexed
+  # would not ask either, and the value below would be answered from a walk
+  # that never ran Ruby.
+  assert_equal(2, k.asks)
+  assert_equal("the value only that entry holds", removed[k])
+end
+
 assert("Hash#to_h") do
   h = { "a" => 100, "b" => 200 }
   assert_equal Hash, h.to_h.class

--- a/src/hash.c
+++ b/src/hash.c
@@ -2103,10 +2103,20 @@ mrb_hash_merge(mrb_state *mrb, mrb_value hash1, mrb_value hash2)
 
   if (h1 == h2) return;
   if (h_size(h2) == 0) return;
+  int ai = mrb_gc_arena_save(mrb);
   H_EACH(h2, entry) {
-    H_CHECK_MODIFIED(mrb, h2) {h_set(mrb, h1, entry->key, entry->val);}
-    mrb_field_write_barrier_value(mrb, (struct RBasic*)h1, entry->key);
-    mrb_field_write_barrier_value(mrb, (struct RBasic*)h1, entry->val);
+    mrb_value key = entry->key, val = entry->val;
+    /* On the arena before the set: it asks the key for its hash code and its
+       eql?, and Ruby there can delete this pair from `h2`, after which the
+       pair is owned by this frame's C locals alone, which the GC does not
+       scan (see `ar_shift`). The slot it came from is no place to read it
+       back from either, deleted or filled with another pair by then. */
+    mrb_gc_protect(mrb, key);
+    mrb_gc_protect(mrb, val);
+    H_CHECK_MODIFIED(mrb, h2) {h_set(mrb, h1, key, val);}
+    mrb_field_write_barrier_value(mrb, (struct RBasic*)h1, key);
+    mrb_field_write_barrier_value(mrb, (struct RBasic*)h1, val);
+    mrb_gc_arena_restore(mrb, ai);
   }
 }
 
@@ -2244,7 +2254,13 @@ mrb_hash_except_keys(mrb_state *mrb, mrb_value hash)
       }
     }
     if (!found) {
-      H_CHECK_MODIFIED(mrb, h) {mrb_hash_set(mrb, result, stored, entry->val);}
+      /* On the arena for the same reason as in `mrb_hash_merge`: the set asks
+         the key for its hash code and its eql?, and Ruby there can delete the
+         pair from `hash`. */
+      mrb_value val = entry->val;
+      mrb_gc_protect(mrb, stored);
+      mrb_gc_protect(mrb, val);
+      H_CHECK_MODIFIED(mrb, h) {mrb_hash_set(mrb, result, stored, val);}
     }
     mrb_gc_arena_restore(mrb, ai);
   }

--- a/src/hash.c
+++ b/src/hash.c
@@ -725,14 +725,20 @@ ar_rehash(mrb_state *mrb, struct RHash *h)
   uint32_t size = ar_size(h), w_size = 0, ea_capa = ar_ea_capa(h);
   hash_entry *ea = ar_ea(h), *w_entry;
   EA_EACH(ea, ea_capa, size, r_entry) {
-    if ((w_entry = ea_get_by_key(mrb, ea, ea_capa, w_size, r_entry->key, h))) {
+    /* the search carries this entry's own key, and the keys already written
+       answer #eql?: Ruby there can vacate the slot the pair is still to be
+       read from */
+    mrb_value key = r_entry->key;
+    w_entry = ea_get_by_key(mrb, ea, ea_capa, w_size, key, h);
+    entry_check_vacated(mrb, r_entry, key);
+    if (w_entry) {
       w_entry->val = r_entry->val;
       ar_set_size(h, --size);
       entry_delete(r_entry);
     }
     else {
       if (w_size != U32(r_entry - ea)) {
-        ea_set(ea, w_size, r_entry->key, r_entry->val);
+        ea_set(ea, w_size, key, r_entry->val);
         entry_delete(r_entry);
       }
       w_size++;
@@ -1110,16 +1116,22 @@ ht_rehash(mrb_state *mrb, struct RHash *h)
   ht_set_size(h, size);
   ht_set_ea_n_used(h, ht_ea_n_used(h));
   EA_EACH(ea, ea_capa, size, r_entry) {
-    IB_CYCLE_BY_KEY(mrb, h, r_entry->key, it) {
+    /* the cycle asks this entry's own key for its hash code, and the key it
+       meets answers #eql?: Ruby in either can vacate the slot the pair is
+       still to be read from, or move the pair out of it with a compress */
+    mrb_value key = r_entry->key;
+    IB_CYCLE_BY_KEY(mrb, h, key, it) {
       if (ib_it_active_p(it)) {
-        if (!obj_eql(mrb, r_entry->key, ib_it_entry(it)->key, h)) continue;
+        if (!entry_key_eql(mrb, h, ib_it_entry(it), key)) continue;
+        entry_check_vacated(mrb, r_entry, key);
         ib_it_entry(it)->val = r_entry->val;
         ht_set_size(h, --size);
         entry_delete(r_entry);
       }
       else {
+        entry_check_vacated(mrb, r_entry, key);
         if (w_size != U32(r_entry - ea)) {
-          ea_set(ea, w_size, r_entry->key, r_entry->val);
+          ea_set(ea, w_size, key, r_entry->val);
           entry_delete(r_entry);
         }
         ib_it_set(it, w_size++);
@@ -2219,17 +2231,20 @@ mrb_hash_except_keys(mrb_state *mrb, mrb_value hash)
      afresh each time, and it can rehash `hash` out from under H_EACH, which
      is what H_CHECK_MODIFIED refuses. */
   H_EACH(h, entry) {
+    mrb_value stored = entry->key;
     mrb_bool found = FALSE;
     for (mrb_int i = 0; i < klen && i < RARRAY_LEN(keys); i++) {
       mrb_bool eq = FALSE;
-      H_CHECK_MODIFIED(mrb, h) {eq = mrb_equal(mrb, entry->key, RARRAY_PTR(keys)[i]);}
+      H_CHECK_MODIFIED(mrb, h) {eq = mrb_equal(mrb, stored, RARRAY_PTR(keys)[i]);}
+      /* the key answers #== here, and can vacate its own slot */
+      entry_check_vacated(mrb, entry, stored);
       if (eq) {
         found = TRUE;
         break;
       }
     }
     if (!found) {
-      H_CHECK_MODIFIED(mrb, h) {mrb_hash_set(mrb, result, entry->key, entry->val);}
+      H_CHECK_MODIFIED(mrb, h) {mrb_hash_set(mrb, result, stored, entry->val);}
     }
     mrb_gc_arena_restore(mrb, ai);
   }
@@ -2257,16 +2272,20 @@ mrb_hash_to_s(mrb_state *mrb, mrb_value self)
   mrb_int i = 0;
   struct RHash *h = mrb_hash_ptr(self);
   H_EACH(h, entry) {
+    mrb_value stored = entry->key;
     if (i++ > 0) mrb_str_cat_lit(mrb, ret, ", ");
-    if (mrb_symbol_p(entry->key)) {
-      mrb_str_cat_str(mrb, ret, mrb_obj_as_string(mrb, entry->key));
+    if (mrb_symbol_p(stored)) {
+      mrb_str_cat_str(mrb, ret, mrb_obj_as_string(mrb, stored));
       mrb_gc_arena_restore(mrb, ai);
       mrb_str_cat_lit(mrb, ret, ": ");
     }
     else {
       H_CHECK_MODIFIED(mrb, h) {
-        mrb_str_cat_str(mrb, ret, mrb_inspect(mrb, entry->key));
+        mrb_str_cat_str(mrb, ret, mrb_inspect(mrb, stored));
       }
+      /* the key's own inspect can vacate this slot, and the value below is
+         read from it */
+      entry_check_vacated(mrb, entry, stored);
       mrb_gc_arena_restore(mrb, ai);
       mrb_str_cat_lit(mrb, ret, " => ");
     }

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -1126,6 +1126,73 @@ assert('Hash scans with the matched entry vacated by an eql? callback') do
   end
 end
 
+assert('Hash scans that read the entry back after a callback') do
+  # The same delete-and-reinsert, reached from the scans that read an entry
+  # again once a callback has returned: #inspect prints the value after the
+  # key printed itself, the walk behind `**rest` stores the pair after the key
+  # answered #==, and #rehash moves the pair after the #eql? that asked
+  # whether an earlier key is the same one. A rehash reads two entries, and
+  # the #eql? can vacate either: the one it is moving, or the one it matched.
+  swapper = Class.new do
+    attr_accessor :armed
+    def initialize(h, victim) @h, @victim, @armed = h, victim, false end
+    def fire
+      return false unless @armed
+      @armed = false
+      @h.delete(@victim || self)
+      @h[:added] = :added_value
+      true
+    end
+    def inspect; fire; "swapper" end
+    def ==(other) fire; false end
+    def eql?(other)
+      return true if (@victim.nil? || @victim.equal?(other)) && fire
+      equal?(other)
+    end
+    def hash; 42 end
+  end
+
+  h = {}
+  20.times { |i| h[i] = i }
+  k = swapper.new(h, nil)
+  h[k] = "value"
+  k.armed = true
+  assert_raise(RuntimeError) { h.inspect }
+  h.keys.each { |x| assert_true(h.key?(x)) }
+
+  h = {}
+  20.times { |i| h[i] = i }
+  k = swapper.new(h, nil)
+  h[k] = "value"
+  k.armed = true
+  assert_raise(RuntimeError) { h.__except([:absent]) }
+  h.keys.each { |x| assert_true(h.key?(x)) }
+
+  # The list (AR) shape, where the duplicate is looked for by walking the
+  # entries already moved.
+  h = {first: "value"}
+  k = swapper.new(h, nil)
+  h[k] = "dup"
+  k.armed = true
+  assert_raise(RuntimeError) { h.rehash }
+  h.keys.each { |x| assert_true(h.key?(x)) }
+
+  # The indexed (HT) shape. Only an entry already moved is in the new index,
+  # so that is the one a callback can take away, and it is the entry the
+  # duplicate is about to be written into.
+  h = {}
+  20.times { |i| h[i] = i }
+  first = swapper.new(h, nil)
+  h[first] = "value"
+  k = swapper.new(h, first)
+  h[k] = "dup"
+  k.armed = true
+  assert_raise(RuntimeError) { h.rehash }
+  # What a rehash stopped part way through leaves is what it left before: the
+  # entries it had not reached yet are out of the index it is rebuilding.
+  assert_true(h.key?(:added))
+end
+
 assert('Hash#assoc, Hash#rassoc') do
   h = {foo: 0, bar: 1, baz: 2}
   assert_equal([:bar, 1], h.assoc(:bar))

--- a/test/t/hash.rb
+++ b/test/t/hash.rb
@@ -1193,6 +1193,55 @@ assert('Hash scans that read the entry back after a callback') do
   assert_true(h.key?(:added))
 end
 
+assert('Hash scans that carry a pair into a set the hash no longer holds') do
+  # A scan that stores the pair it is standing on somewhere else hands it to a
+  # set, and the set asks the key for its hash code before it stores anything.
+  # Ruby there can take the pair out of the hash the scan is reading, and the
+  # only reference left is the one the scan holds in C, which the collector
+  # does not scan. The pair has to survive the set that is carrying it.
+  thief = Class.new do
+    attr_accessor :armed
+    def initialize(h) @h, @armed = h, false end
+    def hash
+      if @armed
+        @armed = false
+        @h.delete(self)
+        @h[:added] = :added_value
+        GC.start
+      end
+      42
+    end
+    def eql?(other) equal?(other) end
+    # The value is built here and not in the assertion so that returning drops
+    # it from the arena: what keeps it alive from then on is the entry alone,
+    # which is what the callback takes away.
+    def self.armed_hash
+      h = {}
+      20.times { |i| h[i] = i }
+      k = new(h)
+      h[k] = "the value only that entry holds"
+      k.armed = true
+      [h, k]
+    end
+  end
+
+  # The hash being written into holds enough entries to be indexed, which is
+  # what asks a key for its hash code in the first place. `armed` goes back
+  # down when the callback has run, so the assertion says the set reached it
+  # and the value is not being answered from a walk that never ran Ruby.
+  h2, k = thief.armed_hash
+  h1 = {}
+  20.times { |i| h1[i + 100] = i }
+  merged = h1.merge(h2)
+  assert_false(k.armed)
+  assert_equal("the value only that entry holds", merged[k])
+
+  h, k = thief.armed_hash
+  excepted = h.__except([:absent])
+  assert_false(k.armed)
+  assert_equal("the value only that entry holds", excepted[k])
+end
+
 assert('Hash#assoc, Hash#rassoc') do
   h = {foo: 0, bar: 1, baz: 2}
   assert_equal([:bar, 1], h.assoc(:bar))


### PR DESCRIPTION
## Summary

08a0432d1 took the `Hash` scans that read the entry again after a comparison. The scans that read it after any other callback, and the ones that carry the pair they are standing on into another hash, were left as they were: they answer from a slot the callback vacated, or hand on an object the collector has taken.

## Changes

| File                                    | What                                                                                                                                                                                               |
| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/hash.c`                            | `Hash#inspect`, the walk behind a pattern's `**rest` and `Hash#rehash` read the entry again once the callback returns; `Hash#merge` and that walk put the pair they carry on the arena for the set |
| `test/t/hash.rb`                        | the four scans with the entry vacated from the callback, and the two with the pair collected under them                                                                                            |
| `mrbgems/mruby-hash-ext/src/hash_ext.c` | `Hash#key`, `Hash#slice` and `Hash#slice!` put what they carry on the arena for the call that runs Ruby                                                                                            |
| `mrbgems/mruby-hash-ext/test/hash.rb`   | the key `Hash#key` answers with, and the value `Hash#slice` and `Hash#slice!` carry                                                                                                                |

### The entry a scan reads after a callback

A key that is not a String, Symbol, Integer or Float answers `hash`, `eql?`, `==` and `inspect` itself, and the Ruby there can delete the entry the scan is standing on and insert another. That puts the size back, and `H_CHECK_MODIFIED` watches the size, the capacity and the pointers, so it reports nothing. `entry_check_vacated()` is what 08a0432d1 added for this, and these scans now ask it where they read the entry again:

- `Hash#inspect` prints the value after the key has printed itself.
- The walk behind a pattern's `**rest` (`Hash#__except`) stores the pair after the key has answered `==`. Without the check the key it stores is `mrb_undef_value()`, which reaches Ruby as a receiver with no class.
- `Hash#rehash` reads two entries per step: the one it is moving and the one it matched. The `eql?` can vacate either, so the indexed path asks through `entry_key_eql()`, which re-reads the entry it matched, and both paths re-read the entry they are moving from.

### The pair a scan carries into a set

`Hash#merge` and the `**rest` walk store the pair they are standing on into another hash, and the set asks the key for its hash code before it stores anything. The Ruby answering that can delete the pair out of the hash being walked, and the only reference left is the scan's own C locals, which the collector does not scan: the pair is collected while the set is still carrying it. `mrb_hash_merge` then hands the same freed object to the write barrier, which is where a build with assertions stops.

The pair goes on the arena for the call, the way `ar_shift()` already does for the pair it hands back, and `mrb_hash_merge` gives the barriers what it read rather than the slot read again.

`mruby-hash-ext` has three of the same: `Hash#key` answers with the key of the pair whose value matched, `Hash#slice` stores the value it read under the same key, and `Hash#slice!` carries each pair from the delete to the result. The last one needs no Ruby at all to lose it, since the delete has already taken the pair out of the receiver by the time the set allocates.

## Behaviour

Where master answered from the vacated slot, these raise `RuntimeError`, which is what a keyed lookup already does for the same callback and what CRuby raises for the same program.

```ruby
swapper = Class.new do
  attr_accessor :armed
  def initialize(h) @h, @armed = h, false end
  def fire
    return false unless @armed
    @armed = false
    @h.delete(self)
    @h[:added] = :added_value
    true
  end
  def inspect; fire; "swapper" end
  def eql?(other) fire || equal?(other) end
  def hash; 42 end
end

h = {}
3.times { |i| h[i] = i }
k = swapper.new(h)
h[k] = "value"
k.armed = true
h.inspect
# CRuby: RuntimeError (can't add a new key into hash during iteration)
# master: "{0 => 0, 1 => 1, 2 => 2, swapper => :added_value}"
# this PR: RuntimeError (hash modified)

h = {first: "value"}
k = swapper.new(h)
h[k] = "dup"
k.armed = true
h.rehash
# CRuby: RuntimeError (can't add a new key into hash during iteration)
# master: {first: "dup"}
# this PR: RuntimeError (hash modified)
```

The `inspect` above prints a pair the hash never held: the value belongs to the entry that took the vacated slot. The `rehash` drops both the entry it was moving and the one the callback added, and gives `:first` a value that was never stored under it. With the value collected rather than replaced, the same two read freed memory; under `clang-asan` the first is a `heap-use-after-free` in `mrb_utf8len` from `mrb_hash_to_s`.

Out of scope: a callback that mutates the hash during a `rehash` still leaves the table half rebuilt, entries the new index does not hold yet, and a second `rehash` then trips `mrb_assert(size == w_size)`. That is what master does today for every `RuntimeError` a rehash raises, and it is not what this PR is about.

## Speed

`Ir(2N) - Ir(N)` over `N` under callgrind, N = 2,000, each case a 20 entry hash with String keys, `bintest` build.

```ruby
n = (ARGV[0] || "1000").to_i
h = {}
20.times { |i| h["k#{i}"] = i }
i = 0
while i < n
  h.rehash          # and dst.merge(src), h.slice(*keys), h.inspect
  i += 1
end
```

| Case                              | master | this PR | delta | per entry |
| --------------------------------- | -----: | ------: | ----: | --------: |
| `dst.merge(src)`, 20 entries each | 20,150 |  20,853 |  +703 |       +35 |
| `h.rehash`                        |  5,176 |   5,602 |  +426 |       +21 |
| `h.slice(*h.keys)`                | 17,710 |  17,893 |  +183 |        +9 |
| `h.inspect`                       | 49,993 |  50,174 |  +181 |        +9 |

`merge` pays two `mrb_gc_protect()` and one arena restore per entry, the others one re-read of the entry, which is the same call every keyed lookup already makes. Nothing on the `Hash#[]`, `#[]=` or `#delete` path changed.

## Size

`bin/mruby` `.text`, `ci/gcc-clang` with `CC=gcc CXX=g++ LD=gcc`.

| Build            |    master |   this PR | delta |
| ---------------- | --------: | --------: | ----: |
| full-debug (-O0) | 2,005,430 | 2,005,910 |  +480 |
| bintest          | 1,403,590 | 1,404,150 |  +560 |
| cxx_abi          | 1,436,073 | 1,436,873 |  +800 |
| byte-string      | 1,364,246 | 1,364,806 |  +560 |
| ascii-ctype      | 1,387,958 | 1,388,518 |  +560 |
| no-float         | 1,328,606 | 1,329,294 |  +688 |
| no-bigint        | 1,287,542 | 1,288,118 |  +576 |

The delta is `src/hash.o` and `mrbgems/mruby-hash-ext/src/hash_ext.o` and nothing else. `hash_ext.o` is +176 everywhere but `full-debug`, where it is +187; `hash.o` is +384 in `bintest`, `byte-string` and `ascii-ctype`, +400 in `no-bigint`, +512 in `no-float`, +624 in `cxx_abi` and +296 at `-O0`.

## Testing

`rake -m test`, all builds on this branch.

| Build       | Total |    OK | Skip |  KO | Crash | Warning |
| ----------- | ----: | ----: | ---: | --: | ----: | ------: |
| host        | 2,846 | 2,772 |   74 |   0 |     0 |       0 |
| full-debug  | 3,098 | 3,087 |   11 |   0 |     0 |       0 |
| bintest     | 3,098 | 3,078 |   20 |   0 |     0 |       0 |
| cxx_abi     | 3,098 | 3,078 |   20 |   0 |     0 |       0 |
| byte-string | 3,006 | 2,932 |   74 |   0 |     0 |       0 |
| ascii-ctype | 3,082 | 3,060 |   22 |   0 |     0 |       0 |
| no-float    | 2,831 | 2,734 |   97 |   0 |     0 |       0 |
| no-bigint   | 3,047 | 3,014 |   33 |   0 |     0 |       0 |

bintest is green where it runs: 138 on host and 155 on the `bintest` build, one skip each, no KO and no Crash.

The first new assertion drives the four scans that read the entry back, in both the list and the indexed shape, and each is a `RuntimeError` only with the check in place: without the C change `Hash#inspect` answers from the vacated slot, `Hash#__except` raises `NoMethodError: undefined method 'hash' for ` from the `mrb_undef_value()` it stored, and both rehash paths return a table with entries dropped.

The second, and the three in `mruby-hash-ext`, build the value in a method so that returning drops it from the arena, and ask for it back after the walk. Without the C change they stop the run: the write barrier assertion in the builds that have assertions, a `heap-use-after-free` under `clang-asan`.

The whole suite also runs green under `build_config/clang-asan.rb` (3,098 / 0 KO / 0 Crash), which is where the freed reads show up.

## Environment

<details>

|          |                                                                   |
| -------- | ----------------------------------------------------------------- |
| OS       | Ubuntu 24.04.5 LTS                                                |
| Kernel   | Linux 7.0.0-31-generic                                            |
| CPU      | AMD Ryzen 9 5950X (16 cores, 32 threads)                          |
| Compiler | gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)                       |
| binutils | GNU ld 2.47.20260726                                              |
| CRuby    | ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux] |

Compile lines from `touch src/hash.c; rake --verbose`, with `-MMD -c`, `-I`, `-o` and the two `-ffile-prefix-map` arguments elided. `cxx_abi` compiles with `gcc -x c++ -std=gnu++03` and uses `g++` only to link.

```
host         gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DMRB_USE_COMPLEX -DMRB_USE_BIGINT -DMRB_USE_DEBUG_HOOK ../../src/hash.c

full-debug   gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -g3 -O0 -DMRB_GC_STRESS -DMRB_USE_DEBUG_HOOK -DMRB_DEBUG -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c

bintest      gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_GC_FIXED_ARENA -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER -DMRB_USE_DEBUG_HOOK ../../src/hash.c

cxx_abi      gcc -g -O3 -Wall -Wundef -Wwrite-strings -x c++ -std=gnu++03 -DMRB_GC_FIXED_ARENA -DMRB_USE_CXX_EXCEPTION -DMRB_USE_CXX_ABI -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c

byte-string  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c

ascii-ctype  gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_USE_ASCII_CTYPE -DMRB_PROCESS_HAVE_GETRUSAGE=0 -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c

no-float     gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_NO_FLOAT -DMRB_REVISION_HEADER -DMRB_USE_BIGINT -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c

no-bigint    gcc -std=gnu99 -g -O3 -Wall -Wundef -Werror-implicit-function-declaration -Wwrite-strings -DMRB_REVISION_HEADER -DMRB_USE_COMPLEX -DHAVE_MRUBY_ENCODING_GEM -DMRB_UTF8_STRING -DHAVE_MRUBY_IO_GEM -DMRB_USE_RATIONAL -DHAVE_MRUBY_REGEXP_GEM -DMRB_USE_SET -DMRB_USE_TASK_SCHEDULER ../../src/hash.c
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hash operation stability when key callbacks modify the hash or trigger garbage collection.
  * Fixed potential crashes and invalid results during `Hash#key`, `Hash#slice`, `Hash#slice!`, `Hash#merge`, `Hash#rehash`, `Hash#inspect`, and key-exclusion operations.
  * Ensured hash entries remain consistent when callbacks delete or replace entries during processing.

* **Tests**
  * Added regression coverage for hash mutation, garbage collection, callback behavior, and entry consistency across supported hash configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->