### PR TITLE
mruby-compiler: allow overriding the initial Prism arena block size

### DIFF
--- a/mrbgems/mruby-compiler/src/ccontext.c
+++ b/mrbgems/mruby-compiler/src/ccontext.c
@@ -34,7 +34,9 @@ mrb_state *global_mrb = NULL;
 
 struct mrc_prism_arena_block *mrc_prism_arena = NULL;
 
+#ifndef MRC_PRISM_ARENA_BLOCK
 #define MRC_PRISM_ARENA_BLOCK (64 * 1024)
+#endif
 
 struct arena_block {
   struct mrc_prism_arena_block head;   /* must be first: the public view */


### PR DESCRIPTION
## Summary

`mruby-compiler` (Prism) unconditionally allocates a fixed 64 KiB arena block every time a compiler context is created (`mrc_ccontext_new()`), regardless of the size of the script being compiled. The allocation is held until `mrc_ccontext_free()` is called. On embedded targets with only a few hundred KB of heap, this fixed overhead alone is enough to trigger `NoMemoryError`.

`arena_block_new()` already doubles the block size on demand when more room is needed, so there's no technical reason for the *initial* block to be this large. This PR adds a `#ifndef` guard so it can be overridden at build time.

## Reproduction

A single `eval("1")` call reproduces it. Confirmed by adding one diagnostic line to `arena_block_new()`:

```c
static struct arena_block *
arena_block_new(size_t need)
{
  size_t size = MRC_PRISM_ARENA_BLOCK;
  while (size - sizeof(struct arena_block) < need) size *= 2;
  fprintf(stderr, "allocating %zu bytes (need=%zu)\n", size, need); // added
  struct arena_block *b = (struct arena_block *)arena_block_alloc(size);
  ...
}
```

```ruby
puts "before eval"
eval("1")
puts "after eval"
```

Output:

```
allocating 65536 bytes (need=0)
before eval
allocating 65536 bytes (need=0)
after eval
```

Compiling the one-character script `"1"` triggers a 65,536-byte allocation.

Note: for a use like `eval`/`mrb_load_string`, where the compiler context is created and destroyed within the same call, this 64 KiB is a transient peak that's freed again by the time the call returns, and doesn't show up as a lasting increase in heap usage afterward. For code that holds the context open until it's explicitly freed (e.g. a sandboxed evaluator or REPL that reuses a parser across calls), this 64 KiB stays allocated for as long as the context is held. Either way, on a heap-constrained system, this peak by itself is large enough to trigger `NoMemoryError`.

## Quantified measurement

Compared heap usage before and after this mechanism was introduced ([`cc455424b374`](https://github.com/mruby/mruby/commit/cc455424b374) -> [`fbcb3dce64f3`](https://github.com/mruby/mruby/commit/fbcb3dce64f3), both commits in this repository straddling [`e23e0d59b1`](https://github.com/mruby/mruby/commit/e23e0d59b1)), using an implementation that holds the compiler context open (creates a context, compiles a short script, and doesn't free it right away):

| Measurement point | Before | After | Delta |
|---|---:|---:|---:|
| Right after VM boot | 289,408 | 354,888 | +65,480 |
| While the compiler context is held | 300,544 | 428,432 | **+62,408** |
| The actual compile itself | +1,120 | +1,112 | negligible |

The cost of compiling and running code itself is unchanged; the increase is concentrated in "VM boot" and "compiler-context creation". Stepping through the code path that creates a context and compiles a short script (the call to `mrc_ccontext_new()`, followed by `mrc_load_string_cxt()`) one line at a time under gdb, measuring heap usage after each line:

| After this line | Heap used (bytes) | Delta |
|---|---:|---:|
| (start of measurement) | 354,944 | -- |
| Small struct allocations in the caller (`mrb_malloc` + `memset`) | 355,552 | +608 |
| `mrc_ccontext_new(mrb)` (internally runs `arena_open()` = `arena_block_new(0)`) | 421,968 | **+66,416** |
| `mrc_load_string_cxt(...)` (the actual Prism compile) | 422,896 | +928 |

The entire `mrc_ccontext_new()` call (the `mrc_calloc`s for the context/parser_state structs, plus `arena_open()`) costs +66,416 bytes, almost all of it the 65,536-byte `MRC_PRISM_ARENA_BLOCK` that `arena_open()` allocates -- dwarfing the actual Prism compile itself (+928 bytes).

## Verifying the fix

Added `conf.cc.defines << "MRC_PRISM_ARENA_BLOCK=4096"` to `build_config/default.rb` in this repository, rebuilt, and confirmed what `arena_block_new()` actually requests:

```
# unmodified default
allocating 65536 bytes

# with -DMRC_PRISM_ARENA_BLOCK=4096
allocating 4096 bytes
```

Confirmed the `#ifndef` guard works as intended and the override takes effect. Behavior without an override is unchanged (still 65,536 bytes), so there's no impact on existing users.

Separately, this regression was causing boot failures on an embedded target (ESP32-S3, no PSRAM, 180 KiB heap); applying this fix (shrinking the initial block to 4 KiB) resolved it with no other changes needed.

## The change

`mrbgems/mruby-compiler/src/ccontext.c`:

```diff
 struct mrc_prism_arena_block *mrc_prism_arena = NULL;

+#ifndef MRC_PRISM_ARENA_BLOCK
 #define MRC_PRISM_ARENA_BLOCK (64 * 1024)
+#endif
```

The default (64 KiB) itself is unchanged, so existing behavior is unaffected. Memory-constrained targets can now override the initial block size at build time, e.g. `-DMRC_PRISM_ARENA_BLOCK=4096`.

## Background

This mechanism was introduced by [`e23e0d59b1`](https://github.com/mruby/mruby/commit/e23e0d59b1) ("mruby-compiler: survive a pattern deeper than the C stack"), and as I understand it, the goal was fixing a C-stack overflow, not reducing memory -- moving deeply-nested parse-tree destruction from recursive walking to bulk arena allocation/deallocation. That approach seems sound to me; the only issue is that the initial block size is fixed and can't be overridden.