### PR TITLE
hw-adc: release ESP32 ADC units after partial initialization failure

### DIFF
--- a/mrbgems/hw-adc/ports/esp32/adc.c
+++ b/mrbgems/hw-adc/ports/esp32/adc.c
@@ -99,8 +99,11 @@ init_units(void)
       .unit_id = units[i],
       .ulp_mode = ADC_ULP_MODE_DISABLE,
     };
-    if (adc_oneshot_new_unit(&cfg, &adc_handles[i]) != ESP_OK)
+    if (adc_oneshot_new_unit(&cfg, &adc_handles[i]) != ESP_OK) {
+      for (int j = 0; j < i; j++)
+        adc_oneshot_del_unit(adc_handles[j]);
       return -1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
## What is the purpose of the change?

The ESP32 `init_units()` helper creates `ADC_UNIT_1` and `ADC_UNIT_2` in sequence. If a later `adc_oneshot_new_unit()` call fails, the function currently returns without deleting units that were created earlier in the same call.

This leaves `adc_initialized` false while an ADC unit remains claimed by the oneshot driver. A later initialization attempt can then fail immediately because that unit is already in use, and other components cannot claim it either. Recovery may require restarting the device.

This path is not limited to an out-of-memory condition. The API can also fail when a unit is already claimed. In addition, ESP-IDF does not support ADC2 oneshot mode on ESP32-C3 by default, while this helper currently attempts to create both units.

This change makes unit initialization transactional: before reporting a failure, it releases every unit successfully created by the current call.

**What does this change do?**

- Delete previously created ADC handles when a later unit creation fails.
- Never delete the unit whose creation failed.
- Leave the successful initialization path unchanged.
- Preserve the existing `-1` error result.
- Allow a later initialization attempt to recover after a transient failure.

This patch only fixes resource rollback. It does not enable unsupported ESP32-C3 ADC2 operation or change the current eager initialization of both ADC units.

## Testing

A focused host-side harness compiled the exact ESP32 port against a stub implementation of the ESP-IDF ADC oneshot API. The harness was built with `-std=c99 -Wall -Wextra -Werror` under both the ESP32 and ESP32-C3 preprocessor configurations.

| Scenario | Unpatched code | Patched code |
|---|---|---|
| Normal initialization | Both units claimed; initialization succeeds | Same |
| Unit 1 succeeds, unit 2 fails | Unit 1 remains claimed; no delete call | Unit 1 is released exactly once |
| Retry after the injected failure is removed | Fails because unit 1 is still claimed | Succeeds |
| First unit is already owned elsewhere | No delete call | No delete call |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ADC initialization failure handling by cleaning up previously initialized resources when setup cannot complete.
  - Prevents resource leaks during partial ADC unit initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->