### PR TITLE
mruby-task: keep mrb_execute_proc_synchronously() from stalling and from leaking its task

### DIFF
--- a/mrbgems/mruby-task/src/task.c
+++ b/mrbgems/mruby-task/src/task.c
@@ -788,6 +788,12 @@ sleep_us_impl(mrb_state *mrb, uint32_t usec)
     }
   }
 
+  /* A synchronous execution (mrb_execute_proc_synchronously) runs its
+     temporary task with no scheduler to hand the CPU to, so parking that
+     task here would leave nothing to resume it. Same rule as the other
+     asynchronous Task APIs. */
+  task_check_scheduler_lock(mrb);
+
   /* In task context - get current running task */
   t = MRB2TASK(mrb);
 
@@ -852,6 +858,9 @@ mrb_f_sleep(mrb_state *mrb, mrb_value self)
         mrb_raise(mrb, E_RUNTIME_ERROR, "can't sleep across C function boundary");
       }
     }
+    /* See sleep_us_impl: never park the temporary task of a synchronous
+       execution. */
+    task_check_scheduler_lock(mrb);
     mrb_task *t = MRB2TASK(mrb);
     mrb_task_excl_enter(mrb);
     mrb_task_q_delete(mrb, t);
@@ -1453,11 +1462,53 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
 
   /* 4. Execute the task in a dedicated loop (no context switching) */
   t->status = MRB_TASK_STATUS_RUNNING;
+  t->c.prev = mrb->c;
+  /* As in execute_task(): tells mrb_vm_exec() this context is driven from
+     C, so an unhandled exception terminates it and returns instead of
+     re-raising into the previous context. */
+  t->c.vmexec = TRUE;
   mrb->c = &t->c;
+
+  /* A pending switch request belongs to the scheduler, not to this loop.
+     mrb_vm_exec() honors task.switching at every OP boundary by returning
+     early (RETURN_IF_TASK_STOPPED), so with the flag left set it would
+     return before executing a single instruction and the loop below
+     would spin forever. Park the request while the temporary task runs
+     and hand it back afterwards. */
+  mrb_bool saved_switching = switching_;
+  switching_ = FALSE;
+
+  /* An exception the proc does not handle must come back here as a value,
+     the way execute_task_vm() arranges for scheduled tasks. Without the
+     flag mrb_vm_exec() longjmps to the caller's jmpbuf (when one exists)
+     straight past the teardown below, leaving the temporary task queued
+     with a freed stack, mrb->c pointing at it and the scheduler locked. */
+  mrb_bool saved_exception_as_result = mrb->task.exception_as_result;
+  mrb->task.exception_as_result = TRUE;
 
   while (t->c.status != MRB_TASK_STOPPED) {
     t->result = mrb_vm_exec(mrb, mrb->c->ci->proc, mrb->c->ci->pc);
+    if (t->c.status == MRB_TASK_STOPPED) break;
+
+    /* Early return without termination: a switch was requested from
+       inside the synchronous code (a tick IRQ expiring the timeslice, a
+       Task API that raised the flag, ...). The temporary task must keep
+       the CPU, so a request that left it runnable is simply dropped.
+       One that parked it (sleep, a suspend from a C extension) cannot be
+       honored here: there is no scheduler to hand the CPU to, so end the
+       execution with an error instead of spinning. */
+    if (t->status == MRB_TASK_STATUS_RUNNING) {
+      switching_ = FALSE;
+      continue;
+    }
+    mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_RUNTIME_ERROR,
+      "Cannot suspend the current task during synchronous execution"));
+    t->c.status = MRB_TASK_STOPPED;
+    break;
   }
+  mrb->task.exception_as_result = saved_exception_as_result;
+  t->c.vmexec = FALSE;
+  t->c.prev = NULL;
 
   /* If there's an unhandled exception after VM stops, save it as result */
   if (mrb->exc) {
@@ -1499,6 +1550,7 @@ mrb_execute_proc_synchronously(mrb_state *mrb, mrb_value proc_val, mrb_int argc,
   /* 7. Restore context and unlock */
   mrb->c = original_c;
   mrb->task.scheduler_lock--;
+  switching_ = saved_switching;
 
   mrb_gc_arena_restore(mrb, ai);
   mrb_gc_protect(mrb, result);

--- a/mrbgems/mruby-task/test/task.rb
+++ b/mrbgems/mruby-task/test/task.rb
@@ -430,3 +430,39 @@ assert("closure escaping a synchronously executed proc survives GC") do
   assert_equal "sync-result", result
   $task_escaped_proc3 = nil
 end
+
+assert("an exception in a synchronously executed proc comes back as its value") do
+  # Unhandled exceptions are returned, not raised, so that the temporary
+  # task is always torn down: a longjmp past mrb_execute_proc_synchronously()
+  # used to leave that task queued with a freed stack and mrb->c pointing at
+  # it, which corrupted every later call on the root context.
+  result = TaskTest.run_sync { raise ArgumentError, "sync boom" }
+  assert_kind_of ArgumentError, result
+  assert_equal "sync boom", result.message
+  assert_equal :ok, TaskTest.run_sync { :ok }
+end
+
+assert("sleep inside a synchronously executed proc fails instead of stalling") do
+  # The temporary task of mrb_execute_proc_synchronously() has no scheduler
+  # to hand the CPU to. Parking it in sleep used to leave the caller's loop
+  # re-entering mrb_vm_exec() forever, since the VM returns at once while a
+  # task switch is pending.
+  assert_kind_of RuntimeError, TaskTest.run_sync { sleep_ms 1 }
+  assert_kind_of RuntimeError, TaskTest.run_sync { sleep }
+  assert_equal :ok, TaskTest.run_sync { :ok }
+end
+
+assert("a pending task switch does not stall a synchronous execution") do
+  # Waking a queue waiter from the root context (what a host's event
+  # callback does) leaves task.switching set until the scheduler runs
+  # again. A synchronous execution entered in that window used to return
+  # from mrb_vm_exec() before its first instruction, forever.
+  q = Task::Queue.new
+  got = []
+  Task.new { got << q.pop }
+  TaskTest.run_once
+  q.push(7)
+  assert_equal :ok, TaskTest.run_sync { :ok }
+  Task.run
+  assert_equal [7], got
+end


### PR DESCRIPTION
This patch fixes two bugs in mruby-task (I enbugged)

## Bug 1
The synchronous executor loops on `mrb_vm_exec()` until its temporary task stops, but `mrb_vm_exec()` returns at once while `task.switching` is set, so a switch request left behind by the scheduler (e.g. a queue waiter woken from the root context) spun the loop forever. 

## Fix
Park the flag for the duration and hand it back afterwards; a switch raised from inside the synchronous code is dropped while the task is still runnable and turned into a RuntimeError once it parked the task.

## Bug 2
An unhandled exception also longjmped past the teardown when a jmpbuf existed, leaving the temporary task queued with a freed stack, `mrb->c` pointing at it and the scheduler locked.

## Fix
Set `vmexec` and `exception_as_result` around the run, as `execute_task_vm()` does, so the exception comes back as the result value.

sleep and sleep_ms now refuse to park the temporary task, like the other asynchronous Task APIs under scheduler_lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Synchronous task execution now safely handles unhandled exceptions by returning them as results.
  - Prevented synchronous execution from stalling when task switching is pending.
  - Added clear runtime errors when synchronous tasks attempt to sleep or suspend without a scheduler.

- **Tests**
  - Added coverage for exception handling, sleep attempts, and pending task-switch scenarios during synchronous execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->